### PR TITLE
Adding wrap_as_model to Block

### DIFF
--- a/merlin/models/tf/core.py
+++ b/merlin/models/tf/core.py
@@ -382,6 +382,39 @@ class Block(SchemaMixin, ContextMixin, Layer):
 
         return output
 
+    def wrap_as_model(
+        self,
+        schema: Schema,
+        input_block: Optional[BlockType] = None,
+        prediction_tasks: Optional[
+            Union["PredictionTask", List["PredictionTask"], "ParallelPredictionBlock"]
+        ] = None,
+        **kwargs,
+    ) -> "Model":
+        """Wrap the block between inputs & outputs to create a model.
+
+        Parameters
+        ----------
+        schema: Schema
+            Schema to use for the model.
+        input_block: Optional[Block]
+            Block to use as input.
+        prediction_tasks: Optional[
+            Union[PredictionTask, List[PredictionTask], ParallelPredictionBlock]
+        ]
+            Prediction tasks to use.
+
+        """
+        from merlin.models.tf.blocks.inputs import InputBlock
+        from merlin.models.tf.models.utils import parse_prediction_tasks
+
+        aggregation = kwargs.pop("aggregation", "concat")
+        input_block = input_block or InputBlock(schema, aggregation=aggregation, **kwargs)
+
+        prediction_tasks = parse_prediction_tasks(schema, prediction_tasks)
+
+        return Model(input_block, self, prediction_tasks)
+
     def connect_with_residual(
         self,
         block: Union[tf.keras.layers.Layer, str],

--- a/merlin/models/tf/core.py
+++ b/merlin/models/tf/core.py
@@ -2350,18 +2350,9 @@ class Model(tf.keras.Model, LossMixin, MetricsMixin):
 
         """
 
-        from merlin.models.tf.blocks.inputs import InputBlock
-        from merlin.models.tf.models.utils import parse_prediction_tasks
-
-        if is_input_block(cls.first):
-            assert input_block is None, "The block already includes an `InputBlock`"
-            input_block = cls.first
-
-        aggregation = kwargs.pop("aggregation", "concat")
-        input_block = input_block or InputBlock(schema, aggregation=aggregation, **kwargs)
-
-        prediction_tasks = parse_prediction_tasks(schema, prediction_tasks)
-        return cls(input_block, block, prediction_tasks)
+        return block.to_model(
+            schema, input_block=input_block, prediction_tasks=prediction_tasks, **kwargs
+        )
 
     def compute_loss(
         self,

--- a/merlin/models/tf/core.py
+++ b/merlin/models/tf/core.py
@@ -405,7 +405,7 @@ class Block(SchemaMixin, ContextMixin, Layer):
             Prediction tasks to use.
 
         """
-        from merlin.models.tf.blocks.inputs import InputBlock
+        from merlin.models.tf.blocks.core.inputs import InputBlock
         from merlin.models.tf.models.utils import parse_prediction_tasks
 
         if is_input_block(self.first):

--- a/merlin/models/tf/models/ranking.py
+++ b/merlin/models/tf/models/ranking.py
@@ -7,7 +7,7 @@ from ..blocks.cross import CrossBlock
 from ..blocks.dlrm import DLRMBlock
 from ..blocks.mlp import MLPBlock
 from ..core import Block, Model, ParallelPredictionBlock, PredictionTask
-from .utils import _parse_prediction_tasks
+from .utils import parse_prediction_tasks
 
 
 def DLRMModel(
@@ -51,7 +51,7 @@ def DLRMModel(
 
     """
 
-    prediction_tasks = _parse_prediction_tasks(schema, prediction_tasks)
+    prediction_tasks = parse_prediction_tasks(schema, prediction_tasks)
 
     dlrm_body = DLRMBlock(
         schema,
@@ -118,7 +118,7 @@ def DCNModel(
 
     aggregation = kwargs.pop("aggregation", "concat")
     input_block = input_block or InputBlock(schema, aggregation=aggregation, **kwargs)
-    prediction_tasks = _parse_prediction_tasks(schema, prediction_tasks)
+    prediction_tasks = parse_prediction_tasks(schema, prediction_tasks)
     if stacked:
         dcn_body = input_block.connect(CrossBlock(depth), deep_block)
     else:

--- a/merlin/models/tf/models/retrieval.py
+++ b/merlin/models/tf/models/retrieval.py
@@ -8,14 +8,18 @@ from ..blocks.mlp import MLPBlock
 from ..blocks.retrieval.matrix_factorization import MatrixFactorizationBlock
 from ..blocks.retrieval.two_tower import TwoTowerBlock
 from ..blocks.sampling.base import ItemSampler
-from ..core import Block, BlockType, Model, ParallelPredictionBlock, PredictionTask
+from ..core import (
+    Block,
+    BlockType,
+    MetricOrMetricClass,
+    Model,
+    ParallelPredictionBlock,
+    PredictionTask,
+)
 from ..losses import LossType
 from ..metrics.ranking import ranking_metrics
-from ..prediction.item_prediction import ItemRetrievalTask, ItemSampler, NextItemPredictionTask
-from .utils import parse_prediction_tasks
 from ..prediction_tasks.next_item import NextItemPredictionTask
 from ..prediction_tasks.retrieval import ItemRetrievalTask
-from .utils import _parse_prediction_tasks
 from .utils import parse_prediction_tasks
 
 
@@ -31,6 +35,7 @@ def MatrixFactorizationModel(
     ] = None,
     softmax_temperature: int = 1,
     loss: Optional[LossType] = "bpr",
+    metrics: Sequence[MetricOrMetricClass] = ItemRetrievalTask.DEFAULT_METRICS,
     samplers: Sequence[ItemSampler] = (),
     **kwargs,
 ) -> Model:
@@ -74,7 +79,7 @@ def MatrixFactorizationModel(
     if not prediction_tasks:
         prediction_tasks = ItemRetrievalTask(
             schema,
-            metrics=[],
+            metrics=metrics,
             softmax_temperature=softmax_temperature,
             samplers=samplers,
             loss=loss,
@@ -110,6 +115,7 @@ def TwoTowerModel(
     ] = None,
     softmax_temperature: int = 1,
     loss: Optional[LossType] = "categorical_crossentropy",
+    metrics: Sequence[MetricOrMetricClass] = ItemRetrievalTask.DEFAULT_METRICS,
     samplers: Sequence[ItemSampler] = (),
     **kwargs,
 ) -> Model:
@@ -162,7 +168,7 @@ def TwoTowerModel(
     if not prediction_tasks:
         prediction_tasks = ItemRetrievalTask(
             schema,
-            metrics=[],
+            metrics=metrics,
             softmax_temperature=softmax_temperature,
             samplers=samplers,
             loss=loss,

--- a/merlin/models/tf/models/retrieval.py
+++ b/merlin/models/tf/models/retrieval.py
@@ -11,6 +11,8 @@ from ..blocks.sampling.base import ItemSampler
 from ..core import Block, BlockType, Model, ParallelPredictionBlock, PredictionTask
 from ..losses import LossType
 from ..metrics.ranking import ranking_metrics
+from ..prediction.item_prediction import ItemRetrievalTask, ItemSampler, NextItemPredictionTask
+from .utils import parse_prediction_tasks
 from ..prediction_tasks.next_item import NextItemPredictionTask
 from ..prediction_tasks.retrieval import ItemRetrievalTask
 from .utils import _parse_prediction_tasks
@@ -78,7 +80,7 @@ def MatrixFactorizationModel(
             **kwargs,
         )
 
-    prediction_tasks = _parse_prediction_tasks(schema, prediction_tasks)
+    prediction_tasks = parse_prediction_tasks(schema, prediction_tasks)
     two_tower = MatrixFactorizationBlock(
         schema=schema,
         dim=dim,
@@ -166,7 +168,7 @@ def TwoTowerModel(
             **kwargs,
         )
 
-    prediction_tasks = _parse_prediction_tasks(schema, prediction_tasks)
+    prediction_tasks = parse_prediction_tasks(schema, prediction_tasks)
     two_tower = TwoTowerBlock(
         schema=schema,
         query_tower=query_tower,

--- a/merlin/models/tf/models/retrieval.py
+++ b/merlin/models/tf/models/retrieval.py
@@ -16,6 +16,7 @@ from .utils import parse_prediction_tasks
 from ..prediction_tasks.next_item import NextItemPredictionTask
 from ..prediction_tasks.retrieval import ItemRetrievalTask
 from .utils import _parse_prediction_tasks
+from .utils import parse_prediction_tasks
 
 
 def MatrixFactorizationModel(

--- a/merlin/models/tf/models/utils.py
+++ b/merlin/models/tf/models/utils.py
@@ -6,7 +6,7 @@ from ..core import ParallelPredictionBlock, PredictionTask
 from ..prediction_tasks.multi import PredictionTasks
 
 
-def _parse_prediction_tasks(
+def parse_prediction_tasks(
     schema: Schema,
     prediction_tasks: Optional[
         Union[PredictionTask, List[PredictionTask], ParallelPredictionBlock]

--- a/tests/tf/test_core.py
+++ b/tests/tf/test_core.py
@@ -6,7 +6,6 @@ from tensorflow.keras import mixed_precision
 
 import merlin.models.tf as ml
 from merlin.models.data.synthetic import SyntheticData
-from merlin.schema import Tags
 from merlin.models.tf.utils import testing_utils
 from merlin.schema import Tags
 

--- a/tests/tf/test_core.py
+++ b/tests/tf/test_core.py
@@ -7,6 +7,7 @@ from tensorflow.keras import mixed_precision
 import merlin.models.tf as ml
 from merlin.models.data.synthetic import SyntheticData
 from merlin.schema import Tags
+from merlin.models.tf.utils import testing_utils
 
 
 def test_filter_features(tf_con_features):
@@ -48,15 +49,13 @@ def test_tabular_block(tf_con_features):
 def test_serialization_continuous_features(
     testing_data: SyntheticData, pre, post, aggregation, include_schema
 ):
-    from merlin.models.tf.utils.testing_utils import assert_serialization
-
     schema = None
     if include_schema:
         schema = testing_data.schema
 
     inputs = ml.TabularBlock(pre=pre, post=post, aggregation=aggregation, schema=schema)
 
-    copy_layer = assert_serialization(inputs)
+    copy_layer = testing_utils.assert_serialization(inputs)
 
     keep_cols = ["user_id", "item_id", "event_hour_sin", "event_hour_cos"]
     tf_tabular_data = testing_data.tf_tensor_dict
@@ -127,12 +126,21 @@ def test_block_context_model(ecommerce_data: SyntheticData, run_eagerly: bool, t
 
 
 def test_simple_model(ecommerce_data: SyntheticData):
-    from merlin.models.tf.utils import testing_utils
-
     model = ml.Model(
         ml.InputBlock(ecommerce_data.schema),
         ml.MLPBlock([64]),
         ml.BinaryClassificationTask("click"),
+    )
+
+    copy_model = testing_utils.assert_serialization(model)
+    testing_utils.assert_loss_and_metrics_are_valid(
+        copy_model, ecommerce_data.tf_features_and_targets
+    )
+
+
+def test_block_wrap_as_model(ecommerce_data: SyntheticData):
+    model = ml.MLPBlock([64]).wrap_as_model(
+        ecommerce_data.schema, prediction_tasks=ml.BinaryClassificationTask("click")
     )
 
     copy_model = testing_utils.assert_serialization(model)


### PR DESCRIPTION
### Goals :soccer:
We recently introduced high-level functions to create models to make it easier to create models. This PR tries to introduce new functionality to each block to be converted to a model. This because otherwise we would need a high-level model-function for each block we create (like for instance #205 does for `MLPBlock`).

### Implementation Details :construction:
This PR adds `wrap_as_model` to a block, which allows you to wrap a block in-between a `InputBlock` and prediction-tasks. This can be used for instance to convert a `MLPBlock` to a model by doing:

```python
model = ml.MLPBlock([512, 256]).wrap_as_model(schema)
```

Another potential solution would be to add `from_block` to the `Model` class, to API would then look as follows:

```python
model = ml.Model.from_block(ml.MLPBlock([512, 256]), schema)
```

### Testing Details :mag:
Added a simple test to ensure wrap_as_model works as expected.
