### PR TITLE
chore: Trigger on closed pull requests

### DIFF
--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, closed]
 
 jobs:
   tests:
@@ -37,9 +38,7 @@ jobs:
       # Build the documentation, treating warnings as errors
       - name: Make HTML
         run: |
-          pushd docs
-            make html
-          popd
+          make -C docs html SPHINXOPTS="-W -q"
       - name: Upload HTML
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
The goal is to run the docs-preview-pr workflow
when a PR is closed.  If it is merged (that is a
closed event), then update the `main` documentation
and delete the review directory.

