### PR TITLE
Fix MatrixFactorizationModel bug

### DIFF
--- a/merlin/models/tf/blocks/core/base.py
+++ b/merlin/models/tf/blocks/core/base.py
@@ -368,6 +368,7 @@ class Block(SchemaMixin, ContextMixin, Layer):
         """
         from merlin.models.tf.blocks.core.combinators import SequentialBlock
         from merlin.models.tf.models.base import Model, RetrievalBlock, RetrievalModel
+        from merlin.models.tf.prediction_tasks.retrieval import ItemRetrievalTask
 
         blocks = [self.parse(b) for b in block]
 
@@ -381,8 +382,10 @@ class Block(SchemaMixin, ContextMixin, Layer):
         )
 
         if isinstance(blocks[-1], ModelLikeBlock):
-            if any(isinstance(b, RetrievalBlock) for b in blocks) or isinstance(
-                self, RetrievalBlock
+            if (
+                any(isinstance(b, RetrievalBlock) for b in blocks)
+                or isinstance(self, RetrievalBlock)
+                and any(isinstance(b, ItemRetrievalTask) for b in blocks)
             ):
                 return RetrievalModel(output)
 
@@ -465,7 +468,6 @@ class Block(SchemaMixin, ContextMixin, Layer):
         ----------
         append: bool
             Whether to append the debug block to the block or to prepend it.
-
         """
         from merlin.models.tf.blocks.core.combinators import Debug, SequentialBlock
 

--- a/tests/tf/models/test_ranking.py
+++ b/tests/tf/models/test_ranking.py
@@ -35,6 +35,23 @@ def test_simple_model(ecommerce_data: SyntheticData, num_epochs=5, run_eagerly=T
     )
 
 
+@pytest.mark.parametrize("run_eagerly", [True, False])
+def test_mf_model_signle_task_from_pred_task(ecommerce_data, run_eagerly, num_epochs=5):
+    model = ml.MatrixFactorizationModel(
+        ecommerce_data.schema,
+        dim=64,
+        prediction_tasks=ml.BinaryClassificationTask("click"),
+    )
+
+    model.compile(optimizer="adam", run_eagerly=run_eagerly)
+
+    losses = model.fit(ecommerce_data.dataset, batch_size=50, epochs=num_epochs)
+    metrics = model.evaluate(*ecommerce_data.tf_features_and_targets, return_dict=True)
+    testing_utils.assert_binary_classification_loss_metrics(
+        losses, metrics, target_name="click", num_epochs=num_epochs
+    )
+
+
 def test_dlrm_model_single_task_from_pred_task(ecommerce_data, num_epochs=5, run_eagerly=True):
     model = ml.DLRMModel(
         ecommerce_data.schema,

--- a/tests/tf/models/test_ranking.py
+++ b/tests/tf/models/test_ranking.py
@@ -36,10 +36,11 @@ def test_simple_model(ecommerce_data: SyntheticData, num_epochs=5, run_eagerly=T
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
-def test_mf_model_signle_task_from_pred_task(ecommerce_data, run_eagerly, num_epochs=5):
+def test_mf_model_signle_binary_task(ecommerce_data, run_eagerly, num_epochs=5):
     model = ml.MatrixFactorizationModel(
         ecommerce_data.schema,
         dim=64,
+        aggregation="cosine",
         prediction_tasks=ml.BinaryClassificationTask("click"),
     )
 


### PR DESCRIPTION
Fixes #278  

MatrixFactorization returns a RetrievalModel by default. However, MF can be used with other tasks (like binary), and in that case, we should return a base `Model` class instead of `RetrievalModel` one. 

I added a check in the `connect` method to detect if an `ItemRetrievalTask` was provided. If so, it returns `RetrievalModel`; otherwise, it returns the `Model` class.  

+ Unit test of MatrixFactorizationModel trained with binary prediction task. 