### PR TITLE
Move interrogate docstring coverage settings to pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,8 @@ repos:
     rev: 1.5.0
     hooks:
       - id: interrogate
-        args: [-viImMpPsSCn, -f, "25.0", merlin]
-        exclude: tests
+        exclude: ^(docs|examples|tests|setup.py|versioneer.py)
+        args: [--config=pyproject.toml]
   # yaml formatting
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,25 @@ known_third_party = ["cudf", "cupy", "dask", "dask_cuda", "dask_cudf", "numba", 
 known_first_party = ["merlin"]
 skip = ["build",".eggs"]
 
-
+[tool.interrogate]
+ignore-init-method = true
+ignore-init-module = true
+ignore-magic = true
+ignore-module = true
+ignore-private = true
+ignore-property-decorators = true
+ignore-nested-classes = true
+ignore-nested-functions = true
+ignore-semiprivate = true
+ignore-setters = true
+fail-under = 25
+exclude = ["docs", "tests", "setup.py", "versioneer.py"]
+verbose = 1
+omit-covered-files = false
+quiet = false
+whitelist-regex = []
+ignore-regex = []
+color = true
 
 [tool.pytest.ini_options]
 filterwarnings = [


### PR DESCRIPTION
The docstring coverage pre-commit hooks has been blocking some commits that touch tests, since the tests weren't properly excluded. Putting the configuration in pyproject.toml (instead of in the command) gives a clean way to fix that.