### PR TITLE
Add a multi-hot column to the tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from pathlib import Path
 
 import pytest
@@ -75,10 +76,15 @@ def labels():
 
 
 def transform_for_inference(training_data):
-    inference_data = {}
+    tf = pytest.importorskip("tensorflow")
+
+    inference_data = defaultdict(dict)
 
     for channel_name, channel_features in training_data.items():
         for feature_name, feature in channel_features.items():
-            inference_data[f"{channel_name}_{feature_name}"] = feature
+            if "__values" in feature_name:
+                inference_data[channel_name][feature_name] = tf.reshape(feature, (-1, 1))
+            else:
+                inference_data[channel_name][feature_name] = feature
 
     return inference_data

--- a/tests/tensorflow/models/test_deepfm.py
+++ b/tests/tensorflow/models/test_deepfm.py
@@ -42,34 +42,29 @@ def test_deepfm(
 
     model.compile("sgd", "binary_crossentropy")
 
-    # Training
+    # Input Data
     training_data = {"deep": {**continuous_features}, "fm": {**categorical_features}}
+    inference_data = transform_for_inference(training_data)
 
+    # Training
     training_ds = tf.data.Dataset.from_tensor_slices((training_data, labels))
+    num_examples = len(training_ds)
 
     model.fit(training_ds)
 
-    # Batch prediction
-    predictions = model.predict(training_data)
-    not_nan = tf.math.logical_not(tf.math.is_nan(predictions))
+    # Prediction
+    predictions = model(inference_data)
 
-    assert not_nan.numpy().all()
-    assert (predictions > 0).all()
-    assert (predictions < 1).all()
+    assert predictions.shape == tf.TensorShape((num_examples, 1))
+    assert (predictions > 0).numpy().all()
+    assert (predictions < 1).numpy().all()
 
     # Save/load
     model.save(tmpdir / model_name)
-    loaded = tf.keras.models.load_model(tmpdir / model_name)
+    loaded_model = tf.keras.models.load_model(tmpdir / model_name)
 
-    # Inference
-    infer = loaded.signatures["serving_default"]
+    predictions = loaded_model(inference_data)
 
-    inference_data = transform_for_inference(training_data)
-
-    outputs = infer(**inference_data)
-    predictions = outputs["output_1"]
-    not_nan = tf.math.logical_not(tf.math.is_nan(predictions))
-
-    assert not_nan.numpy().all()
+    assert predictions.shape == tf.TensorShape((num_examples, 1))
     assert (predictions > 0).numpy().all()
     assert (predictions < 1).numpy().all()

--- a/tests/tensorflow/models/test_dlrm.py
+++ b/tests/tensorflow/models/test_dlrm.py
@@ -44,34 +44,29 @@ def test_dlrm(
 
     model.compile("sgd", "binary_crossentropy")
 
-    # Training
+    # Input Data
     training_data = {"dense": {**continuous_features}, "fm": {**categorical_features}}
+    inference_data = transform_for_inference(training_data)
 
+    # Training
     training_ds = tf.data.Dataset.from_tensor_slices((training_data, labels))
+    num_examples = len(training_ds)
 
     model.fit(training_ds)
 
-    # Batch prediction
-    predictions = model.predict(training_data)
-    not_nan = tf.math.logical_not(tf.math.is_nan(predictions))
+    # Prediction
+    predictions = model(inference_data)
 
-    assert not_nan.numpy().all()
-    assert (predictions > 0).all()
-    assert (predictions < 1).all()
+    assert predictions.shape == tf.TensorShape((num_examples, 1))
+    assert (predictions > 0).numpy().all()
+    assert (predictions < 1).numpy().all()
 
     # Save/load
     model.save(tmpdir / model_name)
-    loaded = tf.keras.models.load_model(tmpdir / model_name)
+    loaded_model = tf.keras.models.load_model(tmpdir / model_name)
 
-    # Inference
-    infer = loaded.signatures["serving_default"]
+    predictions = loaded_model(inference_data)
 
-    inference_data = transform_for_inference(training_data)
-
-    outputs = infer(**inference_data)
-    predictions = outputs["output_1"]
-    not_nan = tf.math.logical_not(tf.math.is_nan(predictions))
-
-    assert not_nan.numpy().all()
+    assert predictions.shape == tf.TensorShape((num_examples, 1))
     assert (predictions > 0).numpy().all()
     assert (predictions < 1).numpy().all()

--- a/tests/tensorflow/models/test_simple_mlp.py
+++ b/tests/tensorflow/models/test_simple_mlp.py
@@ -42,33 +42,29 @@ def test_simple_mlp(
 
     model.compile("sgd", "binary_crossentropy")
 
-    # Training
+    # Input Data
     training_data = {"mlp": {**continuous_features, **categorical_features}}
+    inference_data = transform_for_inference(training_data)
+
+    # Training
     training_ds = tf.data.Dataset.from_tensor_slices((training_data, labels))
+    num_examples = len(training_ds)
 
     model.fit(training_ds)
 
-    # Batch prediction
-    predictions = model.predict(training_data)
-    not_nan = tf.math.logical_not(tf.math.is_nan(predictions))
+    # Prediction
+    predictions = model(inference_data)
 
-    assert not_nan.numpy().all()
-    assert (predictions > 0).all()
-    assert (predictions < 1).all()
+    assert predictions.shape == tf.TensorShape((num_examples, 1))
+    assert (predictions > 0).numpy().all()
+    assert (predictions < 1).numpy().all()
 
     # Save/load
     model.save(tmpdir / model_name)
-    loaded = tf.keras.models.load_model(tmpdir / model_name)
+    loaded_model = tf.keras.models.load_model(tmpdir / model_name)
 
-    # Inference
-    infer = loaded.signatures["serving_default"]
+    predictions = loaded_model(inference_data)
 
-    inference_data = transform_for_inference(training_data)
-
-    outputs = infer(**inference_data)
-    predictions = outputs["output_1"]
-    not_nan = tf.math.logical_not(tf.math.is_nan(predictions))
-
-    assert not_nan.numpy().all()
+    assert predictions.shape == tf.TensorShape((num_examples, 1))
     assert (predictions > 0).numpy().all()
     assert (predictions < 1).numpy().all()

--- a/tests/tensorflow/models/test_wide_and_deep.py
+++ b/tests/tensorflow/models/test_wide_and_deep.py
@@ -42,37 +42,32 @@ def test_wide_and_deep(
 
     model.compile("sgd", "binary_crossentropy")
 
-    # Training
+    # Input Data
     training_data = {
         "deep": {**categorical_features, **continuous_features},
         "wide": {**categorical_features, **continuous_features},
     }
+    inference_data = transform_for_inference(training_data)
 
+    # Training
     training_ds = tf.data.Dataset.from_tensor_slices((training_data, labels))
+    num_examples = len(training_ds)
 
     model.fit(training_ds)
 
-    # Batch prediction
-    predictions = model.predict(training_data)
-    not_nan = tf.math.logical_not(tf.math.is_nan(predictions))
+    # Prediction
+    predictions = model(inference_data)
 
-    assert not_nan.numpy().all()
-    assert (predictions > 0).all()
-    assert (predictions < 1).all()
+    assert predictions.shape == tf.TensorShape((num_examples, 1))
+    assert (predictions > 0).numpy().all()
+    assert (predictions < 1).numpy().all()
 
     # Save/load
     model.save(tmpdir / model_name)
-    loaded = tf.keras.models.load_model(tmpdir / model_name)
+    loaded_model = tf.keras.models.load_model(tmpdir / model_name)
 
-    # Inference
-    infer = loaded.signatures["serving_default"]
+    predictions = loaded_model(inference_data)
 
-    inference_data = transform_for_inference(training_data)
-
-    outputs = infer(**inference_data)
-    predictions = outputs["output_1"]
-    not_nan = tf.math.logical_not(tf.math.is_nan(predictions))
-
-    assert not_nan.numpy().all()
+    assert predictions.shape == tf.TensorShape((num_examples, 1))
     assert (predictions > 0).numpy().all()
     assert (predictions < 1).numpy().all()


### PR DESCRIPTION
A lot of the standard ways of doing prediction/inference with Tensorflow don't seem to work with our DenseLayer and/or multi-hot categoricals, but this way seems to. Unfortunately, it requires feeding tensors of different shape at inference time, but it's the only way I could figure out to make this go.