### PR TITLE
fix: Typo in workflow script

### DIFF
--- a/.github/workflows/docs-preview-pr.yaml
+++ b/.github/workflows/docs-preview-pr.yaml
@@ -39,7 +39,7 @@ jobs:
               console.log("Request to GitHub API for Pages failed with message: " + err)
             }
             core.setOutput('html_url', '')
-            core.setOutput('branch', '')``
+            core.setOutput('branch', '')
 
   # Identify the dir for the HTML.
   store-html:


### PR DESCRIPTION
I somehow had a typo in the workflow and I think it was causing the previews to fail before I added the `gh-pages` branch.

Seems like it should be fixed regardless.