### PR TITLE
Fix SyntheticData.read_schema with proto text files

### DIFF
--- a/merlin_models/data/synthetic.py
+++ b/merlin_models/data/synthetic.py
@@ -100,11 +100,13 @@ class SyntheticData:
 
     @classmethod
     def read_schema(cls, path: Union[str, Path]) -> Schema:
-        _schema_path = (
-            os.path.join(str(path), "schema.json") if os.path.isdir(str(path)) else str(path)
-        )
+        path = str(path)
+        _schema_path = os.path.join(path, "schema.json") if os.path.isdir(path) else path
+
         if _schema_path.endswith(".pb") or _schema_path.endswith(".pbtxt"):
-            TensorflowMetadata.from_from_proto_text(_schema_path).to_merlin_schema()
+            return TensorflowMetadata.from_proto_text_file(
+                os.path.dirname(_schema_path), os.path.basename(_schema_path)
+            ).to_merlin_schema()
 
         return tensorflow_metadata_json_to_schema(_schema_path)
 

--- a/tests/data/testing/test_dataset.py
+++ b/tests/data/testing/test_dataset.py
@@ -15,6 +15,7 @@
 #
 import pytest
 from merlin.schema import Tags
+from merlin.schema.io.tensorflow_metadata import TensorflowMetadata
 
 from merlin_models.data.synthetic import SyntheticData
 from merlin_models.utils.schema import filter_dict_by_schema
@@ -76,3 +77,10 @@ def test_torch_tensors_generation_cpu():
     for val in filter_dict_by_schema(tensors, schema.select_by_tag(Tags.CATEGORICAL)).values():
         assert val.dtype == torch.int64
         assert val.max() < 52000
+
+
+def test_synthetic_read_proto_text(tmpdir):
+    schema = SyntheticData("music_streaming").schema
+    TensorflowMetadata.from_merlin_schema(schema).to_proto_text_file(tmpdir, "schema.pbtxt")
+    reloaded = SyntheticData.read_schema(tmpdir / "schema.pbtxt")
+    assert schema == reloaded


### PR DESCRIPTION
As pointed out https://github.com/NVIDIA-Merlin/models/pull/184#discussion_r810143960
there was some issues with the SyntheticData.read_schema method. Fix
and add a basic unittest that would have caught this

