### PR TITLE
Assume 'merlin' is a first party package for isort

### DIFF
--- a/merlin/models/data/synthetic.py
+++ b/merlin/models/data/synthetic.py
@@ -23,13 +23,13 @@ from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
-from merlin.schema import Schema, Tags
-from merlin.schema.io.tensorflow_metadata import TensorflowMetadata
 
 from merlin.models.utils.schema import (
     schema_to_tensorflow_metadata_json,
     tensorflow_metadata_json_to_schema,
 )
+from merlin.schema import Schema, Tags
+from merlin.schema.io.tensorflow_metadata import TensorflowMetadata
 
 LOG = logging.getLogger("merlin-models")
 HERE = pathlib.Path(__file__).parent

--- a/merlin/models/loader/backend.py
+++ b/merlin/models/loader/backend.py
@@ -36,10 +36,9 @@ from merlin.core.dispatch import (
     make_df,
     pull_apart_list,
 )
-from merlin.schema import Tags
-
 from merlin.models.loader.dataframe_iter import DataFrameIter
 from merlin.models.loader.shuffle import _shuffle_df
+from merlin.schema import Tags
 
 
 def _num_steps(num_samples, step_size):

--- a/merlin/models/loader/tf_utils.py
+++ b/merlin/models/loader/tf_utils.py
@@ -18,10 +18,10 @@ import os
 import warnings
 
 import tensorflow as tf
-from merlin.core.dispatch import HAS_GPU
 from packaging import version
 from tensorflow.python.feature_column import feature_column_v2 as fc
 
+from merlin.core.dispatch import HAS_GPU
 from merlin.models.loader.utils import device_mem_size
 
 

--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -21,7 +21,6 @@ from merlin.models.loader.tf_utils import configure_tensorflow
 
 configure_tensorflow()
 
-from merlin.schema import Schema, Tags
 from tensorflow.keras.layers import Dense, Layer
 from tensorflow.python.keras.losses import Loss
 from tensorflow.python.keras.metrics import Metric
@@ -30,6 +29,7 @@ from tensorflow.python.training.tracking.data_structures import ListWrapper, _Di
 
 # Must happen before any importing of tensorflow to curtail mem usage
 from merlin.models.loader.tf_utils import configure_tensorflow
+from merlin.schema import Schema, Tags
 
 from .. import data
 from ..data.synthetic import SyntheticData

--- a/merlin/models/tf/blocks/aggregation.py
+++ b/merlin/models/tf/blocks/aggregation.py
@@ -18,7 +18,6 @@ from enum import Enum
 from typing import Union, overload
 
 import tensorflow as tf
-from merlin.schema import Schema, Tags
 from tensorflow.python.keras.layers import Dot
 
 from merlin.models.config.schema import requires_schema
@@ -26,6 +25,7 @@ from merlin.models.tf.core import Block, TabularAggregation
 from merlin.models.tf.typing import TabularData
 from merlin.models.tf.utils import tf_utils
 from merlin.models.utils.schema import schema_to_tensorflow_metadata_json
+from merlin.schema import Schema, Tags
 
 from ..utils.tf_utils import maybe_deserialize_keras_objects, maybe_serialize_keras_objects
 

--- a/merlin/models/tf/blocks/cross.py
+++ b/merlin/models/tf/blocks/cross.py
@@ -16,6 +16,7 @@
 from typing import List, Optional, Tuple, Union
 
 import tensorflow as tf
+
 from merlin.schema import Schema, Tags
 
 from ..core import Filter, SequentialBlock, TabularBlock

--- a/merlin/models/tf/blocks/masking.py
+++ b/merlin/models/tf/blocks/masking.py
@@ -17,13 +17,13 @@
 from typing import List, Optional
 
 import tensorflow as tf
-from merlin.schema import Tags
 from tensorflow.keras import backend
 from tensorflow.python.ops import array_ops
 
 from merlin.models.tf.core import Block
 from merlin.models.utils.doc_utils import docstring_parameter
 from merlin.models.utils.registry import Registry
