### PR TITLE
Item retrieval evaluation fixes

### DIFF
--- a/merlin/models/tf/blocks/core/base.py
+++ b/merlin/models/tf/blocks/core/base.py
@@ -469,7 +469,8 @@ class Block(SchemaMixin, ContextMixin, Layer):
         append: bool
             Whether to append the debug block to the block or to prepend it.
         """
-        from merlin.models.tf.blocks.core.combinators import Debug, SequentialBlock
+        from merlin.models.tf.blocks.core.base import Debug
+        from merlin.models.tf.blocks.core.combinators import SequentialBlock
 
         if not append:
             return SequentialBlock([Debug(), self])


### PR DESCRIPTION
Fixes #274 
This PR fixes metrics issues on model.evaluate() of `RetrievalModel`. It was giving higher metric results than expected when `model.fit()` was using `validation_data` argument and then `model.evaluate()` was being called (only in graph mode), as described in #274 
