### PR TITLE
(WIP) Add a multi-hot column to the fixtures

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/src/merlin_models/tensorflow/layers/embedding.py
+++ b/src/merlin_models/tensorflow/layers/embedding.py
@@ -25,11 +25,8 @@ def _sort_columns(feature_columns):
 
 def _validate_numeric_column(feature_column):
     if len(feature_column.shape) > 1:
-        return (
-            "Matrix numeric features are not allowed, "
-            "found feature {} with shape {}".format(
-                feature_column.key, feature_column.shape
-            )
+        return "Matrix numeric features are not allowed, " "found feature {} with shape {}".format(
+            feature_column.key, feature_column.shape
         )
 
 
@@ -39,9 +36,7 @@ def _validate_categorical_column(feature_column):
             "Only acceptable categorical columns for feeding "
             "embeddings are identity, found column {} of type {}. "
             "Consider using NVTabular online preprocessing to perform "
-            "categorical transformations".format(
-                feature_column.name, type(feature_column).__name__
-            )
+            "categorical transformations".format(feature_column.name, type(feature_column).__name__)
         )
 
 
@@ -64,9 +59,7 @@ def _validate_dense_feature_columns(feature_columns):
                     "NVTabular to do preprocessing offline".format(feature_column.name)
                 )
         elif isinstance(feature_column, (fc.EmbeddingColumn, fc.IndicatorColumn)):
-            _errors.append(
-                _validate_categorical_column(feature_column.categorical_column)
-            )
+            _errors.append(_validate_categorical_column(feature_column.categorical_column))
 
         elif isinstance(feature_column, fc.NumericColumn):
             _errors.append(_validate_numeric_column(feature_column))
@@ -119,16 +112,21 @@ def _categorical_embedding_lookup(table, inputs, feature_name, combiner):
             )
 
         # build values and nnz tensors into ragged array, convert to sparse
-        values = inputs[feature_name + "__values"][:, 0]
-        row_lengths = inputs[feature_name + "__nnzs"][:, 0]
+        values = inputs[feature_name + "__values"]
+        nnzs = inputs[feature_name + "__nnzs"]
+
+        if values.shape[1] > 1:
+            values = tf.reshape(values, [-1, 1])
+
+        values = values[:, 0]
+        row_lengths = nnzs[:, 0]
+
         x = tf.RaggedTensor.from_row_lengths(values, row_lengths).to_sparse()
 
         # use ragged array for sparse embedding lookup.
         # note we're using safe_embedding_lookup_sparse to handle empty rows
         # ( https://github.com/NVIDIA/NVTabular/issues/389 )
-        embeddings = tf.nn.safe_embedding_lookup_sparse(
-            table, x, None, combiner=combiner
-        )
+        embeddings = tf.nn.safe_embedding_lookup_sparse(table, x, None, combiner=combiner)
     else:
         embeddings = tf.gather(table, inputs[feature_name][:, 0])
 
@@ -195,9 +193,7 @@ class DenseFeatures(tf.keras.layers.Layer):
             _validate_stack_dimensions(feature_columns)
         elif aggregation != "concat":
             raise ValueError(
-                "Unrecognized aggregation {}, must be stack or concat".format(
-                    aggregation
-                )
+                "Unrecognized aggregation {}, must be stack or concat".format(aggregation)
             )
 
         self.feature_columns = feature_columns
@@ -240,9 +236,7 @@ class DenseFeatures(tf.keras.layers.Layer):
                 feature_name = feature_column.categorical_column.name
                 table = self.embedding_tables[feature_name]
                 combiner = getattr(feature_column, "combiner", "sum")
-                embeddings = _categorical_embedding_lookup(
-                    table, inputs, feature_name, combiner
-                )
+                embeddings = _categorical_embedding_lookup(table, inputs, feature_name, combiner)
                 features.append(embeddings)
 
         if self.aggregation == "stack":
@@ -362,9 +356,7 @@ class LinearFeatures(tf.keras.layers.Layer):
                 shape=(numeric_kernel_dim, 1),
             )
 
-        self.bias = self.add_weight(
-            name="bias", initializer="zeros", trainable=True, shape=(1,)
-        )
+        self.bias = self.add_weight(name="bias", initializer="zeros", trainable=True, shape=(1,))
         self.built = True
 
     def call(self, inputs):
@@ -372,14 +364,10 @@ class LinearFeatures(tf.keras.layers.Layer):
         numeric_inputs = []
         for feature_column in self.feature_columns:
             if isinstance(feature_column, fc.NumericColumn):
-                numeric_inputs.append(
-                    _handle_continuous_feature(inputs, feature_column)
-                )
+                numeric_inputs.append(_handle_continuous_feature(inputs, feature_column))
             else:
                 table = self.embedding_tables[feature_column.key]
-                embeddings = _categorical_embedding_lookup(
-                    table, inputs, feature_column.key, "sum"
-                )
+                embeddings = _categorical_embedding_lookup(table, inputs, feature_column.key, "sum")
                 x = x + embeddings
 
         if len(numeric_inputs) > 0:

--- a/tests/tensorflow/tf_fixtures.py
+++ b/tests/tensorflow/tf_fixtures.py
@@ -24,6 +24,7 @@ def categorical_columns():
     return [
         tf.feature_column.categorical_column_with_identity("one_hot_a", 100),
         tf.feature_column.categorical_column_with_identity("one_hot_b", 100),
+        tf.feature_column.categorical_column_with_identity("multi_hot_a", 100),
     ]
 
 
@@ -43,9 +44,15 @@ def categorical_features():
     one_hot_a = tf.random.uniform((1000, 1), maxval=100, dtype=tf.dtypes.int32)
     one_hot_b = tf.random.uniform((1000, 1), maxval=100, dtype=tf.dtypes.int32)
 
+    nnzs = 5
+    multi_hot_a__nnzs = tf.fill((1000, 1), nnzs)
+    multi_hot_a__values = tf.random.uniform((1000, 5), maxval=100, dtype=tf.dtypes.int32)
+
     return {
         "one_hot_a": one_hot_a,
         "one_hot_b": one_hot_b,
+        "multi_hot_a__nnzs": multi_hot_a__nnzs,
+        "multi_hot_a__values": multi_hot_a__values,
     }
 
 


### PR DESCRIPTION
Using `tf.Dataset` in the tests means that the training data can't contain tensors with different numbers of rows, so my first attempt here is to use a constant number of values per example. In order to make that work, I made a slight tweak to the embedding layer code to defensively flatten tensors where the second dim is greater than 1, which converts a dense non-ragged tensor into the format ragged tensors expect. This works for training, but fails during inference. Not sure why yet.