### PR TITLE
Merlin models examples fixes

### DIFF
--- a/examples/01-Getting-started.ipynb
+++ b/examples/01-Getting-started.ipynb
@@ -136,7 +136,7 @@
    "id": "688b89c7",
    "metadata": {},
    "source": [
-    "We define the DLRM model, whose prediction task is a binary classification. From the `schema`, the categorical features are identified (and embedded) and the target column is also automatically inferred, because of the schema tags. We talk more about the schema in the example notebook [02-Merlin-Models-and-NVTabular-applying-to-your-own-dataset](02-Merlin-Models-and-NVTabular-applying-to-your-own-dataset),"
+    "We define the DLRM model, whose prediction task is a binary classification. From the `schema`, the categorical features are identified (and embedded) and the target column is also automatically inferred, because of the schema tags. We talk more about the schema in the next [example notebook (02)](02-Merlin-Models-and-NVTabular-integration.ipynb),"
    ]
   },
   {

--- a/examples/01-Getting-started.ipynb
+++ b/examples/01-Getting-started.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Copyright 2021 NVIDIA Corporation. All Rights Reserved.\n",
+    "# Copyright 2022 NVIDIA Corporation. All Rights Reserved.\n",
     "#\n",
     "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
     "# you may not use this file except in compliance with the License.\n",
@@ -34,17 +34,17 @@
     "\n",
     "## Overview\n",
     "\n",
-    "[Merlin Models](https://github.com/NVIDIA-Merlin/models/) is a library for training recommender models. Merlin Models let users in industry easily train standard models against their own dataset, getting high performance GPU accelerated models with best practices baked into the library. This will also let researchers to build custom models by incorporating standard components of deep learning recommender models, and then benchmark their new models on example offline datasets. Merlin Models is part of the [Merlin open source framework](https://developer.nvidia.com/nvidia-merlin).\n",
+    "[Merlin Models](https://github.com/NVIDIA-Merlin/models/) is a library for training recommender models. Merlin Models let Data Scientists and ML Engineers easily train standard RecSys models on their own dataset, getting GPU-accelerated models with best practices baked into the library. This will also let researchers to build custom models by incorporating standard components of deep learning recommender models, and then benchmark their new models on example offline datasets. Merlin Models is part of the [Merlin open source framework](https://developer.nvidia.com/nvidia-merlin).\n",
     "\n",
     "Core features are:\n",
-    "- Unified API enables users to create models in TensorFlow or PyTorch\n",
-    "- Deep integration with NVTabular for ETL and model serving\n",
-    "- Flexible APIs targeted to both production and research\n",
     "- Many different recommender system architectures (tabular, two-tower, sequential) or tasks (binary, multi-class classification, multi-task)\n",
+    "- Flexible APIs targeted to both production and research\n",
+    "- Deep integration with NVIDIA Merlin platform, including NVTabular for ETL and Merlin Systems model serving\n",
+    "\n",
     "\n",
     "### Learning objectives\n",
     "\n",
-    "- Training [Facebook's DLRM model](https://arxiv.org/pdf/1906.00091.pdf) with only 3 commands.\n",
+    "- Training [Facebook's DLRM model](https://arxiv.org/pdf/1906.00091.pdf) very easily with our high-level API.\n",
     "- Understanding Merlin Models high-level API"
    ]
   },
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "60653f70",
    "metadata": {},
    "outputs": [
@@ -66,17 +66,20 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-03-17 16:01:59.285737: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 16255 MB memory:  -> device: 0, name: Tesla V100-SXM2-32GB, pci bus id: 0000:0b:00.0, compute capability: 7.0\n",
-      "2022-03-17 16:01:59.286915: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:1 with 29922 MB memory:  -> device: 1, name: Tesla V100-SXM2-32GB, pci bus id: 0000:85:00.0, compute capability: 7.0\n",
-      "2022-03-17 16:01:59.287899: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:2 with 29924 MB memory:  -> device: 2, name: Tesla V100-SXM2-32GB, pci bus id: 0000:86:00.0, compute capability: 7.0\n",
-      "2022-03-17 16:01:59.288930: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:3 with 29924 MB memory:  -> device: 3, name: Tesla V100-SXM2-32GB, pci bus id: 0000:89:00.0, compute capability: 7.0\n"
+      "2022-04-05 14:47:25.928570: I tensorflow/core/platform/cpu_feature_guard.cc:151] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F FMA\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "2022-04-05 14:47:28.104380: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 16249 MB memory:  -> device: 0, name: Quadro GV100, pci bus id: 0000:15:00.0, compute capability: 7.0\n",
+      "2022-04-05 14:47:28.105455: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:1 with 29778 MB memory:  -> device: 1, name: Quadro GV100, pci bus id: 0000:2d:00.0, compute capability: 7.0\n",
+      "2022-04-05 14:47:28.110332: I tensorflow/stream_executor/cuda/cuda_driver.cc:739] failed to allocate 15.87G (17038311424 bytes) from device: CUDA_ERROR_OUT_OF_MEMORY: out of memory\n",
+      "2022-04-05 14:47:28.112154: I tensorflow/stream_executor/cuda/cuda_driver.cc:739] failed to allocate 14.28G (15334479872 bytes) from device: CUDA_ERROR_OUT_OF_MEMORY: out of memory\n",
+      "2022-04-05 14:47:28.114081: I tensorflow/stream_executor/cuda/cuda_driver.cc:739] failed to allocate 12.85G (13801031680 bytes) from device: CUDA_ERROR_OUT_OF_MEMORY: out of memory\n"
      ]
     }
    ],
    "source": [
     "import merlin.models.tf as mm\n",
     "\n",
-    "from merlin.models.data.movielens import get_movielens"
+    "from merlin.datasets.entertainment import get_movielens"
    ]
   },
   {
@@ -84,34 +87,34 @@
    "id": "5327924b",
    "metadata": {},
    "source": [
-    "We run the get_movielens function as a convenience to download the dataset, perform simple preprocessing, and split the data into training and validation datasets."
+    "We provide the `get_movielens()` function as a convenience to download the dataset, perform simple preprocessing, and split the data into training and validation datasets."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "9ba8b53d",
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /home/gmoreira/projects/nvidia/nvidia_merlin/models/merlin/models/utils/nvt_utils.py:14: is_gpu_available (from tensorflow.python.framework.test_util) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Use `tf.config.list_physical_devices('GPU')` instead.\n"
+     ]
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "downloading ml-1m.zip: 5.93MB [00:00, 10.4MB/s]                                 \n",
-      "unzipping files: 100%|█████████████████████████| 5/5 [00:00<00:00, 36.15files/s]\n",
-      "/workspace/01_NVT/55_MM_examples/models-1/merlin/models/data/movielens.py:296: ParserWarning: Falling back to the 'python' engine because the 'c' engine does not support regex separators (separators > 1 char and different from '\\s+' are interpreted as regex); you can avoid this warning by specifying engine='python'.\n",
-      "  users = pd.read_csv(\n",
-      "/workspace/01_NVT/55_MM_examples/models-1/merlin/models/data/movielens.py:301: ParserWarning: Falling back to the 'python' engine because the 'c' engine does not support regex separators (separators > 1 char and different from '\\s+' are interpreted as regex); you can avoid this warning by specifying engine='python'.\n",
-      "  ratings = pd.read_csv(\n",
-      "/workspace/01_NVT/55_MM_examples/models-1/merlin/models/data/movielens.py:306: ParserWarning: Falling back to the 'python' engine because the 'c' engine does not support regex separators (separators > 1 char and different from '\\s+' are interpreted as regex); you can avoid this warning by specifying engine='python'.\n",
-      "  movies = pd.read_csv(\n",
-      "INFO:merlin.models.data.movielens:starting ETL..\n",
-      "/usr/local/lib/python3.8/dist-packages/cudf/core/dataframe.py:1253: UserWarning: The deep parameter is ignored and is only included for pandas compatibility.\n",
-      "  warnings.warn(\n",
-      "/usr/local/lib/python3.8/dist-packages/cudf/core/dataframe.py:1253: UserWarning: The deep parameter is ignored and is only included for pandas compatibility.\n",
-      "  warnings.warn(\n",
-      "INFO:merlin.models.data.movielens:saving the workflow..\n",
-      "/usr/local/lib/python3.8/dist-packages/cudf/core/dataframe.py:1253: UserWarning: The deep parameter is ignored and is only included for pandas compatibility.\n",
+      "WARNING:tensorflow:From /home/gmoreira/projects/nvidia/nvidia_merlin/models/merlin/models/utils/nvt_utils.py:14: is_gpu_available (from tensorflow.python.framework.test_util) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Use `tf.config.list_physical_devices('GPU')` instead.\n",
+      "2022-04-05 14:47:28.568643: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /device:GPU:0 with 16249 MB memory:  -> device: 0, name: Quadro GV100, pci bus id: 0000:15:00.0, compute capability: 7.0\n",
+      "2022-04-05 14:47:28.570027: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /device:GPU:1 with 29778 MB memory:  -> device: 1, name: Quadro GV100, pci bus id: 0000:2d:00.0, compute capability: 7.0\n",
+      "/home/gmoreira/miniconda3/envs/merlin_22.04_dev/lib/python3.8/site-packages/cudf/core/dataframe.py:1253: UserWarning: The deep parameter is ignored and is only included for pandas compatibility.\n",
       "  warnings.warn(\n"
      ]
     }
