### PR TITLE
Check if valid data is merlin.io.dataset and then convert to BatchedDataset

### DIFF
--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -6,6 +6,7 @@ import tensorflow as tf
 import merlin.io
 from merlin.models.tf.blocks.core.base import Block, BlockContext, BlockType
 from merlin.models.tf.blocks.core.combinators import SequentialBlock
+from merlin.models.tf.dataset import BatchedDataset
 from merlin.models.tf.prediction_tasks.base import ParallelPredictionBlock, PredictionTask
 from merlin.models.tf.typing import TabularData
 from merlin.models.tf.utils.mixins import LossMixin, MetricsMixin, ModelLikeBlock
@@ -331,9 +332,13 @@ class Model(tf.keras.Model, LossMixin, MetricsMixin):
         if hasattr(x, "to_ddf"):
             if not batch_size:
                 raise ValueError("batch_size must be specified when using merlin-dataset.")
-            from merlin.models.tf.dataset import BatchedDataset
 
             x = BatchedDataset(x, batch_size=batch_size, **kwargs)
+
+        if hasattr(validation_data, "to_ddf"):
+            validation_data = BatchedDataset(
+                validation_data, batch_size=batch_size, shuffle=False, **kwargs
+            )
 
         callbacks = self._add_metrics_callback(callbacks, train_metrics_steps)
 


### PR DESCRIPTION
Currently, we get error if we do the following because we do not check if a merlin.io.Dataset object is passed as validation_data, and if so we need to convert it to a BatchedDataset. This PR is fixing that issue.

```
train = Dataset(os.path.join(output_path + '/train/*.parquet'), part_size="500MB")
valid = Dataset(os.path.join(output_path + '/test/*.parquet'), part_size="500MB")
model.compile('adam', run_eagerly=False)
model.fit(train, validation_data=valid, batch_size=batch_size)
````

