### PR TITLE
fix for tf when creating cpu dataloader

### DIFF
--- a/merlin/models/tf/dataset.py
+++ b/merlin/models/tf/dataset.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import contextlib
+import logging
 import os
 
 import dask.dataframe as dd
@@ -25,6 +26,8 @@ from merlin.core.dispatch import HAS_GPU
 from merlin.models.loader.backend import DataLoader
 from merlin.models.loader.tf_utils import get_dataset_schema_from_feature_columns
 from merlin.schema import Tags
+
+LOG = logging.getLogger("merlin.models")
 
 if version.parse(tf.__version__) < version.parse("2.3.0"):
     try:

--- a/merlin/models/tf/dataset.py
+++ b/merlin/models/tf/dataset.py
@@ -40,9 +40,9 @@ else:
 try:
     from merlin.io import Dataset
 
-    nvt_dataset_class = Dataset
+    merlin_dataset_class = Dataset
 except ImportError:
-    nvt_dataset_class = None
+    merlin_dataset_class = None
 # pylint has issues with TF array ops, so disable checks until fixed:
 # https://github.com/PyCQA/pylint/issues/3613
 # pylint: disable=no-value-for-parameter,unexpected-keyword-arg,redundant-keyword-arg
@@ -85,11 +85,11 @@ def _validate_dataset(paths_or_dataset, batch_size, buffer_size, engine, device,
 
     cpu = device and "cpu" in device
 
-    if nvt_dataset_class:
-        return nvt_dataset_class(files, engine=engine, cpu=cpu)
+    if merlin_dataset_class:
+        return merlin_dataset_class(files, engine=engine, cpu=cpu)
     else:
         LOG.warning(
-            "NVTabular Dataset class not detected, reverting to Dask Dataframe."
+            "Merlin Dataset class not detected, reverting to Dask Dataframe."
             "Expect slower iteration speeds."
         )
     return dd_engine[engine](files)


### PR DESCRIPTION
This fix updates the dataloader to use the dataset again by default, even when creating from a series of paths and not an nvt dataset. It also ensures that the cpu toggle forces complete logic off gpu for dataloader.