### PR TITLE
chore: add PR doc previews

### DIFF
--- a/.github/workflows/docs-preview-pr.yaml
+++ b/.github/workflows/docs-preview-pr.yaml
@@ -1,0 +1,134 @@
+name: docs-preview-pr
+
+on:
+  workflow_run:
+    workflows: [tensorflow]
+    types: [completed]
+
+env:
+  WF_ID: ${{ github.event.workflow_run.id }}
+
+jobs:
+
+  # Always determine if GitHub Pages are configured for this repo.
+  get-gh-pages-url:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.api-resp.outputs.html_url }}
+      branch: ${{ steps.api-resp.outputs.branch }}
+    steps:
+      - name: Check for GitHub Pages
+        id: api-resp
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const pages_url = [process.env.GITHUB_API_URL, "repos", process.env.GITHUB_REPOSITORY, "pages"].join("/")
+            console.log("Request to GitHub API for GitHub Pages URL: " + pages_url)
+            try {
+              const resp = await github.request(pages_url)
+              if (resp.status == "200") {
+                console.log("GitHub Pages are configured and available at: " + resp.data.html_url)
+                console.log("  ..and deployed from branch: " + resp.data.source.branch)
+                core.setOutput('html_url', resp.data.html_url)
+                core.setOutput('branch', resp.data.source.branch)
+                return
+              }
+              console.log(resp)
+            } catch (err) {
+              console.log("Request to GitHub API for Pages failed with message: " + err)
+            }
+            core.setOutput('html_url', '')
+            core.setOutput('branch', '')``
+
+  # Identify the dir for the HTML.
+  store-html:
+    runs-on: ubuntu-latest
+    needs: [get-gh-pages-url]
+    if: needs.get-gh-pages-url.outputs.url != ''
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.get-gh-pages-url.outputs.branch }}
+      - name: Initialize Git configuration
+        run: |
+          git config user.name docs-preview
+          git config user.email do-not-send-@github.com
+      - name: Ensure dot-nojekyll file exists
+        run: |
+          if [ ! -f ".nojekyll" ]; then
+            touch .nojekyll
+            git add .nojekyll
+          fi
+      - name: Download artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run view "${WF_ID}"
+          gh run download "${WF_ID}"
+          PR=$(cat ./pr/pr.txt)
+          MERGED=$(cat ./pr/merged.txt)
+          ACTION=$(cat ./pr/action.txt)
+          echo "PR_NO=${PR}" >> $GITHUB_ENV
+          echo "MERGE_STATUS=${MERGED}" >> $GITHUB_ENV
+          echo "PR_ACTION=${ACTION}" >> $GITHUB_ENV
+          echo "REVIEW_DIR=review/" >> $GITHUB_ENV
+          echo "PR_REVIEW_DIR=review/pr-${PR}" >> $GITHUB_ENV
+
+          # Remove the pr artifact directory so that it does not
+          # appear in listings or confuse git with untracked files.
+          rm -rf ./pr
+
+      # Permutations:
+      # - PR was merged, update `main` directory; PR_ACTION is closed, need to delete review directory.
+      # - PR was updated, PR_ACTION is !closed, need to delete review directory and update it.
+      # - PR was closed (regardless of merge), PR_ACTION is closed, need to delete review directory.
+
+      # If the PR was merged, store in directory `main`. PR_ACTION is closed and handled two steps later.
+      - name: Handle HTML for merges to main
+        if: env.MERGE_STATUS == 'true'
+        run: |
+          rm -rf main 2>/dev/null || true
+          mv ./html-build-artifact/  main
+          git add main
+      # If this PR is still open, store HTML in a review directory.
+      - name: Handle HTML review directory for open PRs and updates to PRs
+        if: env.MERGE_STATUS == 'false' && env.PR_ACTION != 'closed'
+        run: |
+          rm -rf "${{ env.PR_REVIEW_DIR }}" 2>/dev/null || true
+          if [ ! -d "${{ env.REVIEW_DIR }}" ]; then
+            mkdir "${{ env.REVIEW_DIR }}"
+          fi
+          mv ./html-build-artifact/ "${{ env.PR_REVIEW_DIR }}"
+          git add "${{ env.PR_REVIEW_DIR }}"
+      # If the PR was closed, merged or not, delete review directory.
+      - name: Delete HTML review directory for closed PRs
+        if: env.PR_ACTION == 'closed'
+        run: |
+          if [ -d ./html-build-artifact/ ]; then
+            rm -rf ./html-build-artifact/ 2>/dev/null
+          fi
+          if [ -d "${{ env.PR_REVIEW_DIR }}" ]; then
+            git rm -rf "${{ env.PR_REVIEW_DIR }}"
+          fi
+      - name: Commit changes to the GitHub Pages branch
+        run: |
+          git status
+          if git commit -m 'Pushing changes to GitHub Pages.'; then
+            git push -f
+          else 
+           echo "Nothing changed."
+          fi
+      - name: Add HTML review URL comment to a newly opened PR
+        if: env.MERGE_STATUS == 'false' && env.PR_ACTION == 'opened'
+        env:
+          URL: ${{ needs.get-gh-pages-url.outputs.url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          echo -e "## Documentation preview"                  > body
+          echo -e ""                                         >> body
+          echo -e "<${{ env.URL }}${{ env.PR_REVIEW_DIR }}>" >> body
+          cat body
+          gh pr comment ${{ env.PR_NO }} --body-file body
+

--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y protobuf-compiler
+          sudo apt-get install -y protobuf-compiler pandoc
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -34,3 +34,27 @@ jobs:
       - name: Run unittests
         run: |
           make tests-tf
+      # Build the documentation, treating warnings as errors
+      - name: Make HTML
+        run: |
+          pushd docs
+            make html
+          popd
+      - name: Upload HTML
+        uses: actions/upload-artifact@v2
+        with:
+          name: html-build-artifact
+          path: docs/build/html
+          if-no-files-found: error
+          retention-days: 1
+      - name: Store PR information
+        run: |
+          mkdir ./pr
+          echo ${{ github.event.number }}              > ./pr/pr.txt
+          echo ${{ github.event.pull_request.merged }} > ./pr/merged.txt
+          echo ${{ github.event.action }}              > ./pr/action.txt
+      - name: Upload PR information
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
     hooks:
       - id: prettier
         types: [yaml]
+        exclude: ^.github/workflows/
 #      - repo: https://github.com/pre-commit/mirrors-mypy
 #        rev: 'v0.910'
 #        hooks:


### PR DESCRIPTION
* I applied these files to my fork and it seemed to go well.  I pushed the workflow files to `main` in my own fork and then made a fake PR at <https://github.com/mikemckiernan/models/pull/3>.  The workflow seemed to run as expected.

* I still have fear that the workflow file updates will not run when I make this PR.  My suspicion is that contributing workflow files so they are run as part of the contribution has to happen with something other than a PR.  I'm happy to learn otherwise.

* At random, I picked the tensorflow build to update.  During the 08MAR Merlin CI meeting, the suggestion is that the torch tests can be merged with tensorflow into a single workflow file.