@@ -133,12 +136,12 @@
    "id": "688b89c7",
    "metadata": {},
    "source": [
-    "We initialize the DLRM model."
+    "We define the DLRM model, whose prediction task is a binary classification. From the `schema`, the categorical features are identified (and embedded) and the target column is also automatically inferred, because of the schema tags. We talk more about the schema in the example notebook [02-Merlin-Models-and-NVTabular-applying-to-your-own-dataset](02-Merlin-Models-and-NVTabular-applying-to-your-own-dataset),"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "d3b8942c",
    "metadata": {},
    "outputs": [],
@@ -164,7 +167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "33343067",
    "metadata": {},
    "outputs": [
@@ -172,23 +175,23 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-03-17 16:02:18.246713: W tensorflow/python/util/util.cc:368] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
+      "2022-04-05 14:47:29.832785: W tensorflow/python/util/util.cc:368] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "782/782 [==============================] - 15s 10ms/step - rating_binary/binary_classification_task/precision: 0.7226 - rating_binary/binary_classification_task/recall: 0.8241 - rating_binary/binary_classification_task/binary_accuracy: 0.7168 - rating_binary/binary_classification_task/auc: 0.7791 - loss: 0.5524 - regularization_loss: 0.0000e+00 - total_loss: 0.5524\n"
+      "782/782 [==============================] - 18s 18ms/step - rating_binary/binary_classification_task/precision: 0.7286 - rating_binary/binary_classification_task/recall: 0.8216 - rating_binary/binary_classification_task/binary_accuracy: 0.7212 - rating_binary/binary_classification_task/auc: 0.7841 - loss: 0.5474 - regularization_loss: 0.0000e+00 - total_loss: 0.5474\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<keras.callbacks.History at 0x7f9394461d30>"
+       "<keras.callbacks.History at 0x7fb7c04772e0>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -202,12 +205,12 @@
    "id": "4bd668ab",
    "metadata": {},
    "source": [
-    "We evaluate the model."
+    "We evaluate the model..."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "13d60260",
    "metadata": {},
    "outputs": [
@@ -215,19 +218,19 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-03-17 16:02:36.403253: W tensorflow/core/grappler/optimizers/loop_optimizer.cc:907] Skipping loop optimization for Merge node with control input: cond/then/_0/cond/cond/branch_executed/_170\n"
+      "2022-04-05 14:47:49.426085: W tensorflow/core/grappler/optimizers/loop_optimizer.cc:907] Skipping loop optimization for Merge node with control input: cond/then/_0/cond/cond/branch_executed/_170\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "196/196 [==============================] - 4s 8ms/step - rating_binary/binary_classification_task/precision: 0.7201 - rating_binary/binary_classification_task/recall: 0.8576 - rating_binary/binary_classification_task/binary_accuracy: 0.7264 - rating_binary/binary_classification_task/auc: 0.7931 - loss: 0.5402 - regularization_loss: 0.0000e+00 - total_loss: 0.5402\n"
+      "196/196 [==============================] - 4s 12ms/step - rating_binary/binary_classification_task/precision: 0.7350 - rating_binary/binary_classification_task/recall: 0.8234 - rating_binary/binary_classification_task/binary_accuracy: 0.7285 - rating_binary/binary_classification_task/auc: 0.7936 - loss: 0.5388 - regularization_loss: 0.0000e+00 - total_loss: 0.5388\n"
      ]
     }
    ],
    "source": [
-    "history = model.evaluate(valid, batch_size=1024)"
+    "metrics = model.evaluate(valid, batch_size=1024, return_dict=True)"
    ]
   },
   {
@@ -235,34 +238,34 @@
    "id": "60b9afe7",
    "metadata": {},
    "source": [
-    "We view the collected metrics. The method produces a list of the metrics and the metrics are stored in the same order that they were generated."
+    "... and check the evaluation metrics. We use by default typical binary classification metrics -- Precision, Recall, Accuracy and AUC. But you can also provide your own metrics list by setting `BinaryClassificationTask(..., metrics=[])`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "4d415278",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[0.7200919985771179,\n",
-       " 0.8575936555862427,\n",
-       " 0.726421058177948,\n",
-       " 0.7930966019630432,\n",
-       " 0.5442478060722351,\n",
-       " 0.0,\n",
-       " 0.5442478060722351]"
+       "{'rating_binary/binary_classification_task/precision': 0.7349662184715271,\n",
+       " 'rating_binary/binary_classification_task/recall': 0.8234366178512573,\n",
+       " 'rating_binary/binary_classification_task/binary_accuracy': 0.7284606695175171,\n",
+       " 'rating_binary/binary_classification_task/auc': 0.7936176657676697,\n",
+       " 'loss': 0.5581252574920654,\n",
+       " 'regularization_loss': 0.0,\n",
+       " 'total_loss': 0.5581252574920654}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "history"
+    "metrics"
    ]
   },
   {
@@ -308,7 +311,7 @@
    "id": "b9ba3102",
    "metadata": {},
    "source": [
-    "In the next example notebooks, we will show how to use your own dataset and how to explore different recommender models."
+    "In the next example notebooks, we will show how the integration with NVTabular and how to explore different recommender models."
    ]
   }
  ],
