### PR TITLE
Refactor and optimize model evaluation 

### DIFF
--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -47,6 +47,7 @@ from .blocks.core.transformations import (
     AsDenseFeatures,
     AsSparseFeatures,
     ExpandDims,
+    LabelToOneHot,
     StochasticSwapNoise,
 )
 from .blocks.cross import CrossBlock
@@ -169,6 +170,7 @@ __all__ = [
     "InputBlock",
     "PredictionTasks",
     "StochasticSwapNoise",
+    "LabelToOneHot",
     "ExpandDims",
     "NoOp",
     "data",

--- a/merlin/models/tf/blocks/core/index.py
+++ b/merlin/models/tf/blocks/core/index.py
@@ -222,7 +222,8 @@ class TopKIndexBlock(IndexBlock):
             ],
             axis=1,
         )
-        return PredictionOutput(predictions, targets)
+        label_relevant_counts = tf.ones([tf.shape(predictions)[0]])
+        return PredictionOutput(predictions, targets, label_relevant_counts)
 
     def compute_output_shape(self, input_shape):
         batch_size = input_shape[0]

--- a/merlin/models/tf/blocks/retrieval/top_k.py
+++ b/merlin/models/tf/blocks/retrieval/top_k.py
@@ -55,5 +55,5 @@ class ItemsPredictionTopK(Block):
             num_classes = tf.shape(predictions)[-1]
             targets = tf_utils.tranform_label_to_onehot(targets, num_classes)
 
-        topk_scores, _, topk_labels = tf_utils.extract_topk(self._k, predictions, targets)
+        topk_scores, topk_labels = tf_utils.extract_topk(self._k, predictions, targets)
         return PredictionOutput(topk_scores, topk_labels)

--- a/merlin/models/tf/core.py
+++ b/merlin/models/tf/core.py
@@ -56,6 +56,7 @@ from .typing import TabularData, TensorOrTabularData
 from .utils.mixins import LossMixin, MetricsMixin, ModelLikeBlock
 from .utils.tf_utils import (
     calculate_batch_size_from_input_shapes,
+    extract_topk,
     maybe_deserialize_keras_objects,
     maybe_serialize_keras_objects,
 )
@@ -67,6 +68,7 @@ BlockType = Union["Block", str, Sequence[str]]
 class PredictionOutput(NamedTuple):
     predictions: Union[TabularData, tf.Tensor]
     targets: Union[TabularData, tf.Tensor]
+    label_relevant_counts: Optional[tf.Tensor] = None
 
 
 @tf.keras.utils.register_keras_serializable(package="merlin.models")
@@ -1769,6 +1771,9 @@ class PredictionTask(Layer, LossMixin, MetricsMixin, ContextMixin):
         self.label_metrics = create_metrics(label_metrics) if label_metrics else []
         self.loss_metrics = create_metrics(loss_metrics) if loss_metrics else []
 
+    def set_pre_eval_topk(self, block):
+        self.pre_eval_topk = block
+
     def pre_call(self, inputs, **kwargs):
         x = inputs
 
@@ -1885,43 +1890,77 @@ class PredictionTask(Layer, LossMixin, MetricsMixin, ContextMixin):
 
         update_ops = []
 
+        label_relevant_counts_eval = None
         if not training and self.pre_eval_topk:
-            outputs = self.pre_eval_topk.call_targets(
+            outputs = self.pre_eval_topk.call_outputs(
                 PredictionOutput(predictions, targets), **kwargs
             )
-            targets, predictions = outputs.targets, outputs.predictions
-            relevant_count = None
+            targets, predictions, label_relevant_counts_eval = (
+                outputs.targets,
+                outputs.predictions,
+                outputs.label_relevant_counts,
+            )
 
         if len(self.eval_metrics) > 0:
             predictions_eval = predictions
             targets_eval = targets
 
-            if training:
-                ranking_metrics = list(
-                    [metric for metric in self.eval_metrics if isinstance(metric, RankingMetric2)]
+            ranking_metrics = list(
+                [metric for metric in self.eval_metrics if isinstance(metric, RankingMetric2)]
+            )
+
+            if len(ranking_metrics) > 0:
+
+                tf.assert_equal(
+                    tf.shape(targets),
+                    tf.shape(predictions),
+                    f"Predictions ({tf.shape(predictions)}) and targets ({tf.shape(targets)}) "
+                    f"should have the same shape. Check if targets were one-hot encoded "
+                    f"(with LabelToOneHot() block for example).",
                 )
 
-                if len(ranking_metrics) > 0:
-                    # Checking the highest k used in ranking metrics
-                    max_k = tf.reduce_max([metric.k for metric in ranking_metrics])
-                    # Pre-sorts predictions and targets (by prediction scores) only once
-                    # for all ranking metric (for performance optimization) and extracts
-                    # only the top-k predictions/targets.
-                    # The relevant_count is necessary because when extracing the labels from the
-                    # top-k predictions some relevant items might not be included, but the
-                    # relevant count is necessary for many ranking metrics (e.g. recall, ndcg)
-                    (
-                        predictions_eval,
-                        targets_eval,
-                        relevant_count,
-                    ) = RankingMetric2.extract_topk_for_metrics(predictions, targets, max_k)
+                max_k = tf.reduce_max([metric.k for metric in ranking_metrics])
+                tf.debugging.assert_greater_equal(
+                    tf.shape(predictions_eval)[-1],
+                    max_k,
+                    f"The max k for ranking metrics ({max_k}) is higher than "
+                    f"the number of predictions in this batch",
+                )
+
+                pre_sorted_ranking_metrics = list(
+                    [metric for metric in ranking_metrics if metric.pre_sorted]
+                )
+
+                if len(pre_sorted_ranking_metrics) > 0:
+
+                    if len(ranking_metrics) > len(pre_sorted_ranking_metrics):
+                        raise Exception(
+                            "If one of the ranking metrics is set to 'pre_sorted=True', all the "
+                            "other ranking metrics should have the same configuration to avoid "
+                            "sorting predictions twice."
+                        )
+
+                    if training or self.pre_eval_topk is None:
+                        # Checking the highest k used in ranking metrics
+                        max_k = tf.reduce_max([metric.k for metric in pre_sorted_ranking_metrics])
+                        # Pre-sorts predictions and targets (by prediction scores) only once
+                        # for all ranking metric (for performance optimization) and extracts
+                        # only the top-k predictions/targets.
+                        # The label_relevant_counts is necessary because when extracing the labels
+                        # from the top-k predictions some relevant items might not be included, but
+                        # the relevant count is necessary for many ranking metrics (recall, ndcg)
+                        (
+                            predictions_eval,
+                            targets_eval,
+                            label_relevant_counts_eval,
+                        ) = extract_topk(max_k, predictions, targets)
 
             for metric in self.eval_metrics:
-                if isinstance(metric, RankingMetric2):
+                if isinstance(metric, RankingMetric2) and metric.pre_sorted:
                     metric_state = metric.update_state(
                         targets_eval,
                         predictions_eval,
-                        relevant_count,
+                        label_relevant_counts_eval,
                         sample_weight=sample_weight,
                     )
                 else:
@@ -2714,8 +2753,8 @@ class RetrievalModel(Model):
             self.retrieval_block.item_block(), data=data, k=k - 1, context=self.context, **kwargs
         )
         # set cache_query to True in the ItemRetrievalScorer
-        self.loss_block.retrieval_scorer.cache_query = True
-        self.loss_block.pre_eval_topk = topk_index
+        self.loss_block.set_retrieval_cache_query(True)
+        self.loss_block.set_pre_eval_topk(topk_index)
         return self
 
     def to_top_k_recommender(self, data: merlin.io.Dataset, k: int, **kwargs) -> ModelBlock:

--- a/merlin/models/tf/prediction_tasks/classification.py
+++ b/merlin/models/tf/prediction_tasks/classification.py
@@ -50,7 +50,7 @@ class BinaryClassificationTask(PredictionTask):
     ):
         output_layer = kwargs.pop("output_layer", None)
         super().__init__(
-            metrics=list(metrics),
+            metrics=metrics,
             target_name=target_name,
             task_name=task_name,
             task_block=task_block,
@@ -156,7 +156,7 @@ class MultiClassClassificationTask(PredictionTask):
     ):
 
         super().__init__(
-            metrics=list(metrics),
+            metrics=metrics,
             target_name=target_name,
             task_name=task_name,
             task_block=task_block,

--- a/merlin/models/tf/prediction_tasks/classification.py
+++ b/merlin/models/tf/prediction_tasks/classification.py
@@ -204,13 +204,7 @@ class MultiClassClassificationTask(PredictionTask):
     def metric_results(self, mode: str = None):
         dict_results = {}
         for metric in self.metrics:
-            if hasattr(metric, "top_ks"):
-                topks = metric.top_ks
-                results = metric.result()
-                for i, k in enumerate(topks):
-                    dict_results[f"{metric.name}_{k}"] = results[i]
-            else:
-                dict_results.update({metric.name: metric.result()})
+            dict_results.update({metric.name: metric.result()})
 
         return dict_results
 

--- a/merlin/models/tf/prediction_tasks/next_item.py
+++ b/merlin/models/tf/prediction_tasks/next_item.py
@@ -199,10 +199,10 @@ def NextItemPredictionTask(
     if normalize:
         prediction_call = L2Norm().connect(prediction_call)
 
-    pre_metrics = None
+    pre_eval_topk = None
     if len(metrics) > 0:
         max_k = tf.reduce_max(sum([metric.top_ks for metric in metrics], []))
-        pre_metrics = ItemsPredictionTopK(
+        pre_eval_topk = ItemsPredictionTopK(
             k=max_k, transform_to_onehot=transform_to_onehot or not sampled_softmax
         )
 
@@ -216,5 +216,5 @@ def NextItemPredictionTask(
         loss=loss,
         metrics=metrics,
         pre=prediction_call,
-        pre_metrics=pre_metrics,
+        pre_eval_topk=pre_eval_topk,
     )

--- a/merlin/models/tf/prediction_tasks/retrieval.py
+++ b/merlin/models/tf/prediction_tasks/retrieval.py
@@ -82,11 +82,9 @@ class ItemRetrievalTask(MultiClassClassificationTask):
         target_name: Optional[str] = None,
         task_name: Optional[str] = None,
         task_block: Optional[Layer] = None,
-        train_metrics: Sequence[MetricOrMetricClass] = None,
         extra_pre_call: Optional[Block] = None,
         softmax_temperature: float = 1.0,
         normalize: bool = True,
-        compute_train_metrics: bool = False,
         cache_query: bool = False,
         **kwargs,
     ):
@@ -94,16 +92,14 @@ class ItemRetrievalTask(MultiClassClassificationTask):
         self.cache_query = cache_query
         pre = self._build_prediction_call(samplers, normalize, softmax_temperature, extra_pre_call)
         self.loss = loss_registry.parse(loss)
-        self.compute_train_metrics = compute_train_metrics
 
         super().__init__(
             loss=self.loss,
-            metrics=list(metrics),
+            metrics=metrics,
             target_name=target_name,
             task_name=task_name,
             task_block=task_block,
             pre=pre,
-            compute_train_metrics=compute_train_metrics,
             **kwargs,
         )
 

--- a/merlin/models/tf/prediction_tasks/retrieval.py
+++ b/merlin/models/tf/prediction_tasks/retrieval.py
@@ -133,3 +133,6 @@ class ItemRetrievalTask(MultiClassClassificationTask):
     @property
     def retrieval_scorer(self):
         return self.pre[0][1]
+
+    def set_retrieval_cache_query(self, value: bool):
+        self.retrieval_scorer.cache_query = value

--- a/merlin/models/tf/utils/mixins.py
+++ b/merlin/models/tf/utils/mixins.py
@@ -53,7 +53,8 @@ class MetricsMixin(abc.ABC):
         inputs: Union[tf.Tensor, TabularData],
         targets: Union[tf.Tensor, TabularData],
         mode: str = "val",
-        forward=True,
+        forward: bool = True,
+        training: bool = False,
         **kwargs,
     ) -> Dict[str, Union[Dict[str, tf.Tensor], tf.Tensor]]:
         """Calculate metrics on a batch of data, each metric is stateful and this updates the state.
@@ -111,6 +112,7 @@ class ModelLikeBlock(Protocol):
         targets: Union[tf.Tensor, TabularData],
         mode: str = "val",
         forward=True,
+        training=False,
         **kwargs,
     ) -> Dict[str, Union[Dict[str, tf.Tensor], tf.Tensor]]:
         ...

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -103,12 +103,14 @@ def maybe_deserialize_keras_objects(
 
 
 def extract_topk(max_k, scores, labels):
+    # Computes the number of relevant items per row (before extracting only the top-k)
+    label_relevant_counts = tf.reduce_sum(labels, axis=-1)
     topk_scores, topk_indices = tf.math.top_k(scores, max_k)
     topk_labels = gather_torch_like(labels, topk_indices, max_k)
-    return topk_scores, topk_labels
+    return topk_scores, topk_labels, label_relevant_counts
 
 
-def tranform_label_to_onehot(labels, vocab_size):
+def transform_label_to_onehot(labels, vocab_size):
     return tf.one_hot(tf.reshape(labels, (-1,)), vocab_size)
 
 

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -105,7 +105,7 @@ def maybe_deserialize_keras_objects(
 def extract_topk(max_k, scores, labels):
     topk_scores, topk_indices = tf.math.top_k(scores, max_k)
     topk_labels = gather_torch_like(labels, topk_indices, max_k)
-    return topk_scores, topk_indices, topk_labels
+    return topk_scores, topk_labels
 
 
 def tranform_label_to_onehot(labels, vocab_size):
@@ -117,17 +117,12 @@ def create_output_placeholder(scores, ks):
 
 
 def gather_torch_like(labels, indices, max_k):
-    # gather_indices = []
-    gather_indices = tf.TensorArray(tf.int32, size=tf.shape(indices)[0])
-    for i in range(tf.shape(indices)[0]):
-        gather_indices = gather_indices.write(
-            i,
-            tf.concat(
-                [i * tf.ones((max_k, 1), tf.int32), tf.expand_dims(indices[i, :], -1)], axis=1
-            ),
-        )
-    all_indices = gather_indices.stack()
-    labels = tf.reshape(tf.gather_nd(labels, all_indices), tf.shape(indices))
+
+    row_idxs = tf.repeat(tf.range(tf.shape(labels)[0]), max_k)
+    col_idx = tf.reshape(indices, tf.shape(row_idxs))
+    all_indices = tf.transpose(tf.stack([row_idxs, col_idx]))
+
+    labels = tf.reshape(tf.gather_nd(labels, all_indices), (tf.shape(labels)[0], max_k))
     return labels
 
 

--- a/tests/tf/prediction/test_next_item.py
+++ b/tests/tf/prediction/test_next_item.py
@@ -270,7 +270,6 @@ def test_retrieval_task_inbatch_cached_samplers_fit(
         ecommerce_data._schema,
         softmax_temperature=2,
         samplers=samplers,
-        compute_train_metrics=False,
     )
     model = two_tower.connect(task)
 

--- a/tests/tf/prediction/test_next_item.py
+++ b/tests/tf/prediction/test_next_item.py
@@ -302,10 +302,7 @@ def test_last_item_prediction_task(
         masking="clm",
         split_sparse=True,
     )
-    if sampled_softmax:
-        loss = tf.keras.losses.CategoricalCrossentropy(from_logits=True)
-    else:
-        loss = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
+    loss = tf.keras.losses.CategoricalCrossentropy(from_logits=True)
     task = ml.NextItemPredictionTask(
         schema=sequence_testing_data.schema,
         loss=loss,


### PR DESCRIPTION
This PR refactors model evaluation and also optimizes eval performance:

- [x] Renaming `pre_metrics` (e.g. BruteForceTopK) to `pre_eval_topk` (for both `ItemRetrievalTask` and `NextItemPredictionTask`), to make it clear it is only called during evaluation/prediction, and not when evaluating during training
- [x] Converting `tf_utils.gather_torch_like()` method into a vectorized version to retrieve the top-k labels. Closes #202 
- [x] Created the LabelToOneHot transformation block to centralized that logic, which was done in many places. Now it is expected that when ranking metrics are used the labels must be necessarily one-hot encoded, as that is required by `extract_topk`.
- [x] Encapsulated internal properties with setter methods for better maintainability (e.g. `self.loss_block.retrieval_scorer.cache_query` and self.loss_block.pre_eval_topk)
- [x] Refactored metrics pre-sorting computation to avoid incorrect calculation (because pre-sorting and extracting top-k changes the number of relevant count for each row, which is not correct). Closes #225 
- [x] Refactored ranking metrics to have a single instance for each k (rather one metric with many `top_ks`), which simplifies naming and collecting results 
- [ ] Refactored ranking metrics to accumulate only the sum of batch metrics and the batches count, to aggregate results the same way default Keras metrics does (simple average over the epoch by dividing the sum by the count) **(in progress)**
- [ ] Making train metrics to be computed each `train_metrics_steps`. If `train_metrics_steps=0` no metrics are computed during training. Closes #210  **(In progress)**