+from merlin.schema import Tags
 
 masking_registry = Registry("tf.masking")
 

--- a/merlin/models/tf/blocks/mlp.py
+++ b/merlin/models/tf/blocks/mlp.py
@@ -17,6 +17,7 @@
 from typing import List, Optional, Union
 
 import tensorflow as tf
+
 from merlin.schema import Schema, Tags
 
 from ..core import Block, Filter, ResidualBlock, SequentialBlock, tabular_aggregation_registry

--- a/merlin/models/tf/blocks/multi_task.py
+++ b/merlin/models/tf/blocks/multi_task.py
@@ -16,8 +16,9 @@
 from typing import Dict, List, Optional, Tuple, Union
 
 import tensorflow as tf
-from merlin.schema import Schema
 from tensorflow.keras.layers import Layer
+
+from merlin.schema import Schema
 
 from ..blocks.aggregation import StackFeatures
 from ..core import Block, ParallelBlock, ParallelPredictionBlock, PredictionTask, TabularBlock

--- a/merlin/models/tf/blocks/retrieval.py
+++ b/merlin/models/tf/blocks/retrieval.py
@@ -16,6 +16,7 @@
 from typing import Any, Callable, Dict, Optional
 
 import tensorflow as tf
+
 from merlin.schema import Schema, Tags
 
 from ..core import Block, BlockType, ModelBlock, ParallelBlock

--- a/merlin/models/tf/blocks/transformations.py
+++ b/merlin/models/tf/blocks/transformations.py
@@ -16,13 +16,13 @@
 from typing import Dict, Optional, Union
 
 import tensorflow as tf
-from merlin.schema import Schema, Tags
 from tensorflow.keras import backend
 from tensorflow.python.keras.utils import control_flow_util
 from tensorflow.python.ops import array_ops
 
 from merlin.models.tf.core import Block, TabularBlock
 from merlin.models.tf.typing import TabularData, TensorOrTabularData
+from merlin.schema import Schema, Tags
 
 
 @Block.registry.register("as-sparse")

--- a/merlin/models/tf/core.py
+++ b/merlin/models/tf/core.py
@@ -33,13 +33,12 @@ from typing import (
     runtime_checkable,
 )
 
-import merlin.io
 import six
 import tensorflow as tf
-from merlin.schema import Schema, Tags
 from tensorflow.keras.layers import Layer
 from tensorflow.python.keras.utils import generic_utils
 
+import merlin.io
 from merlin.models.config.schema import SchemaMixin
 from merlin.models.utils.doc_utils import docstring_parameter
 from merlin.models.utils.misc_utils import filter_kwargs
@@ -48,6 +47,7 @@ from merlin.models.utils.schema import (
     schema_to_tensorflow_metadata_json,
     tensorflow_metadata_json_to_schema,
 )
+from merlin.schema import Schema, Tags
 
 from .typing import TabularData, TensorOrTabularData
 from .utils.mixins import LossMixin, MetricsMixin, ModelLikeBlock

--- a/merlin/models/tf/dataset.py
+++ b/merlin/models/tf/dataset.py
@@ -19,12 +19,12 @@ import os
 import dask.dataframe as dd
 import numpy as np
 import tensorflow as tf
-from merlin.core.dispatch import HAS_GPU
-from merlin.schema import Tags
 from packaging import version
 
+from merlin.core.dispatch import HAS_GPU
 from merlin.models.loader.backend import DataLoader
 from merlin.models.loader.tf_utils import get_dataset_schema_from_feature_columns
+from merlin.schema import Tags
 
 if version.parse(tf.__version__) < version.parse("2.3.0"):
     try:

--- a/merlin/models/tf/features/continuous.py
+++ b/merlin/models/tf/features/continuous.py
@@ -17,9 +17,9 @@
 from typing import List, Optional
 
 import tensorflow as tf
-from merlin.schema import Schema
 
 from merlin.models.utils.doc_utils import docstring_parameter