@@ -328,7 +331,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/examples/02-Merlin-Models-and-NVTabular-applying-to-your-own-dataset.ipynb
+++ b/examples/02-Merlin-Models-and-NVTabular-applying-to-your-own-dataset.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Copyright 2021 NVIDIA Corporation. All Rights Reserved.\n",
+    "# Copyright 2022 NVIDIA Corporation. All Rights Reserved.\n",
     "#\n",
     "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
     "# you may not use this file except in compliance with the License.\n",
@@ -30,40 +30,40 @@
    "source": [
     "<img src=\"http://developer.download.nvidia.com/compute/machine-learning/frameworks/nvidia_logo.png\" style=\"width: 90px; float: right;\">\n",
     "\n",
-    "# Applying to your own dataset with Merlin Models and NVTabular\n",
+    "# From ETL to Training RecSys models - NVTabular and Merlin Models integrated example\n",
     "\n",
     "## Overview\n",
     "\n",
-    "In [01-getting-started.ipynb](01-getting-started.ipynb), we provide a getting started example to train a DLRM model on the MovieLens 1M dataset. In this notebook, we will explore how Merlin Models uses the ETL output from [NVTabular](https://github.com/NVIDIA-Merlin/NVTabular/).<br><br>\n",
+    "In [01-Getting-started.ipynb](01-Getting-started.ipynb), we provide a getting started example to train a DLRM model on the MovieLens 1M dataset. In this notebook, we will explore how Merlin Models uses the ETL output from [NVTabular](https://github.com/NVIDIA-Merlin/NVTabular/).<br><br>\n",
     "\n",
     "### Learning objectives\n",
     "\n",
-    "This notebook provides details how NVTabular and Merlin Models are linked together. We will discuss the concept of the `schema` file.\n",
+    "This notebook provides details on how NVTabular and Merlin Models are linked together. We will discuss the concept of the `schema` file.\n",
     "\n",
     "## Merlin\n",
     "\n",
-    "[Merlin](https://developer.nvidia.com/nvidia-merlin) is an open-source framework for building large-scale (deep learning) recommender systems. It is designed to support recommender systems end-to-end from ETL to training to deployment on CPU or GPU. Common deep learning frameworks are integrated such as TensorFlow or PyTorch. Its key benefits are the easy-to-use APIs, accelerations with GPU and scaling to multi-GPU or multi-node systems.\n",
+    "[Merlin](https://developer.nvidia.com/nvidia-merlin) is an open-source framework for building large-scale (deep learning) recommender systems. It is designed to support recommender systems end-to-end from ETL to training to deployment on CPU or GPU. Common deep learning frameworks are integrated such as TensorFlow (and PyTorch in the future). Among its key benefits are the easy-to-use and flexible APIs, availability of popular recsys architectures, accelerated training and evaluation with GPU and scaling to multi-GPU or multi-node systems.\n",
     "\n",
     "Merlin Models and NVTabular are components of Merlin. They are designed to work closely together. \n",
     "\n",
-    "[Merlin Models](https://github.com/NVIDIA-Merlin/models/) is a library to make it easy for users in industry or academia to train and deploy recommender models with best practices baked into the library. This will let users in industry easily train standard models against their own dataset, getting high performance GPU accelerated models into production. This will also let researchers to build custom models by incorporating standard components of deep learning recommender models, and then benchmark their new models on example offline datasets.\n",
+    "[Merlin Models](https://github.com/NVIDIA-Merlin/models/) is a library to make it easy for users in industry or academia to train and deploy recommender models with best practices baked into the library. Data Scientists and ML Engineers can easily train standard and state-of-the art models on their own dataset, getting high performance GPU accelerated models into production. Researchers can build custom models by incorporating standard components of deep learning recommender models and benchmark their new models on example offline datasets.\n",
     "\n",
-    "[NVTabular](https://github.com/NVIDIA-Merlin/NVTabular/) is a feature engineering and preprocessing library for tabular data that is designed to easily manipulate terabyte scale datasets and train deep learning (DL) based recommender systems. It provides high-level abstraction to simplify code and accelerates computation on the GPU using the RAPIDS Dask-cuDF library.\n",
+    "[NVTabular](https://github.com/NVIDIA-Merlin/NVTabular/) is a feature engineering and preprocessing library for tabular data that is designed to easily manipulate terabyte scale datasets and train deep learning (DL) based recommender systems. It provides high-level abstraction to simplify code and accelerates computation on the GPU using the RAPIDS Dask-cuDF library under the hood.\n",
     "\n",
     "## Integration of NVTabular and Merlin Models\n",
     "\n",
     "<img src=\"images/schema.png\">\n",
     "\n",
-    "We take a look on a subsequence of our pipeline. We are interested in the interactions of feature engineering and model training.\n",
+    "In this notebook, we focus on an important piece of an ML pipeline: feature engineering and model training.\n",
     "\n",
-    "If you use NVTabular for feature engineering, in addition to the data, NVTabular will provide a `schema file` describing the dataset structures. NVTabular will automatically collect statistics and detect some types of `Tags`. For example:\n",
-    "- Categorify: Transform categorical columns into continuous integers 0, ..., |C| for embedding layers. It collects the cardinality of the embedding table and tags it as categorical.\n",
-    "- Normalize: Normalize continuous features. It collects the mean and std of the feature and tags it as continuous.\n",
+    "If you use NVTabular for feature engineering, NVTabular will output (in addition to the preprocessed parquet files), a **schema** file describing the dataset structures. The schema contains columns statistics, tags and metadata collected by NVTabular. Here are some examples of such metadata computed by some NVTabular preprocessing ops:\n",
     "\n",
+    "- **Categorify:** This op transforms categorical columns into contiguous integers (`0, ..., |C|`) for embedding layers. The columns that are processed by this op have save in the schema its cardinality `|C|` and are also tagged as **CATEGORICAL**.\n",
+    "- **Normalize**: This op applies standardization to normalize continuous features. The mean and stddev of the columns are saved to the schema, also being tagged as **CONTINUOUS**.\n",
     "\n",
-    "Some `Tags` have to be provided manually. \n",
+    "The users can also define their own tags in the preprocessing pipeline to group together related features, for further modeling purposes.\n",
     "\n",
-    "Let's take a look on the MovieLens 1M example."
+    "**Let's take a look on the MovieLens 1M example.**"
    ]
   },
   {
@@ -71,17 +71,7 @@
    "execution_count": 3,
    "id": "157fe18f",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2022-03-25 18:08:06.544710: I tensorflow/core/platform/cpu_feature_guard.cc:151] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F FMA\n",
