### PR TITLE
docs: Add nightly multi-version build

### DIFF
--- a/.github/workflows/docs-preview-pr.yaml
+++ b/.github/workflows/docs-preview-pr.yaml
@@ -9,10 +9,11 @@ env:
   WF_ID: ${{ github.event.workflow_run.id }}
 
 jobs:
-
   # Always determine if GitHub Pages are configured for this repo.
   get-gh-pages-url:
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    if:
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     outputs:
       url: ${{ steps.api-resp.outputs.html_url }}
@@ -54,12 +55,6 @@ jobs:
         run: |
           git config user.name docs-preview
           git config user.email do-not-send-@github.com
-      - name: Ensure dot-nojekyll file exists
-        run: |
-          if [ ! -f ".nojekyll" ]; then
-            touch .nojekyll
-            git add .nojekyll
-          fi
       - name: Download artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -80,17 +75,10 @@ jobs:
           rm -rf ./pr
 
       # Permutations:
-      # - PR was merged, update `main` directory; PR_ACTION is closed, need to delete review directory.
+      # - REMOVED: PR was merged, update `main` directory; PR_ACTION is closed, need to delete review directory.
       # - PR was updated, PR_ACTION is !closed, need to delete review directory and update it.
       # - PR was closed (regardless of merge), PR_ACTION is closed, need to delete review directory.
 
-      # If the PR was merged, store in directory `main`. PR_ACTION is closed and handled two steps later.
-      - name: Handle HTML for merges to main
-        if: env.MERGE_STATUS == 'true'
-        run: |
-          rm -rf main 2>/dev/null || true
-          mv ./html-build-artifact/  main
-          git add main
       # If this PR is still open, store HTML in a review directory.
       - name: Handle HTML review directory for open PRs and updates to PRs
         if: env.MERGE_STATUS == 'false' && env.PR_ACTION != 'closed'
@@ -116,7 +104,7 @@ jobs:
           git status
           if git commit -m 'Pushing changes to GitHub Pages.'; then
             git push -f
-          else 
+          else
            echo "Nothing changed."
           fi
       - name: Check for existing documentation review comment

--- a/.github/workflows/docs-sched-rebuild.yaml
+++ b/.github/workflows/docs-sched-rebuild.yaml
@@ -1,0 +1,81 @@
+name: docs-sched-rebuild
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.9.7]
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Ubuntu packages
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y protobuf-compiler pandoc
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[all]
+      - name: Build
+        run: |
+          python setup.py develop
+      - name: Report the versions to build
+        run: |
+          sphinx-multiversion --dump-metadata docs/source docs/build/html | jq "keys"
+      - name: Building docs (multiversion)
+        run: |
+          sphinx-multiversion docs/source docs/build/html
+      - name: Upload HTML
+        uses: actions/upload-artifact@v2
+        with:
+          name: html-build-artifact
+          path: docs/build/html
+          if-no-files-found: error
+          retention-days: 1
+
+  # Identify the dir for the HTML.
+  store-html:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: "gh-pages"
+      - name: Initialize Git configuration
+        run: |
+          git config user.name docs-sched-rebuild
+          git config user.email do-not-send-@github.com
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: html-build-artifact
+      - name: Copy HTML directories
+        run: |
+          ls -asl
+          for i in `ls -d *`
+          do
+            echo "Git adding ${i}"
+            git add "${i}"
+          done
+      - name: Commit changes to the GitHub Pages branch
+        run: |
+          git status
+          if git commit -m 'Pushing changes to GitHub Pages.'; then
+            git push -f
+          else
+           echo "Nothing changed."
+          fi

--- a/docs/source/_templates/versions.html
+++ b/docs/source/_templates/versions.html
@@ -1,0 +1,27 @@
+{%- if current_version %}
+<div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    <span class="fa fa-book"> Other Versions</span>
+    v: {{ current_version.name }}
+    <span class="fa fa-caret-down"></span>
+  </span>
+  <div class="rst-other-versions">
+    {%- if versions.tags %}
+    <dl>
+      <dt>Tags</dt>
+      {%- for item in versions.tags %}
+      <dd><a href="{{ item.url }}">{{ item.name }}</a></dd>
+      {%- endfor %}
+    </dl>
+    {%- endif %}
+    {%- if versions.branches %}
+    <dl>
+      <dt>Branches</dt>
+      {%- for item in versions.branches %}
+      <dd><a href="{{ item.url }}">{{ item.name }}</a></dd>
+      {%- endfor %}
+    </dl>
+    {%- endif %}
+  </div>
+</div>
+{%- endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,11 +27,17 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+import subprocess
 import sys
 
+from natsort import natsorted
 from recommonmark.parser import CommonMarkParser
 
 sys.path.insert(0, os.path.abspath("../../"))
+
+repodir = os.path.abspath(os.path.join(__file__, r"../../.."))
+gitdir = os.path.join(repodir, r".git")
+
 
 # -- Project information -----------------------------------------------------
 
@@ -46,6 +52,7 @@ author = "NVIDIA"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "sphinx_multiversion",
     "sphinx_rtd_theme",
     "recommonmark",
     "sphinx_markdown_tables",
@@ -79,18 +86,29 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ["../../images"]
-# html_extra_path = ["images"]
+html_static_path = []
 
 source_parsers = {".md": CommonMarkParser}
 source_suffix = [".rst", ".md"]
+
+nbsphinx_allow_errors = True
+html_show_sourcelink = False
+
+if os.path.exists(gitdir):
+    tag_refs = subprocess.check_output(["git", "tag", "-l", "v*"]).decode("utf-8").split()
+    tag_refs = natsorted(tag_refs)[-6:]
+    smv_tag_whitelist = r"^(" + r"|".join(tag_refs) + r")$"
+else:
+    smv_tag_whitelist = r"^v.*$"
+
+smv_branch_whitelist = r"^main$"
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "cudf": ("https://docs.rapids.ai/api/cudf/stable/", None),
     "distributed": ("https://distributed.dask.org/en/latest/", None),
     "torch": ("https://pytorch.org/docs/stable/", None),
-    "merlin-core": ("https://nvidia-merlin.github.io/core/", None),
+    "merlin-core": ("https://nvidia-merlin.github.io/main/core/", None),
 }
 
 autodoc_inherit_docstrings = False

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,9 +8,13 @@ isort
 nbsphinx>=0.6
 mypy
 Sphinx==3.5.4
+jinja2<3.1
+markupsafe==2.0.1
 sphinx_markdown_tables
+sphinx-multiversion
 sphinx_rtd_theme
 sklearn
 recommonmark>=0.6
+natsort==8.1.0
 tensorflow-metadata
 tensorflow-ranking>=0.4


### PR DESCRIPTION
* Docs preview for PRs are still created.

* Change: Add a comment to PRs with the preview URL
  on a subsequent build (in case pre-commit fails).

* Add nightly build that uses sphinx-multiversion.

The `v0.1.0` docs are not built because there was
no `docs/source/conf.py` when the release was tagged.

I applied this commit to my fork and it seems to work: https://mikemckiernan.github.io/models/v0.2.0/index.html