### PR TITLE
Set up automated docstring coverage checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,11 @@ repos:
     rev: v0.3.1
     hooks:
       - id: absolufy-imports
+ - repo: https://github.com/econchick/interrogate
+        rev: 1.5.0
+        hooks:
+        - id: interrogate
+          args: [-viImMpPsSCn, -f, "25.0", merlin]
   # yaml formatting
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
     hooks:
       - id: interrogate
         args: [-viImMpPsSCn, -f, "25.0", merlin]
+        exclude: tests
   # yaml formatting
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,11 +17,11 @@ repos:
     rev: v0.3.1
     hooks:
       - id: absolufy-imports
- - repo: https://github.com/econchick/interrogate
-        rev: 1.5.0
-        hooks:
-        - id: interrogate
-          args: [-viImMpPsSCn, -f, "25.0", merlin]
+  - repo: https://github.com/econchick/interrogate
+    rev: 1.5.0
+    hooks:
+      - id: interrogate
+        args: [-viImMpPsSCn, -f, "25.0", merlin]
   # yaml formatting
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,6 +3,7 @@ pytest>=5
 pytest-cov>=2
 black==20.8b1
 flake8
+interrogate==1.5.0
 isort
 nbsphinx>=0.6
 mypy


### PR DESCRIPTION
This sets up a docstring coverage tool in the pre-commit hooks and checks for 25% coverage as a starting point.

(Hoping to get that much higher in all our libraries, but also don't want to block every PR on docstrings. We can bump the threshold as coverage improves to check for regressions.)