### PR TITLE
Fix small bug when shuffle is passed in .fit

### DIFF
--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -340,6 +340,7 @@ class Model(tf.keras.Model, LossMixin, MetricsMixin):
                 raise ValueError("batch_size must be specified when using merlin-dataset.")
             from merlin.models.tf.dataset import BatchedDataset
 
+            kwargs.pop("shuffle", None)
             validation_data = BatchedDataset(
                 validation_data, batch_size=batch_size, shuffle=False, **kwargs
             )


### PR DESCRIPTION
### Goals :soccer:
Right now when shuffle is passed in in kwargs in fit + validation_data we would get an error since the shuffle argument is passed in twice in BatchedDataset. This PR fixes this.