### PR TITLE
Specify encoding when reading csv file for ml-1m

### DIFF
--- a/merlin/models/data/movielens.py
+++ b/merlin/models/data/movielens.py
@@ -309,6 +309,7 @@ def movielens_download_etl(local_filename, name="ml-25m", outputdir=None):
             os.path.join(local_filename, "ml-1m/movies.dat"),
             names=["movieId", "title", "genres"],
             sep="::",
+            encoding="latin1",
         )
         movies["genres"] = movies["genres"].str.split("|")
         movies.to_parquet(os.path.join(local_filename, name, "movies_converted.parquet"))


### PR DESCRIPTION
We were failing to process the ml-1m dataset using pandas 1.3.
Fix by specifying the proper encoding (rather than using utf8)

Same fix as in https://github.com/NVIDIA-Merlin/models/pull/249 but for the ml-1m dataset
