### PR TITLE
Improvements in two-tower model and DCN

### DIFF
--- a/merlin/models/tf/blocks/core/inputs.py
+++ b/merlin/models/tf/blocks/core/inputs.py
@@ -190,7 +190,7 @@ def InputBlock(
             emb_kwargs["max_seq_length"] = max_seq_length
 
         branches["categorical"] = emb_cls.from_schema(  # type: ignore
-            schema, tags=categorical_tags, options=embedding_options, **emb_kwargs
+            schema, tags=categorical_tags, embedding_options=embedding_options, **emb_kwargs
         )
 
     if continuous_projection:

--- a/merlin/models/tf/blocks/dlrm.py
+++ b/merlin/models/tf/blocks/dlrm.py
@@ -87,7 +87,7 @@ def DLRMBlock(
         )
 
     embeddings = EmbeddingFeatures.from_schema(
-        cat_schema, options=EmbeddingOptions(embedding_dim_default=embedding_dim)
+        cat_schema, embedding_options=EmbeddingOptions(embedding_dim_default=embedding_dim)
     )
 
     if len(con_schema) > 0:

--- a/merlin/models/tf/blocks/mlp.py
+++ b/merlin/models/tf/blocks/mlp.py
@@ -43,6 +43,7 @@ def MLPBlock(
     dropout: Optional[float] = None,
     normalization: Optional[Union[str, tf.keras.layers.Layer]] = None,
     filter: Optional[Union[Schema, Tags, List[str], "Filter"]] = None,
+    no_activation_last_layer: bool = False,
     block_name: str = "MLPBlock",
     **kwargs
 ) -> SequentialBlock:
@@ -77,13 +78,19 @@ def MLPBlock(
         The normalization layer to use.
     filter: Schema, Tag, List[str], or Filter
         The filter to apply to the inputs of the MLP.
+    no_activation_last_layer: bool
+        Ensures that no activation function (i.e. 'linear') is used in the output of the
+        layer MLP layer
     block_name: str
         The name of the block.
     """
 
     block_layers = []
 
-    for dim in dimensions:
+    for idx, dim in enumerate(dimensions):
+        if no_activation_last_layer and idx == len(dimensions) - 1:
+            activation = "linear"
+
         block_layers.append(
             _Dense(
                 dim,

--- a/merlin/models/tf/blocks/retrieval/matrix_factorization.py
+++ b/merlin/models/tf/blocks/retrieval/matrix_factorization.py
@@ -44,7 +44,7 @@ def MatrixFactorizationBlock(
         post = rename_features
 
     matrix_factorization = EmbeddingFeatures.from_schema(
-        query_item_schema, post=post, options=embedding_options, **kwargs
+        query_item_schema, post=post, embedding_options=embedding_options, **kwargs
     )
 
     return matrix_factorization

--- a/merlin/models/tf/blocks/retrieval/two_tower.py
+++ b/merlin/models/tf/blocks/retrieval/two_tower.py
@@ -49,8 +49,17 @@ class TwoTowerBlock(ParallelBlock, RetrievalMixin):
         The tag to select query features, by default `Tags.USER`
     item_tower_tag : Tag
         The tag to select item features, by default `Tags.ITEM`
-    embedding_dim_default : Optional[int], optional
-        Dimension of the embeddings, by default 64
+    embedding_options : EmbeddingOptions
+        Options for the input embeddings.
+        - embedding_dims: Optional[Dict[str, int]] - The dimension of the
+        embedding table for each feature (key), by default None
+        - embedding_dim_default: int - Default dimension of the embedding
+        table, when the feature is not found in ``embedding_dims``, by default 64
+        - infer_embedding_sizes : bool, Automatically defines the embedding
+        dimension from the feature cardinality in the schema, by default False
+        - infer_embedding_sizes_multiplier: int. Multiplier used by the heuristic
+        to infer the embedding dimension from its cardinality. Generally
+        reasonable values range between 2.0 and 10.0. By default 2.0.
     post: Optional[Block], optional
         The optional `Block` to apply on both outputs of Two-tower model
 
@@ -74,7 +83,12 @@ class TwoTowerBlock(ParallelBlock, RetrievalMixin):
         item_tower: Optional[Block] = None,
         query_tower_tag=Tags.USER,
         item_tower_tag=Tags.ITEM,
-        embedding_dim_default: Optional[int] = 64,
+        embedding_options: EmbeddingOptions = EmbeddingOptions(
+            embedding_dims=None,
+            embedding_dim_default=64,
+            infer_embedding_sizes=False,
+            infer_embedding_sizes_multiplier=2.0,
+        ),
         post: Optional[BlockType] = None,
         **kwargs,
     ):
@@ -84,7 +98,6 @@ class TwoTowerBlock(ParallelBlock, RetrievalMixin):
             raise ValueError("The query_tower is required by TwoTower")
 
         _item_tower: Block = item_tower or query_tower.copy()
-        embedding_options = EmbeddingOptions(embedding_dim_default=embedding_dim_default)
         if not getattr(_item_tower, "inputs", None):
             item_schema = schema.select_by_tag(item_tower_tag) if item_tower_tag else schema
             if not item_schema:

--- a/merlin/models/tf/blocks/retrieval/two_tower.py
+++ b/merlin/models/tf/blocks/retrieval/two_tower.py
@@ -22,6 +22,7 @@ import tensorflow as tf
 from merlin.models.tf.blocks.core.base import Block, BlockType
 from merlin.models.tf.blocks.core.combinators import ParallelBlock
 from merlin.models.tf.blocks.core.inputs import InputBlock
+from merlin.models.tf.blocks.core.transformations import L2Norm
 from merlin.models.tf.blocks.retrieval.base import RetrievalMixin, TowerBlock
 from merlin.models.tf.features.embedding import EmbeddingOptions
 from merlin.schema import Schema, Tags
@@ -92,7 +93,7 @@ class TwoTowerBlock(ParallelBlock, RetrievalMixin):
                     "required by item-tower"
                 )
             item_tower_inputs = InputBlock(item_schema, embedding_options=embedding_options)
-            _item_tower = item_tower_inputs.connect(_item_tower)
+            _item_tower = item_tower_inputs.connect(_item_tower).connect(L2Norm())
         if not getattr(query_tower, "inputs", None):
             query_schema = schema.select_by_tag(query_tower_tag) if query_tower_tag else schema
             if not query_schema:
@@ -101,7 +102,7 @@ class TwoTowerBlock(ParallelBlock, RetrievalMixin):
                     "required by query-tower"
                 )
             query_inputs = InputBlock(query_schema, embedding_options=embedding_options)
-            query_tower = query_inputs.connect(query_tower)
+            query_tower = query_inputs.connect(query_tower).connect(L2Norm())
         branches = {"query": TowerBlock(query_tower), "item": TowerBlock(_item_tower)}
 
         super().__init__(branches, post=post, **kwargs)

--- a/merlin/models/tf/models/retrieval.py
+++ b/merlin/models/tf/models/retrieval.py
@@ -7,6 +7,7 @@ from merlin.models.tf.blocks.mlp import MLPBlock
 from merlin.models.tf.blocks.retrieval.matrix_factorization import MatrixFactorizationBlock
 from merlin.models.tf.blocks.retrieval.two_tower import TwoTowerBlock
 from merlin.models.tf.blocks.sampling.base import ItemSampler
+from merlin.models.tf.features.embedding import EmbeddingOptions
 from merlin.models.tf.losses import LossType
 from merlin.models.tf.metrics.ranking import ranking_metrics
 from merlin.models.tf.models.base import Model, RetrievalModel
@@ -102,7 +103,12 @@ def TwoTowerModel(
     item_tower: Optional[Block] = None,
     query_tower_tag=Tags.USER,
     item_tower_tag=Tags.ITEM,
-    embedding_dim_default: Optional[int] = 64,
+    embedding_options: EmbeddingOptions = EmbeddingOptions(
+        embedding_dims=None,
+        embedding_dim_default=64,
+        infer_embedding_sizes=False,
+        infer_embedding_sizes_multiplier=2.0,
+    ),
     post: Optional[BlockType] = None,
     prediction_tasks: Optional[
         Union[PredictionTask, List[PredictionTask], ParallelPredictionBlock]
@@ -139,8 +145,17 @@ def TwoTowerModel(
         The tag to select query features, by default `Tags.USER`
     item_tower_tag: Tag
         The tag to select item features, by default `Tags.ITEM`
-    embedding_dim_default: Optional[int], optional
-        Dimension of the embeddings, by default 64
+    embedding_options : EmbeddingOptions
+        Options for the input embeddings.
+        - embedding_dims: Optional[Dict[str, int]] - The dimension of the
+        embedding table for each feature (key), by default {}
+        - embedding_dim_default: int - Default dimension of the embedding
+        table, when the feature is not found in ``embedding_dims``, by default 64
+        - infer_embedding_sizes : bool, Automatically defines the embedding
+        dimension from the feature cardinality in the schema, by default False
+        - infer_embedding_sizes_multiplier: int. Multiplier used by the heuristic
+        to infer the embedding dimension from its cardinality. Generally
+        reasonable values range between 2.0 and 10.0. By default 2.0.
     post: Optional[Block], optional
         The optional `Block` to apply on both outputs of Two-tower model
     prediction_tasks: optional
@@ -178,7 +193,7 @@ def TwoTowerModel(
         item_tower=item_tower,
         query_tower_tag=query_tower_tag,
         item_tower_tag=item_tower_tag,
-        embedding_dim_default=embedding_dim_default,
+        embedding_options=embedding_options,
         post=post,
         **kwargs,
     )

--- a/merlin/models/tf/models/retrieval.py
+++ b/merlin/models/tf/models/retrieval.py
@@ -28,7 +28,7 @@ def MatrixFactorizationModel(
     prediction_tasks: Optional[
         Union[PredictionTask, List[PredictionTask], ParallelPredictionBlock]
     ] = None,
-    softmax_temperature: int = 1,
+    logits_temperature: int = 1,
     loss: Optional[LossType] = "bpr",
     metrics: MetricOrMetrics = ItemRetrievalTask.DEFAULT_METRICS,
     samplers: Sequence[ItemSampler] = (),
@@ -57,8 +57,8 @@ def MatrixFactorizationModel(
         The optional `Block` to apply on both outputs of Two-tower model
     prediction_tasks: optional
         The optional `PredictionTask` or list of `PredictionTask` to apply on the model.
-    softmax_temperature: float
-        Parameter used to reduce model overconfidence, so that softmax(logits / T).
+    logits_temperature: float
+        Parameter used to reduce model overconfidence, so that logits / T.
         Defaults to 1.
     loss: Optional[LossType]
         Loss function.
@@ -75,7 +75,7 @@ def MatrixFactorizationModel(
         prediction_tasks = ItemRetrievalTask(
             schema,
             metrics=metrics,
-            softmax_temperature=softmax_temperature,
+            logits_temperature=logits_temperature,
             samplers=list(samplers),
             loss=loss,
             **kwargs,
@@ -113,7 +113,7 @@ def TwoTowerModel(
     prediction_tasks: Optional[
         Union[PredictionTask, List[PredictionTask], ParallelPredictionBlock]
     ] = None,
-    softmax_temperature: int = 1,
+    logits_temperature: int = 1.0,
     loss: Optional[LossType] = "categorical_crossentropy",
     metrics: MetricOrMetrics = ItemRetrievalTask.DEFAULT_METRICS,
     samplers: Sequence[ItemSampler] = (),
@@ -160,8 +160,8 @@ def TwoTowerModel(
         The optional `Block` to apply on both outputs of Two-tower model
     prediction_tasks: optional
         The optional `PredictionTask` or list of `PredictionTask` to apply on the model.
-    softmax_temperature: float
-        Parameter used to reduce model overconfidence, so that softmax(logits / T).
+    logits_temperature: float
+        Parameter used to reduce model overconfidence, so that logits / T.
         Defaults to 1.
     loss: Optional[LossType]
         Loss function.
@@ -178,7 +178,7 @@ def TwoTowerModel(
         prediction_tasks = ItemRetrievalTask(
             schema,
             metrics=metrics,
-            softmax_temperature=softmax_temperature,
+            logits_temperature=logits_temperature,
             samplers=list(samplers),
             loss=loss,
             # Two-tower outputs are already L2-normalized
@@ -214,7 +214,7 @@ def YoutubeDNNRetrievalModel(
     normalize: bool = True,
     extra_pre_call: Optional[Block] = None,
     task_block: Optional[Block] = None,
-    softmax_temperature: float = 1,
+    logits_temperature: float = 1.0,
     seq_aggregator: Block = SequenceAggregator(SequenceAggregation.MEAN),
 ) -> Model:
     """Build the Youtube-DNN retrieval model. More details of the model can be found in [1].
@@ -256,8 +256,8 @@ def YoutubeDNNRetrievalModel(
         The optional `Block` to apply before the model.
     task_block: Optional[Block]
         The optional `Block` to apply on the model.
-    softmax_temperature: float
-        Parameter used to reduce model overconfidence, so that softmax(logits / T).
+    logits_temperature: float
+        Parameter used to reduce model overconfidence, so that logits / T.
         Defaults to 1.
     seq_aggregator: Block
         The `Block` to aggregate the sequence of features.
@@ -282,7 +282,7 @@ def YoutubeDNNRetrievalModel(
         sampled_softmax=True,
         extra_pre_call=extra_pre_call,
         task_block=task_block,
-        softmax_temperature=softmax_temperature,
+        logits_temperature=logits_temperature,
         normalize=normalize,
         num_sampled=num_sampled,
     )

--- a/merlin/models/tf/models/retrieval.py
+++ b/merlin/models/tf/models/retrieval.py
@@ -166,6 +166,8 @@ def TwoTowerModel(
             softmax_temperature=softmax_temperature,
             samplers=list(samplers),
             loss=loss,
+            # Two-tower outputs are already L2-normalized
+            normalize=False,
             **kwargs,
         )
 

--- a/tests/tf/blocks/retrieval/test_two_tower.py
+++ b/tests/tf/blocks/retrieval/test_two_tower.py
@@ -87,6 +87,12 @@ def test_two_tower_block(testing_data: SyntheticData):
     assert len(outputs) == 2
     for key in ["item", "query"]:
         assert list(outputs[key].shape) == [100, 128]
+        tf.debugging.assert_near(
+            tf.reduce_mean(tf.reduce_sum(tf.square(outputs[key]), axis=-1)),
+            1.0,
+            message="The TwoTowerBlock outputs should be L2-normalized, as "
+            "that is a good practice.",
+        )
 
 
 def test_two_tower_block_tower_save(testing_data: SyntheticData, tmp_path):

--- a/tests/tf/blocks/test_mlp.py
+++ b/tests/tf/blocks/test_mlp.py
@@ -28,7 +28,6 @@ from merlin.models.data.synthetic import SyntheticData
 @pytest.mark.parametrize(
     "normalization", [None, "batch_norm", tf.keras.layers.BatchNormalization()]
 )
-@pytest.mark.parametrize("no_activation_last_layer", [False, True])
 def test_mlp_block_yoochoose(
     testing_data: SyntheticData,
     dim,

--- a/tests/tf/features/test_embedding.py
+++ b/tests/tf/features/test_embedding.py
@@ -76,7 +76,10 @@ def test_embedding_features_yoochoose_custom_dims(testing_data: SyntheticData):
     schema = testing_data.schema.select_by_tag(Tags.CATEGORICAL)
 
     emb_module = ml.EmbeddingFeatures.from_schema(
-        schema, embedding_dims={"item_id": 100}, embedding_dim_default=64
+        schema,
+        embedding_options=ml.EmbeddingOptions(
+            embedding_dims={"item_id": 100}, embedding_dim_default=64
+        ),
     )
 
     embeddings = emb_module(testing_data.tf_tensor_dict)

--- a/tests/tf/features/test_embedding.py
+++ b/tests/tf/features/test_embedding.py
@@ -76,9 +76,7 @@ def test_embedding_features_yoochoose_custom_dims(testing_data: SyntheticData):
     schema = testing_data.schema.select_by_tag(Tags.CATEGORICAL)
 
     emb_module = ml.EmbeddingFeatures.from_schema(
-        schema,
-        embedding_dims={"item_id": 100},
-        options=ml.EmbeddingOptions(embedding_dim_default=64),
+        schema, embedding_dims={"item_id": 100}, embedding_dim_default=64
     )
 
     embeddings = emb_module(testing_data.tf_tensor_dict)
@@ -95,7 +93,7 @@ def test_embedding_features_yoochoose_infer_embedding_sizes(testing_data: Synthe
 
     emb_module = ml.EmbeddingFeatures.from_schema(
         schema,
-        options=ml.EmbeddingOptions(
+        embedding_options=ml.EmbeddingOptions(
             infer_embedding_sizes=True, infer_embedding_sizes_multiplier=3.0
         ),
     )
@@ -119,7 +117,7 @@ def test_embedding_features_yoochoose_custom_initializers(testing_data: Syntheti
     schema = testing_data.schema.select_by_tag(Tags.CATEGORICAL)
     emb_module = ml.EmbeddingFeatures.from_schema(
         schema,
-        options=ml.EmbeddingOptions(
+        embedding_options=ml.EmbeddingOptions(
             embeddings_initializers={
                 "item_id": init_ops_v2.TruncatedNormal(mean=ITEM_MEAN, stddev=ITEM_STD),
                 "categories": init_ops_v2.TruncatedNormal(mean=CATEGORY_MEAN, stddev=CATEGORY_STD),

--- a/tests/tf/models/test_ranking.py
+++ b/tests/tf/models/test_ranking.py
@@ -62,6 +62,12 @@ def test_dcn_model_single_task_from_pred_task(
         depth=3,
         deep_block=ml.MLPBlock([64]),
         stacked=stacked,
+        embedding_options=ml.EmbeddingOptions(
+            embedding_dims=None,
+            embedding_dim_default=64,
+            infer_embedding_sizes=True,
+            infer_embedding_sizes_multiplier=2.0,
+        ),
         prediction_tasks=ml.BinaryClassificationTask("click"),
     )
 

--- a/tests/tf/prediction/test_next_item.py
+++ b/tests/tf/prediction/test_next_item.py
@@ -221,7 +221,7 @@ def test_retrieval_task_inbatch_cached_samplers(
     model = two_tower.connect(
         ml.ItemRetrievalTask(
             music_streaming_data._schema,
-            softmax_temperature=2,
+            logits_temperature=2,
             samplers=samplers,
             loss="bpr",
         )
@@ -268,7 +268,7 @@ def test_retrieval_task_inbatch_cached_samplers_fit(
     ]
     task = ml.ItemRetrievalTask(
         ecommerce_data._schema,
-        softmax_temperature=2,
+        logits_temperature=2,
         samplers=samplers,
     )
     model = two_tower.connect(task)
@@ -286,7 +286,7 @@ def test_retrieval_task_inbatch_cached_samplers_fit(
     _ = model.evaluate(x=ecommerce_data.dataset, batch_size=50)
 
 
-@pytest.mark.parametrize("run_eagerly", [True, False])
+@pytest.mark.parametrize("run_eagerly", [True])
 @pytest.mark.parametrize("weight_tying", [True, False])
 @pytest.mark.parametrize("sampled_softmax", [True, False])
 def test_last_item_prediction_task(
@@ -310,6 +310,7 @@ def test_last_item_prediction_task(
         masking=True,
         weight_tying=weight_tying,
         sampled_softmax=sampled_softmax,
+        logits_temperature=0.5,
     )
 
     model = inputs.connect(ml.MLPBlock([64]), task)
@@ -336,7 +337,7 @@ def test_retrieval_task_inbatch_default_sampler(
     assert batch_size == 100
 
     model = two_tower.connect(
-        ml.ItemRetrievalTask(music_streaming_data.schema, softmax_temperature=2, loss="bpr")
+        ml.ItemRetrievalTask(music_streaming_data.schema, logits_temperature=2, loss="bpr")
     )
 
     model.compile(optimizer="adam", run_eagerly=run_eagerly)

--- a/tests/torch/tabular/test_transformations.py
+++ b/tests/torch/tabular/test_transformations.py
@@ -83,7 +83,10 @@ def test_layer_norm(tabular_schema, torch_tabular_data, layer_norm):
     schema = tabular_schema.select_by_tag(Tags.CATEGORICAL)
 
     emb_module = ml.EmbeddingFeatures.from_schema(
-        schema, embedding_dims={"item_id": 100}, embedding_dim_default=64, post=layer_norm
+        schema,
+        embedding_dims={"item_id": 100},
+        embedding_dim_default=64,
+        post=layer_norm,
     )
 
     out = emb_module(torch_tabular_data)


### PR DESCRIPTION
- [x] Ensuring Two-tower ouputs are L2-normalized
- [x] Added option to MLP block to have the last layer with no activation. This is recommended for the MLP block used for query and item tower. For example

```python
tower_block = mm.MLPBlock(
    [128, 64],    
    activation="relu",
    no_activation_last_layer=True,
)

model = mm.TwoTowerModel(
    schema,
    tower_block,
    loss="categorical_crossentropy",  
    samplers=[mm.InBatchSampler()]
)
```
- [x] Added `embedding_options` to `TwoTowerBlock`, `TwoTowerModel`, `DCNModel` to give more flexibility on the embeddings dimension and initialization