+from merlin.schema import Schema
 
 from ..core import (
     TABULAR_MODULE_PARAMS_DOCSTRING,

--- a/merlin/models/tf/features/embedding.py
+++ b/merlin/models/tf/features/embedding.py
@@ -19,7 +19,6 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Union
 
 import tensorflow as tf
-from merlin.schema import Schema, Tags, TagsType
 from tensorflow.python import to_dlpack
 from tensorflow.python.keras import backend
 from tensorflow.python.tpu.tpu_embedding_v2_utils import FeatureConfig, TableConfig
@@ -31,6 +30,7 @@ from merlin.models.utils.schema import (
     categorical_domains,
     get_embedding_sizes_from_schema,
 )
+from merlin.schema import Schema, Tags, TagsType
 
 from ..core import (
     TABULAR_MODULE_PARAMS_DOCSTRING,

--- a/merlin/models/tf/prediction/batch.py
+++ b/merlin/models/tf/prediction/batch.py
@@ -3,6 +3,7 @@ import typing as tp
 
 import numpy as np
 import tensorflow as tf
+
 from merlin.core.dispatch import DataFrameType, concat_columns, get_lib
 from merlin.schema import Schema, Tags
 

--- a/merlin/models/tf/prediction/classification.py
+++ b/merlin/models/tf/prediction/classification.py
@@ -17,12 +17,12 @@
 from typing import Optional, Sequence
 
 import tensorflow as tf
-from merlin.schema import Schema, Tags
 from tensorflow.keras.layers import Layer
 from tensorflow.python.keras.layers import Dense
 
 from merlin.models.tf.losses import LossType, loss_registry
 from merlin.models.tf.metrics.ranking import ranking_metrics
+from merlin.schema import Schema, Tags
 
 from ...utils.schema import categorical_cardinalities
 from ..core import Block, MetricOrMetricClass, PredictionTask

--- a/merlin/models/tf/prediction/item_prediction.py
+++ b/merlin/models/tf/prediction/item_prediction.py
@@ -17,9 +17,10 @@ import logging
 from typing import List, Optional, Sequence, Tuple, Union
 
 import tensorflow as tf
-from merlin.schema import Schema, Tags
 from tensorflow.python.layers.base import Layer
 from tensorflow.python.ops import embedding_ops
+
+from merlin.schema import Schema, Tags
 
 from ...utils.constants import MIN_FLOAT
 from ...utils.schema import categorical_cardinalities

--- a/merlin/models/torch/dataset.py
+++ b/merlin/models/torch/dataset.py
@@ -16,9 +16,9 @@
 import numpy as np
 import pandas as pd
 import torch
-from merlin.core.dispatch import HAS_GPU
 from torch.utils.dlpack import from_dlpack
 
+from merlin.core.dispatch import HAS_GPU
 from merlin.models.loader.backend import DataLoader
 
 

--- a/merlin/models/torch/features/continuous.py
+++ b/merlin/models/torch/features/continuous.py
@@ -17,9 +17,9 @@
 from typing import List, Optional
 
 import torch
-from merlin.schema import Schema
 
 from merlin.models.utils.doc_utils import docstring_parameter
+from merlin.schema import Schema
 
 from ..tabular.base import (
     TABULAR_MODULE_PARAMS_DOCSTRING,

--- a/merlin/models/torch/features/embedding.py
+++ b/merlin/models/torch/features/embedding.py
@@ -18,9 +18,9 @@ from functools import partial
 from typing import Any, Callable, Dict, Optional, Text, Union
 
 import torch
-from merlin.schema import Schema, Tags
 
 from merlin.models.utils.doc_utils import docstring_parameter
+from merlin.schema import Schema, Tags
 
 from ...utils.schema import categorical_cardinalities, get_embedding_sizes_from_schema
 from ..tabular.base import (

--- a/merlin/models/torch/features/tabular.py
+++ b/merlin/models/torch/features/tabular.py
@@ -16,9 +16,8 @@
 
 from typing import List, Optional, Tuple, Type, Union
 
-from merlin.schema import Schema, Tags, TagsType
-
 from merlin.models.utils.doc_utils import docstring_parameter
+from merlin.schema import Schema, Tags, TagsType
 
 from ..block.base import SequentialBlock
 from ..block.mlp import MLPBlock

--- a/merlin/models/torch/model/base.py
+++ b/merlin/models/torch/model/base.py
@@ -21,10 +21,10 @@ from typing import Callable, Dict, Iterable, List, Optional, Type, Union, cast
 import numpy as np
 import torch
 import torchmetrics as tm
-from merlin.schema import Schema, Tags
 from tqdm import tqdm
 
 from merlin.models.utils.registry import camelcase_to_snakecase
+from merlin.schema import Schema, Tags
 
 from ..block.base import BlockBase, BlockOrModule, BlockType
 from ..features.base import InputBlock

--- a/merlin/models/torch/tabular/aggregation.py
+++ b/merlin/models/torch/tabular/aggregation.py
@@ -15,6 +15,7 @@
 #
 
 import torch
+
 from merlin.schema import Schema, Tags
 
 from ...config.schema import requires_schema

--- a/merlin/models/torch/tabular/base.py
+++ b/merlin/models/torch/tabular/base.py
@@ -20,10 +20,10 @@ from functools import reduce
 from typing import Dict, List, Optional, Union
 
 import torch
-from merlin.schema import Schema
 
 from merlin.models.utils.doc_utils import docstring_parameter
 from merlin.models.utils.registry import Registry
+from merlin.schema import Schema
 
 from ..block.base import BlockBase, SequentialBlock, right_shift_block
 from ..typing import TabularData, TensorOrTabularData

--- a/merlin/models/torch/utils/data_utils.py
+++ b/merlin/models/torch/utils/data_utils.py
@@ -18,11 +18,11 @@ import logging
 from abc import ABC
 
 import numpy as np
-from merlin.schema import Schema, Tags
 from torch.utils.data import DataLoader as PyTorchDataLoader
 from torch.utils.data import Dataset, IterableDataset
 
 from merlin.models.utils.registry import Registry
+from merlin.schema import Schema, Tags
 
 from ...utils import dependencies
 

--- a/merlin/models/torch/utils/torch_utils.py
+++ b/merlin/models/torch/utils/torch_utils.py
@@ -18,6 +18,7 @@ import abc
 from typing import Dict, Union
 
 import torch
+
 from merlin.schema import Schema
 
 from ...config.schema import SchemaMixin

--- a/merlin/models/utils/schema.py
+++ b/merlin/models/utils/schema.py
@@ -18,6 +18,7 @@ import os
 from typing import Dict, Optional
 
 import numpy as np
+
 from merlin.schema import ColumnSchema, Schema, Tags, TagsType
 from merlin.schema.io.tensorflow_metadata import TensorflowMetadata
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ line_length = 100
 balanced_wrapping = true
 indent = "    "
 known_third_party = ["cudf", "cupy", "dask", "dask_cuda", "dask_cudf", "numba", "numpy", "pytest", "torch", "rmm", "tensorflow"]
+known_first_party = ["merlin"]
 skip = ["build",".eggs"]
 
 

--- a/tests/data/testing/test_dataset.py
+++ b/tests/data/testing/test_dataset.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 #
 import pytest
-from merlin.schema import Tags
-from merlin.schema.io.tensorflow_metadata import TensorflowMetadata
 
 from merlin.models.data.synthetic import SyntheticData
 from merlin.models.utils.schema import filter_dict_by_schema
+from merlin.schema import Tags
+from merlin.schema.io.tensorflow_metadata import TensorflowMetadata
 
 
 def test_tabular_sequence_testing_data():

--- a/tests/tf/blocks/test_aggregation.py
+++ b/tests/tf/blocks/test_aggregation.py
@@ -17,11 +17,11 @@
 import numpy as np
 import pytest
 import tensorflow as tf
-from merlin.schema import Tags
 
 import merlin.models.tf as ml
 from merlin.models.data.synthetic import SyntheticData
 from merlin.models.tf.blocks.aggregation import ElementWiseMultiply
+from merlin.schema import Tags
 
 
 def test_concat_aggregation_yoochoose(testing_data: SyntheticData):

--- a/tests/tf/blocks/test_dlrm.py
+++ b/tests/tf/blocks/test_dlrm.py
@@ -15,10 +15,10 @@
 #
 
 import pytest
-from merlin.schema import Tags
 
 import merlin.models.tf as ml
 from merlin.models.data.synthetic import SyntheticData
+from merlin.schema import Tags
 
 
 def test_dlrm_block(testing_data: SyntheticData):

--- a/tests/tf/blocks/test_masking.py
+++ b/tests/tf/blocks/test_masking.py
@@ -16,10 +16,10 @@
 
 import pytest
 import tensorflow as tf
-from merlin.schema import Tags
 
 import merlin.models.tf as ml
 from merlin.models.data.synthetic import SyntheticData
+from merlin.schema import Tags
 
 
 @pytest.mark.parametrize("mask_block", [ml.CausalLanguageModeling, ml.MaskedLanguageModeling])

--- a/tests/tf/blocks/test_retrieval.py
+++ b/tests/tf/blocks/test_retrieval.py
@@ -18,12 +18,12 @@ import os
 import numpy as np
 import pytest
 import tensorflow as tf
-from merlin.schema import Tags
 
 import merlin.models.tf as ml
 from merlin.models.data.synthetic import SyntheticData
 from merlin.models.tf.blocks.aggregation import ElementWiseMultiply
 from merlin.models.tf.utils import testing_utils
+from merlin.schema import Tags
 
 
 def test_matrix_factorization_block(music_streaming_data: SyntheticData):

--- a/tests/tf/blocks/test_transformations.py
+++ b/tests/tf/blocks/test_transformations.py
@@ -16,10 +16,10 @@
 
 import pytest
 import tensorflow as tf
-from merlin.schema import Schema, Tags
 
 import merlin.models.tf as ml
 from merlin.models.utils.schema import create_categorical_column
+from merlin.schema import Schema, Tags
 
 
 @pytest.mark.parametrize("replacement_prob", [0.1, 0.3, 0.5, 0.7])

--- a/tests/tf/features/test_continuous.py
+++ b/tests/tf/features/test_continuous.py
@@ -15,11 +15,11 @@
 #
 
 import pytest
-from merlin.schema import Tags
 
 import merlin.models.tf as ml
 from merlin.models.data.synthetic import SyntheticData
 from merlin.models.tf.utils import testing_utils
+from merlin.schema import Tags
 
 
 def test_continuous_features(tf_con_features):

--- a/tests/tf/features/test_embedding.py
+++ b/tests/tf/features/test_embedding.py
@@ -15,12 +15,12 @@
 #
 
 import pytest
-from merlin.schema import Tags
 from tensorflow.python.ops import init_ops_v2
 
 import merlin.models.tf as ml
 from merlin.models.data.synthetic import SyntheticData
 from merlin.models.tf.utils import testing_utils
+from merlin.schema import Tags
 
 
 def test_embedding_features(tf_cat_features):

--- a/tests/tf/features/test_tabular.py
+++ b/tests/tf/features/test_tabular.py
@@ -15,11 +15,11 @@
 #
 
 import pytest
-from merlin.schema import Tags
 
 import merlin.models.tf as ml
 from merlin.models.data.synthetic import SyntheticData
 from merlin.models.tf.utils import testing_utils
+from merlin.schema import Tags
 
 
 def test_tabular_features(testing_data: SyntheticData):

--- a/tests/tf/models/test_retrieval.py
+++ b/tests/tf/models/test_retrieval.py
@@ -1,8 +1,8 @@
 import pytest
-from merlin.schema import Tags
 
 import merlin.models.tf as ml
 from merlin.models.data.synthetic import SyntheticData
+from merlin.schema import Tags
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])

--- a/tests/tf/prediction/test_item_prediction.py
+++ b/tests/tf/prediction/test_item_prediction.py
@@ -16,10 +16,10 @@
 
 import pytest
 import tensorflow as tf
-from merlin.schema import Tags
 
 import merlin.models.tf as ml
 from merlin.models.data.synthetic import SyntheticData
+from merlin.schema import Tags
 
 
 @pytest.mark.parametrize("ignore_last_batch_on_sample", [True, False])

--- a/tests/tf/test_core.py
+++ b/tests/tf/test_core.py
@@ -2,10 +2,10 @@ from typing import List
 
 import pytest
 import tensorflow as tf
-from merlin.schema import Tags
 
 import merlin.models.tf as ml
 from merlin.models.data.synthetic import SyntheticData
+from merlin.schema import Tags
 
 
 def test_filter_features(tf_con_features):

--- a/tests/tf/test_dataset.py
+++ b/tests/tf/test_dataset.py
@@ -19,12 +19,12 @@ import numpy as np
 import pandas as pd
 import pytest
 import tensorflow as tf
-from merlin.core.dispatch import make_df
-from merlin.io.dataset import Dataset
 from sklearn.metrics import roc_auc_score
 
 import merlin.models.tf as ml
 import merlin.models.tf.dataset as tf_dataloader
+from merlin.core.dispatch import make_df
+from merlin.io.dataset import Dataset
 from merlin.models.data.synthetic import SyntheticData
 
 

--- a/tests/torch/features/test_continuous.py
+++ b/tests/torch/features/test_continuous.py
@@ -14,9 +14,8 @@
 # limitations under the License.
 #
 
-from merlin.schema import Tags
-
 import merlin.models.torch as ml
+from merlin.schema import Tags
 
 
 def test_continuous_features(torch_con_features):

--- a/tests/torch/features/test_embedding.py
+++ b/tests/torch/features/test_embedding.py
@@ -19,9 +19,9 @@ from functools import partial
 import numpy as np
 import pytest
 import torch
-from merlin.schema import Tags
 
 import merlin.models.torch as ml
+from merlin.schema import Tags
 
 
 def test_embedding_features(torch_cat_features):

--- a/tests/torch/features/test_tabular.py
+++ b/tests/torch/features/test_tabular.py
@@ -15,9 +15,9 @@
 #
 
 import pytest
-from merlin.schema import Tags
 
 import merlin.models.torch as ml
+from merlin.schema import Tags
 
 torch_utils = pytest.importorskip("merlin.models.torch.utils.torch_utils")
 

--- a/tests/torch/tabular/test_aggregation.py
+++ b/tests/torch/tabular/test_aggregation.py
@@ -16,9 +16,9 @@
 
 import pytest
 import torch
-from merlin.schema import Tags
 
 import merlin.models.torch as ml
+from merlin.schema import Tags
 
 
 def test_concat_aggregation_yoochoose(tabular_schema, torch_tabular_data):

--- a/tests/torch/tabular/test_transformations.py
+++ b/tests/torch/tabular/test_transformations.py
@@ -16,10 +16,10 @@
 
 import pytest
 import torch
-from merlin.schema import Schema, Tags
 
 import merlin.models.torch as ml
 from merlin.models.utils.schema import create_categorical_column
+from merlin.schema import Schema, Tags
 
 
 @pytest.mark.parametrize("replacement_prob", [0.1, 0.3, 0.5, 0.7])

--- a/tests/torch/test_dataset.py
+++ b/tests/torch/test_dataset.py
@@ -17,6 +17,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
+
 from merlin.core.dispatch import HAS_GPU, make_df
 from merlin.io.dataset import Dataset
 


### PR DESCRIPTION
Rather than have things like 'merlin.schema' appear with the 3rd party imports,
include with the first party imports