-      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2022-03-25 18:08:07.655653: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 16254 MB memory:  -> device: 0, name: Quadro GV100, pci bus id: 0000:15:00.0, compute capability: 7.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "import pandas as pd\n",
@@ -93,7 +83,7 @@
     "\n",
     "from nvtabular import ops\n",
     "from merlin.core.utils import download_file\n",
-    "from merlin.models.data.movielens import get_movielens\n",
+    "from merlin.datasets.entertainment import get_movielens\n",
     "from merlin.schema.tags import Tags"
    ]
   },
@@ -112,16 +102,43 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /home/gmoreira/projects/nvidia/nvidia_merlin/models/merlin/models/utils/nvt_utils.py:14: is_gpu_available (from tensorflow.python.framework.test_util) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Use `tf.config.list_physical_devices('GPU')` instead.\n"
+     ]
+    },
+    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/lib/python3.8/dist-packages/cudf/core/dataframe.py:1253: UserWarning: The deep parameter is ignored and is only included for pandas compatibility.\n",
+      "WARNING:tensorflow:From /home/gmoreira/projects/nvidia/nvidia_merlin/models/merlin/models/utils/nvt_utils.py:14: is_gpu_available (from tensorflow.python.framework.test_util) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Use `tf.config.list_physical_devices('GPU')` instead.\n",
+      "2022-04-05 14:50:05.704849: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /device:GPU:0 with 16249 MB memory:  -> device: 0, name: Quadro GV100, pci bus id: 0000:15:00.0, compute capability: 7.0\n",
+      "2022-04-05 14:50:05.706716: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /device:GPU:1 with 29778 MB memory:  -> device: 1, name: Quadro GV100, pci bus id: 0000:2d:00.0, compute capability: 7.0\n",
+      "/home/gmoreira/miniconda3/envs/merlin_22.04_dev/lib/python3.8/site-packages/cudf/core/dataframe.py:1253: UserWarning: The deep parameter is ignored and is only included for pandas compatibility.\n",
       "  warnings.warn(\n"
      ]
     }
    ],
    "source": [
     "train, valid = get_movielens(variant=\"ml-1m\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01329e9e",
+   "metadata": {},
+   "source": [
+    "P.s. You can also choose to generate synthetic data to test your models using `generate_data()`. The `input` argument can be either the name of one of the supported public datasets (e.g. \"movielens-1m\", \"criteo\") or the schema of a dataset (which is explained next). For example:\n",
+    "\n",
+    "```python\n",
+    "from merlin.datasets.synthetic import generate_data\n",
+    "train, valid = generate_data(input=\"movielens-1m\", num_rows=1000000, set_sizes=(0.8, 0.2))\n",
+    "```"
    ]
   },
   {
@@ -137,7 +154,7 @@
    "id": "5d9ba7f9",
    "metadata": {},
    "source": [
-    "When NVTabular process the data, it will persist the schema as a file to disk. The dataset contains the schema as a property, as well."
+    "When NVTabular process the data, it will persist the schema as a file to disk. You can access the `schema` from the Merlin `Dataset` class (like below)."
    ]
   },
   {
@@ -145,7 +162,7 @@
    "id": "16ceb1c9",
    "metadata": {},
    "source": [
-    "The `schema` can be interpreted as a list of features in the dataset, where each element describes the feature. It contains the name, some properties (e.g. statistics) and multiple tags. "
+    "The `schema` can be interpreted as a list of features in the dataset, where each element describes metadata of the feature. It contains the name, some properties (e.g. statistics) depending on the feature type and multiple tags. "
    ]
   },
   {
@@ -157,7 +174,7 @@
     {
      "data": {
       "text/plain": [
-       "[{'name': 'movieId', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM: 'item'>, <Tags.ITEM_ID: 'item_id'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'max_size': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.movieId.parquet', 'embedding_sizes': {'cardinality': 3685.0, 'dimension': 159.0}, 'domain': {'min': 0, 'max': 3685}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'userId', 'tags': {<Tags.USER_ID: 'user_id'>, <Tags.CATEGORICAL: 'categorical'>, <Tags.USER: 'user'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'max_size': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.userId.parquet', 'embedding_sizes': {'cardinality': 6041.0, 'dimension': 210.0}, 'domain': {'min': 0, 'max': 6041}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'rating_binary', 'tags': {<Tags.BINARY_CLASSIFICATION: 'binary_classification'>, <Tags.TARGET: 'target'>}, 'properties': {}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}]"
+       "[{'name': 'userId', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.USER_ID: 'user_id'>, <Tags.USER: 'user'>}, 'properties': {'num_buckets': None, 'cat_path': './/categories/unique.userId.parquet', 'start_index': 0.0, 'embedding_sizes': {'dimension': 210.0, 'cardinality': 6041.0}, 'freq_threshold': 0.0, 'max_size': 0.0, 'domain': {'min': 0, 'max': 6041}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'movieId', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM: 'item'>, <Tags.ITEM_ID: 'item_id'>}, 'properties': {'max_size': 0.0, 'num_buckets': None, 'start_index': 0.0, 'embedding_sizes': {'cardinality': 3681.0, 'dimension': 159.0}, 'cat_path': './/categories/unique.movieId.parquet', 'freq_threshold': 0.0, 'domain': {'min': 0, 'max': 3681}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'title', 'tags': {<Tags.CATEGORICAL: 'categorical'>}, 'properties': {'start_index': 0.0, 'cat_path': './/categories/unique.title.parquet', 'max_size': 0.0, 'freq_threshold': 0.0, 'num_buckets': None, 'embedding_sizes': {'dimension': 159.0, 'cardinality': 3681.0}, 'domain': {'min': 0, 'max': 3681}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'genres', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM: 'item'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'start_index': 0.0, 'embedding_sizes': {'dimension': 16.0, 'cardinality': 19.0}, 'cat_path': './/categories/unique.genres.parquet', 'max_size': 0.0, 'domain': {'min': 0, 'max': 19}, 'value_count': {'min': 1, 'max': 6}}, 'dtype': dtype('int32'), 'is_list': True, 'is_ragged': True}, {'name': 'gender', 'tags': {<Tags.CATEGORICAL: 'categorical'>}, 'properties': {'cat_path': './/categories/unique.gender.parquet', 'num_buckets': None, 'freq_threshold': 0.0, 'start_index': 0.0, 'embedding_sizes': {'cardinality': 3.0, 'dimension': 16.0}, 'max_size': 0.0, 'domain': {'min': 0, 'max': 3}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'age', 'tags': {<Tags.CATEGORICAL: 'categorical'>}, 'properties': {'max_size': 0.0, 'start_index': 0.0, 'num_buckets': None, 'cat_path': './/categories/unique.age.parquet', 'freq_threshold': 0.0, 'embedding_sizes': {'dimension': 16.0, 'cardinality': 8.0}, 'domain': {'min': 0, 'max': 8}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'occupation', 'tags': {<Tags.CATEGORICAL: 'categorical'>}, 'properties': {'cat_path': './/categories/unique.occupation.parquet', 'embedding_sizes': {'cardinality': 22.0, 'dimension': 16.0}, 'freq_threshold': 0.0, 'num_buckets': None, 'start_index': 0.0, 'max_size': 0.0, 'domain': {'min': 0, 'max': 22}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'zipcode', 'tags': {<Tags.CATEGORICAL: 'categorical'>}, 'properties': {'embedding_sizes': {'cardinality': 3440.0, 'dimension': 153.0}, 'freq_threshold': 0.0, 'start_index': 0.0, 'num_buckets': None, 'max_size': 0.0, 'cat_path': './/categories/unique.zipcode.parquet', 'domain': {'min': 0, 'max': 3440}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'TE_age_rating', 'tags': {<Tags.USER: 'user'>, <Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}, {'name': 'TE_gender_rating', 'tags': {<Tags.USER: 'user'>, <Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}, {'name': 'TE_occupation_rating', 'tags': {<Tags.USER: 'user'>, <Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}, {'name': 'TE_zipcode_rating', 'tags': {<Tags.USER: 'user'>, <Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}, {'name': 'TE_movieId_rating', 'tags': {<Tags.ITEM: 'item'>, <Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}, {'name': 'TE_userId_rating', 'tags': {<Tags.USER: 'user'>, <Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}, {'name': 'rating_binary', 'tags': {<Tags.BINARY_CLASSIFICATION: 'binary_classification'>, <Tags.TARGET: 'target'>}, 'properties': {}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'rating', 'tags': {<Tags.TARGET: 'target'>, <Tags.REGRESSION: 'regression'>}, 'properties': {}, 'dtype': dtype('float32'), 'is_list': False, 'is_ragged': False}]"
       ]
      },
      "execution_count": 5,
@@ -174,7 +191,7 @@
    "id": "61f74a04",
    "metadata": {},
    "source": [
-    "We can select the features by `Name`."
+    "We can select the features by **name**."
    ]
   },
   {
@@ -186,7 +203,7 @@
     {
      "data": {
       "text/plain": [
-       "[{'name': 'userId', 'tags': {<Tags.USER_ID: 'user_id'>, <Tags.CATEGORICAL: 'categorical'>, <Tags.USER: 'user'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'max_size': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.userId.parquet', 'embedding_sizes': {'cardinality': 6041.0, 'dimension': 210.0}, 'domain': {'min': 0, 'max': 6041}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}]"
+       "[{'name': 'userId', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.USER_ID: 'user_id'>, <Tags.USER: 'user'>}, 'properties': {'num_buckets': None, 'cat_path': './/categories/unique.userId.parquet', 'start_index': 0.0, 'embedding_sizes': {'dimension': 210.0, 'cardinality': 6041.0}, 'freq_threshold': 0.0, 'max_size': 0.0, 'domain': {'min': 0, 'max': 6041}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}]"
       ]
      },
      "execution_count": 6,
@@ -203,7 +220,8 @@
    "id": "7acc733d",
    "metadata": {},
    "source": [
-    "We can see, that NVTabular set the `Tags` `user_id`, `user` and `categorical`. In additionl, it collected the cardinality of the categorical features `6041`. Merlin Models uses the information to define the embedding table size."
+    "We can also select features by **tags**. As we described earlier in the notebook, categorical and continuous features are automatically tagged when using ops like `Categorify()` and `Normalize()`.\n",
+    "In our example preprocessing workflow for this dataset, we also set the `Tags` for the the `user` and `item` features, and also for the `user_id` and `item_id`, which are important for collaborative filtering architectures. "
    ]
   },
   {
@@ -223,7 +241,14 @@
     {
      "data": {
       "text/plain": [
-       "['movieId', 'userId']"
+       "['userId',\n",
+       " 'movieId',\n",
+       " 'title',\n",
+       " 'genres',\n",
+       " 'gender',\n",
+       " 'age',\n",
+       " 'occupation',\n",
+       " 'zipcode']"
       ]
      },
      "execution_count": 7,
@@ -245,7 +270,12 @@
     {
      "data": {
       "text/plain": [
-       "[]"
+       "['TE_age_rating',\n",
+       " 'TE_gender_rating',\n",
+       " 'TE_occupation_rating',\n",
+       " 'TE_zipcode_rating',\n",
+       " 'TE_movieId_rating',\n",
+       " 'TE_userId_rating']"
       ]
      },
      "execution_count": 8,
@@ -267,7 +297,7 @@
     {
      "data": {
       "text/plain": [
-       "['rating_binary']"
+       "['rating_binary', 'rating']"
       ]
      },
      "execution_count": 9,
@@ -289,7 +319,7 @@
     {
      "data": {
       "text/plain": [
-       "['movieId']"
+       "['movieId', 'genres', 'TE_movieId_rating']"
       ]
      },
      "execution_count": 10,
@@ -305,16 +335,43 @@
   {
    "cell_type": "code",
    "execution_count": 11,
+   "id": "66e7559b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['movieId']"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The item id feature name\n",
+    "train.schema.select_by_tag(Tags.ITEM_ID).column_names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
    "id": "2f0e26e9",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['userId']"
+       "['userId',\n",
+       " 'TE_age_rating',\n",
+       " 'TE_gender_rating',\n",
+       " 'TE_occupation_rating',\n",
+       " 'TE_zipcode_rating',\n",
+       " 'TE_userId_rating']"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -325,17 +382,64 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "e098f4c4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['userId']"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The user id feature name\n",
+    "train.schema.select_by_tag(Tags.USER_ID).column_names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e48dc304",
+   "metadata": {},
+   "source": [
+    "We can also query all properties of a feature. Here we see that the cardinality (number of unique values) of the `movieId` feature is `3682`, which is an important information to build the corresponding embedding table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "59f69c03",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'name': 'movieId', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM: 'item'>, <Tags.ITEM_ID: 'item_id'>}, 'properties': {'max_size': 0.0, 'num_buckets': None, 'start_index': 0.0, 'embedding_sizes': {'cardinality': 3681.0, 'dimension': 159.0}, 'cat_path': './/categories/unique.movieId.parquet', 'freq_threshold': 0.0, 'domain': {'min': 0, 'max': 3681}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train.schema.select_by_tag(Tags.ITEM_ID)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "f361318c",
    "metadata": {},
    "source": [
-    "The `schema` is a great way to combine Feature Engineering and Model Training as one end-to-end pipeline. Many popular (deep learning) recommender models define the architecture based on different feature types. \n",
+    "The `schema` is a great interface between feature engineering and modeling libraries, describing the available features and their metadata/statistics. It makes it easy to build generic models definition, as the features names and types are automatically inferred from schema and represented properly in the neural networks architectures. That means that when the dataset changes (e.g. features are added or removed), you don't have to change the modeling code to leverage the new dataset!\n",
     "\n",
-    "DLRM applies embedding layers to each categorical input feature and applies a MLP (called bottom MLP) to the continuous input features.\n",
-    "\n",
-    "Two Tower model applies a MLP (with embedding layers for categorical features) to all item features (called item tower) and another MLP to all user features (called user tower).\n",
-    "\n",
-    "The `schema` file contains all required information to build the architecture. If the dataset changes (e.g. more features are added), then the same code can be used to define the same architecture."
+    "For example, the `DLRMModel` embeds categorical features and applies an MLP (called bottom MLP) to combine the continuous features. As another example, The `TwoTowerModel` (for retrieval) builds one MLP tower to combine user features and another MLP tower for the item features, factorizing both towers in the output."
    ]
   },
   {
@@ -343,11 +447,11 @@
    "id": "1eaa0769",
    "metadata": {},
    "source": [
-    "## Applying NVTabular and Merlin Models to your own dataset.\n",
+    "## Integrated pipeline with NVTabular and Merlin Models\n",
     "\n",
-    "We have a solid understanding of the importance of the schema and how the schema works. Let's take a look on how to apply it to your own dataset.\n",
+    "Now you have a solid understanding of the importance of the schema and how the schema works. \n",
     "\n",
-    "The best way is to use [NVTabular](https://github.com/NVIDIA-Merlin/NVTabular/) for the feature engineering step. We will look on a minimal example for the MovieLens dataset."
+    "The best way is to use [NVTabular](https://github.com/NVIDIA-Merlin/NVTabular/) for the feature engineering step, so that the schema file is automatically created for you. We will look on a minimal example for the MovieLens dataset."
    ]
   },
   {
@@ -363,12 +467,12 @@
    "id": "893b1e0b",
    "metadata": {},
    "source": [
-    "We will download the dataset, if it is not already downloaded or cached locally."
+    "We will download the dataset, if it is not already downloaded and cached locally."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "7588e8fd",
    "metadata": {},
    "outputs": [
@@ -376,8 +480,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "downloading ml-1m.zip: 5.93MB [00:00, 10.6MB/s]                                                                                                                                              \n",
-      "unzipping files: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00, 39.65files/s]\n"
+      "downloading ml-1m.zip: 5.93MB [00:01, 3.25MB/s]                                 \n",
+      "unzipping files: 100%|█████████████████████████| 5/5 [00:00<00:00, 41.71files/s]\n"
      ]
     }
    ],
@@ -403,7 +507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "id": "2a324b56",
    "metadata": {},
    "outputs": [
@@ -411,8 +515,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_24861/340885424.py:1: ParserWarning: Falling back to the 'python' engine because the 'c' engine does not support regex separators (separators > 1 char and different from '\\s+' are interpreted as regex); you can avoid this warning by specifying engine='python'.\n",
-      "  ratings = pd.read_csv(\n"
+      "/home/gmoreira/miniconda3/envs/merlin_22.04_dev/lib/python3.8/site-packages/pandas/util/_decorators.py:311: ParserWarning: Falling back to the 'python' engine because the 'c' engine does not support regex separators (separators > 1 char and different from '\\s+' are interpreted as regex); you can avoid this warning by specifying engine='python'.\n",
+      "  return func(*args, **kwargs)\n"
      ]
     }
    ],
@@ -422,6 +526,7 @@
     "    sep=\"::\",\n",
     "    names=[\"userId\", \"movieId\", \"rating\", \"timestamp\"],\n",
     ")\n",
+    "# Shuffling rows\n",
     "ratings = ratings.sample(len(ratings), replace=False)\n",
     "\n",
     "num_valid = int(len(ratings) * 0.2)\n",
@@ -444,17 +549,17 @@
    "id": "3356461f",
    "metadata": {},
    "source": [
-    "We use NVTabular to define a feature engineering pipeline. \n",
+    "We use NVTabular to define a preprocessing and feature engineering pipeline. \n",
     "\n",
-    "NVTabular has already implemented multiple transformations, called `ops`. An `op` can be applied to a `ColumnGroup` from an overloaded `>>` operator.<br><br>\n",
+    "NVTabular has already implemented multiple transformations, called `ops` that can be applied to a `ColumnGroup` from an overloaded `>>` operator.<br><br>\n",
     "**Example:**<br>\n",
     "```python\n",
     "features = [ column_name, ...] >> op1 >> op2 >> ...\n",
     "```\n",
     "\n",
     "We need to perform following steps:\n",
-    "- Categorify userId and movieId, that the values are continuous integers from 0 ... |C|\n",
-    "- Transform the rating column to a binary target by using `>3` as `1` and otherwise `0`\n",
+    "- Categorify userId and movieId, that the values are contiguous integers from 0 ... |C|\n",
+    "- Transform the rating column ([1,5] interval) to a binary target by using as threshold the value `3`\n",
     "- Add Tags with `ops.AddMetadata` for `item_id`, `user_id`, `item`, `user` and `target`."
    ]
   },
@@ -463,12 +568,12 @@
    "id": "1de8ff5c",
    "metadata": {},
    "source": [
-    "Categorify will transform categorical columns into continuous integers 0, ..., |C| for embedding layers. It collects the cardinality of the embedding table and tags it as categorical."
+    "Categorify will transform categorical columns into contiguous integers (`0, ..., |C|`) for embedding layers. It collects the cardinality of the embedding table and tags it as categorical."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "id": "d7ea1f71",
    "metadata": {},
    "outputs": [],
@@ -481,12 +586,12 @@
    "id": "6e3a2c63",
    "metadata": {},
    "source": [
-    "The tags for `user`, `userId`, `item` and `itemID` cannot be inferred from the dataset. Therefore, we need to provide them manually during the NVTabular workflow. Actually, the DLRM model does not differentiate between `user` and `item` features. But other architectures, such as the `Two Tower Model`, depends on the `user` and `item` feature. We will show how to add them manually in a NVTabular workflow below. "
+    "The tags for `user`, `userId`, `item` and `itemId` cannot be inferred from the dataset. Therefore, we need to provide them manually during the NVTabular workflow. Actually, the `DLRMModel` does not differentiate between `user` and `item` features. But other architectures, such as the `TwoTowerModel` depends on the `user` and `item` features distinction. We will show how to tag features manually in a NVTabular workflow below. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "id": "565595ef",
    "metadata": {},
    "outputs": [],
@@ -507,12 +612,12 @@
    "id": "c13a384b",
    "metadata": {},
    "source": [
-    "We apply the workflow to our dataset."
+    "We fit the workflow to our train set and apply to the valid and test sets."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "id": "e8881f3c",
    "metadata": {},
    "outputs": [
@@ -520,8 +625,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 680 ms, sys: 276 ms, total: 956 ms\n",
-      "Wall time: 993 ms\n"
+      "CPU times: user 646 ms, sys: 122 ms, total: 769 ms\n",
+      "Wall time: 776 ms\n"
      ]
     }
    ],
@@ -529,7 +634,7 @@
     "%%time\n",
     "train_path = os.path.join(input_path, name, \"train.parquet\")\n",
     "valid_path = os.path.join(input_path, name, \"valid.parquet\")\n",
-    "output_path = os.path.join(input_path, name)\n",
+    "output_path = os.path.join(input_path, name+\"_02\")\n",
     "\n",
     "workflow_fit_transform(output, train_path, valid_path, output_path)"
    ]
@@ -547,12 +652,12 @@
    "id": "13a09bb6",
    "metadata": {},
    "source": [
-    "We can load the data as a Merlin Dataset object. The Dataset expect the schema as `.pb` file in the train/valid folder, which NVTabular automatically generates."
+    "We can load the data as a Merlin Dataset object. The Dataset expect the schema as Protobuf text format (`.pbtxt`) file in the train/valid folder, which NVTabular automatically generates."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "id": "e67f0b71",
    "metadata": {},
    "outputs": [],
@@ -567,15 +672,66 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00fabd60",
+   "id": "3ee46b11",
    "metadata": {},
    "source": [
-    "We can train and evaluate our model."
+    "We can see that the `schema` object contains the features tags and the cardinalities of the categorical features.\n",
+    "As we prepared only a minimal example, our schema has only tree features `movieId`, `userId` and `rating_binary`.|"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
+   "id": "f63da5d8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['movieId', 'userId', 'rating_binary']"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train.schema.column_names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "255f122a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'name': 'movieId', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM: 'item'>, <Tags.ITEM_ID: 'item_id'>}, 'properties': {'freq_threshold': 0.0, 'embedding_sizes': {'cardinality': 3679.0, 'dimension': 159.0}, 'num_buckets': None, 'cat_path': './/categories/unique.movieId.parquet', 'max_size': 0.0, 'start_index': 0.0, 'domain': {'min': 0, 'max': 3679}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'userId', 'tags': {<Tags.USER: 'user'>, <Tags.CATEGORICAL: 'categorical'>, <Tags.USER_ID: 'user_id'>}, 'properties': {'embedding_sizes': {'dimension': 210.0, 'cardinality': 6041.0}, 'freq_threshold': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.userId.parquet', 'max_size': 0.0, 'num_buckets': None, 'domain': {'min': 0, 'max': 6041}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'rating_binary', 'tags': {<Tags.BINARY_CLASSIFICATION: 'binary_classification'>, <Tags.TARGET: 'target'>}, 'properties': {}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}]"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train.schema"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00fabd60",
+   "metadata": {},
+   "source": [
+    "Here we train our model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
    "id": "aeda7ece",
    "metadata": {},
    "outputs": [
@@ -583,43 +739,23 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-03-25 18:09:33.123429: W tensorflow/python/util/util.cc:368] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
+      "2022-04-05 14:50:13.763581: W tensorflow/python/util/util.cc:368] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "782/782 [==============================] - 12s 10ms/step - rating_binary/binary_classification_task/precision: 0.7117 - rating_binary/binary_classification_task/recall: 0.8238 - rating_binary/binary_classification_task/binary_accuracy: 0.7068 - rating_binary/binary_classification_task/auc: 0.7685 - loss: 0.5628 - regularization_loss: 0.0000e+00 - total_loss: 0.5628\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2022-03-25 18:09:47.324792: W tensorflow/core/grappler/optimizers/loop_optimizer.cc:907] Skipping loop optimization for Merge node with control input: cond/then/_0/cond/cond/branch_executed/_101\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "196/196 [==============================] - 3s 8ms/step - rating_binary/binary_classification_task/precision: 0.7318 - rating_binary/binary_classification_task/recall: 0.8307 - rating_binary/binary_classification_task/binary_accuracy: 0.7272 - rating_binary/binary_classification_task/auc: 0.7927 - loss: 0.5386 - regularization_loss: 0.0000e+00 - total_loss: 0.5386\n"
+      "782/782 [==============================] - 10s 10ms/step - rating_binary/binary_classification_task/precision: 0.7105 - rating_binary/binary_classification_task/recall: 0.8292 - rating_binary/binary_classification_task/binary_accuracy: 0.7076 - rating_binary/binary_classification_task/auc: 0.7694 - loss: 0.5621 - regularization_loss: 0.0000e+00 - total_loss: 0.5621\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[0.7317950129508972,\n",
-       " 0.8306925892829895,\n",
-       " 0.7272159457206726,\n",
-       " 0.7927199006080627,\n",
-       " 0.5734753608703613,\n",
-       " 0.0,\n",
-       " 0.5734753608703613]"
+       "<keras.callbacks.History at 0x7f9c6450d610>"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -636,45 +772,65 @@
     ")\n",
     "\n",
     "model.compile(optimizer=\"adam\")\n",
-    "model.fit(train, batch_size=1024)\n",
-    "model.evaluate(valid, batch_size=1024)"
+    "model.fit(train, batch_size=1024)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3ee46b11",
+   "id": "1e6295e4",
    "metadata": {},
    "source": [
-    "We can take a look on the schema."
+    "Let's run the evaluation on validations set. We use by default typical binary classification metrics -- Precision, Recall, Accuracy and AUC. But you also can provide your own metrics list by setting `BinaryClassificationTask(..., metrics=[])`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "255f122a",
+   "execution_count": 24,
+   "id": "54261d01",
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  1/196 [..............................] - ETA: 2:26 - rating_binary/binary_classification_task/precision: 0.7254 - rating_binary/binary_classification_task/recall: 0.8220 - rating_binary/binary_classification_task/binary_accuracy: 0.7129 - rating_binary/binary_classification_task/auc: 0.7765 - loss: 0.5487 - regularization_loss: 0.0000e+00 - total_loss: 0.5487"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-04-05 14:50:25.244836: W tensorflow/core/grappler/optimizers/loop_optimizer.cc:907] Skipping loop optimization for Merge node with control input: cond/then/_0/cond/cond/branch_executed/_101\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "196/196 [==============================] - 2s 8ms/step - rating_binary/binary_classification_task/precision: 0.7283 - rating_binary/binary_classification_task/recall: 0.8330 - rating_binary/binary_classification_task/binary_accuracy: 0.7249 - rating_binary/binary_classification_task/auc: 0.7890 - loss: 0.5418 - regularization_loss: 0.0000e+00 - total_loss: 0.5418\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "[{'name': 'movieId', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM: 'item'>, <Tags.ITEM_ID: 'item_id'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'max_size': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.movieId.parquet', 'embedding_sizes': {'cardinality': 3685.0, 'dimension': 159.0}, 'domain': {'min': 0, 'max': 3685}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'userId', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.USER_ID: 'user_id'>, <Tags.USER: 'user'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'max_size': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.userId.parquet', 'embedding_sizes': {'cardinality': 6041.0, 'dimension': 210.0}, 'domain': {'min': 0, 'max': 6041}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'rating_binary', 'tags': {<Tags.BINARY_CLASSIFICATION: 'binary_classification'>, <Tags.TARGET: 'target'>}, 'properties': {}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}]"
+       "{'rating_binary/binary_classification_task/precision': 0.7282863855361938,\n",
+       " 'rating_binary/binary_classification_task/recall': 0.8329658508300781,\n",
+       " 'rating_binary/binary_classification_task/binary_accuracy': 0.7248613834381104,\n",
+       " 'rating_binary/binary_classification_task/auc': 0.7890403270721436,\n",
+       " 'loss': 0.5056475400924683,\n",
+       " 'regularization_loss': 0.0,\n",
+       " 'total_loss': 0.5056475400924683}"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "train.schema"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7275a8cc",
-   "metadata": {},
-   "source": [
-    "As we prepared only a minimal example, our schema has only tree features `movieId`, `userId` and `rating_binary`."
+    "metrics = model.evaluate(valid, batch_size=1024, return_dict=True)\n",
+    "metrics"
    ]
   },
   {
@@ -684,17 +840,13 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Feature engineering and model training are depending on each other. The `schema` object is a convenient way to provide information from the feature engineering step to the model training step. It avoids that the user has to declare the same information multiple times and prevents errors.\n",
+    "This example shows the easiness and flexilibity provided by the integration between NVTabular and Merlin Models.\n",
+    "Feature engineering and model training are depending on each other. The `schema` object is a convient way to provide information from the available features for dynamically setting the model definition. It allows for the modeling code to capture changes in the available features and avoids hardcoding feature names.\n",
     "\n",
-    "The `schema` defined the dataset schema and characteristics and Merlin Models can create the neural network architecture based on the information.\n",
+    "The dataset features are `tagged` automatically (and manually if needed) to group together features, for further modeling usage. \n",
     "\n",
-    "The dataset features will be `tagged` to indicate which type of feature it represents. \n",
+    "The recommended practice is to use `NVTabular` for feature engineering, which generates a `schema` file. NVTabular can automatically add `Tags` for certrain operations. For example, the output of `Categorify` is always a categorical feature and will be tagged. Similar, the output of `Normalize` is always continuous. If you choose to use another preprocessing library, you can create the `schema` file manually, using either the Protobuf text format (`.pbtxt`) or `json` format.\n",
     "\n",
-    "The recommended practice is to use `NVTabular` for feature engineering, which generates a `schema` file. NVTabular can automatically add `Tags` for certain operations. For example, the output of `Categorify` is always a categorical feature and will be tagged. Similar, the output of `Normalize` is always continuous.\n",
-    "\n",
-    "You can take a look on the full example of our util function for MovieLens in our repository.\n",
-    "\n",
-    "Alternatively, you can manually create a schema file. We support JSON format for schema files.\n",
     "\n",
     "## Next Steps\n",
     "\n",
@@ -706,14 +858,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f58cd570",
+   "metadata": {},
    "outputs": [],
-   "source": [],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   "source": []
   }
  ],
  "metadata": {
@@ -732,7 +880,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/examples/02-Merlin-Models-and-NVTabular-integration.ipynb
+++ b/examples/02-Merlin-Models-and-NVTabular-integration.ipynb
@@ -634,7 +634,7 @@
     "%%time\n",
     "train_path = os.path.join(input_path, name, \"train.parquet\")\n",
     "valid_path = os.path.join(input_path, name, \"valid.parquet\")\n",
-    "output_path = os.path.join(input_path, name+\"_02\")\n",
+    "output_path = os.path.join(input_path, name + \"_integration\")\n",
     "\n",
     "workflow_fit_transform(output, train_path, valid_path, output_path)"
    ]

--- a/examples/04-Exporting-ranking-models.ipynb
+++ b/examples/04-Exporting-ranking-models.ipynb
@@ -314,7 +314,7 @@
    "id": "04c124c8",
    "metadata": {},
    "source": [
-    "NVTabular workflow above exports a schema file, schema.pbtxt, of our processed dataset. To learn more about the schema object, schema file  and `tags`, you can explore [02-Merlin-Models-and-NVTabular-applying-to-your-own-dataset](https://github.com/NVIDIA-Merlin/models/blob/main/examples/02-Merlin-Models-and-NVTabular-applying-to-your-own-dataset.ipynb) notebook."
+    "NVTabular workflow above exports a schema file, schema.pbtxt, of our processed dataset. To learn more about the schema object, schema file  and `tags`, you can explore [02-Merlin-Models-and-NVTabular-integration.ipynb](02-Merlin-Models-and-NVTabular-integration.ipynb)."
    ]
   },
   {
@@ -517,7 +517,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -8,7 +8,7 @@ Inventory
 
 * `Getting Started: Develop a Model for MovieLens <01-Getting-started.ipynb>`_: Get started with Merlin Models by training `Facebook's DLRM <https://arxiv.org/pdf/1906.00091.pdf>`_ architecture with only 3 commands.
 
-* `Applying to your own dataset with Merlin Models and NVTabular <02-Merlin-Models-and-NVTabular-applying-to-your-own-dataset.ipynb>`_: Learn how the `Schema` object connects the feature engineering and training steps. You'll learn how to apply Merlin Models to your own dataset structures.
+* `From ETL to Training RecSys models - NVTabular and Merlin Models integrated example <02-Merlin-Models-and-NVTabular-integration.ipynb>`_: Learn how the `Schema` object connects the feature engineering and training steps. You'll learn how to apply Merlin Models to your own dataset structures.
 
 * `Iterating over Deep Learning Models <03-Exploring-different-models.ipynb>`_: Explore different ranking model architectures, such as `Neural Collaborative Filtering (NCF) <https://arxiv.org/pdf/1708.05031.pdf>`_, MLP, `DRLM <https://arxiv.org/abs/1906.00091>`_, and `Deep & Cross Network (DCN) <https://arxiv.org/pdf/1708.05123.pdf>`_.
 
@@ -17,7 +17,7 @@ Inventory
    :hidden:
 
    01-Getting-started.ipynb
-   02-Merlin-Models-and-NVTabular-applying-to-your-own-dataset.ipynb
+   02-Merlin-Models-and-NVTabular-integration.ipynb
    03-Exploring-different-models.ipynb
 
 Running the Example Notebooks


### PR DESCRIPTION
- Adjustments in example notebooks 1 and 2 from the bug bash, like text editing and small improvements (e.g. returning metrics dict instead of list)
- Improving the text in general
- Adding instructions on how to use synthetic data (so that the user is aware)
- Renaming the example 2 notebook from "Applying to your own dataset with Merlin Models and NVTabular" to "From ETL to Training RecSys models - NVTabular and Merlin Models integrated example"