### PR TITLE
Pairwise losses fixes

### DIFF
--- a/merlin/models/tf/blocks/core/base.py
+++ b/merlin/models/tf/blocks/core/base.py
@@ -52,8 +52,8 @@ class PredictionOutput(NamedTuple):
 
     def copy_with_updates(
         self,
-        predictions: Union[TabularData, tf.Tensor] = None,
-        targets: Union[TabularData, tf.Tensor] = None,
+        predictions: Optional[Union[TabularData, tf.Tensor]] = None,
+        targets: Optional[Union[TabularData, tf.Tensor]] = None,
         positive_item_ids: Optional[tf.Tensor] = None,
         label_relevant_counts: Optional[tf.Tensor] = None,
         valid_negatives_mask: Optional[tf.Tensor] = None,

--- a/merlin/models/tf/blocks/core/base.py
+++ b/merlin/models/tf/blocks/core/base.py
@@ -48,6 +48,35 @@ class PredictionOutput(NamedTuple):
     targets: Union[TabularData, tf.Tensor]
     positive_item_ids: Optional[tf.Tensor] = None
     label_relevant_counts: Optional[tf.Tensor] = None
+    valid_negatives_mask: Optional[tf.Tensor] = None
+
+    def copy_with_updates(
+        self,
+        predictions: Union[TabularData, tf.Tensor] = None,
+        targets: Union[TabularData, tf.Tensor] = None,
+        positive_item_ids: Optional[tf.Tensor] = None,
+        label_relevant_counts: Optional[tf.Tensor] = None,
+        valid_negatives_mask: Optional[tf.Tensor] = None,
+    ):
+        """Creates a new instance of PredictionOutput
+        allowing to override the attributes for the copy
+        """
+        output = PredictionOutput(
+            predictions=(self.predictions if predictions is None else predictions),
+            targets=(self.targets if targets is None else targets),
+            positive_item_ids=(
+                self.positive_item_ids if positive_item_ids is None else positive_item_ids
+            ),
+            label_relevant_counts=(
+                self.label_relevant_counts
+                if label_relevant_counts is None
+                else label_relevant_counts
+            ),
+            valid_negatives_mask=(
+                self.valid_negatives_mask if valid_negatives_mask is None else valid_negatives_mask
+            ),
+        )
+        return output
 
 
 @tf.keras.utils.register_keras_serializable(package="merlin.models")

--- a/merlin/models/tf/blocks/core/index.py
+++ b/merlin/models/tf/blocks/core/index.py
@@ -252,7 +252,7 @@ class TopKIndexBlock(IndexBlock):
         top_scores, top_ids = self(queries, k=self._k)
 
         # remove accidental hits
-        top_scores = tf_utils.rescore_false_negatives(
+        top_scores, _ = tf_utils.rescore_false_negatives(
             outputs.positive_item_ids, top_ids, top_scores, self.false_negatives_score
         )
 
@@ -273,8 +273,10 @@ class TopKIndexBlock(IndexBlock):
         predictions_sorted, targets_sorted, _ = tf_utils.extract_topk(self._k, predictions, targets)
         label_relevant_counts = tf.ones([tf.shape(predictions)[0]])
 
-        return PredictionOutput(
-            predictions_sorted, targets_sorted, label_relevant_counts=label_relevant_counts
+        return outputs.copy_with_updates(
+            predictions=predictions_sorted,
+            targets=targets_sorted,
+            label_relevant_counts=label_relevant_counts,
         )
 
     def compute_output_shape(self, input_shape):

--- a/merlin/models/tf/blocks/core/masking.py
+++ b/merlin/models/tf/blocks/core/masking.py
@@ -383,4 +383,6 @@ class MaskingHead(Block):
         targets = self.context[self.item_id_feature_name]
         mask = self.context.get_mask()
         targets = tf.where(mask, targets, self.padding_idx)
-        return PredictionOutput(outputs.predictions, targets)
+        return outputs.copy_with_updates(
+            targets=targets,
+        )

--- a/merlin/models/tf/blocks/core/transformations.py
+++ b/merlin/models/tf/blocks/core/transformations.py
@@ -389,7 +389,10 @@ class RemovePad3D(Block):
             predictions = tf.boolean_mask(
                 predictions, tf.broadcast_to(tf.expand_dims(non_pad_mask, 1), tf.shape(predictions))
             )
-        return PredictionOutput(predictions, targets)
+        return outputs.copy_with_updates(
+            predictions=predictions,
+            targets=targets,
+        )
 
 
 @Block.registry.register_with_multiple_names("sampling-bias-correction")
@@ -440,7 +443,8 @@ class LogitsTemperatureScaler(Block):
         if training:
             assert isinstance(predictions, tf.Tensor), "Predictions must be a tensor"
             predictions = predictions / self.temperature
-        return PredictionOutput(predictions, targets, outputs.positive_item_ids)
+
+        return outputs.copy_with_updates(predictions=predictions, targets=targets)
 
     def compute_output_shape(self, input_shape):
         return input_shape
@@ -551,4 +555,4 @@ class LabelToOneHot(Block):
         num_classes = tf.shape(predictions)[-1]
         targets = transform_label_to_onehot(targets, num_classes)
 
-        return PredictionOutput(predictions, targets, outputs.positive_item_ids)
+        return outputs.copy_with_updates(targets=targets)

--- a/merlin/models/tf/losses/__init__.py
+++ b/merlin/models/tf/losses/__init__.py
@@ -17,7 +17,6 @@
 from merlin.models.tf.losses.base import LossType, loss_registry
 from merlin.models.tf.losses.listwise import CategoricalCrossEntropy, SparseCategoricalCrossEntropy
 from merlin.models.tf.losses.pairwise import (
-    AdaptiveHingeLoss,
     BPRLoss,
     BPRmaxLoss,
     HingeLoss,
@@ -30,7 +29,6 @@ from merlin.models.tf.losses.pairwise import (
 __all__ = [
     "CategoricalCrossEntropy",
     "SparseCategoricalCrossEntropy",
-    "AdaptiveHingeLoss",
     "BPRLoss",
     "BPRmaxLoss",
     "HingeLoss",

--- a/merlin/models/tf/losses/pairwise.py
+++ b/merlin/models/tf/losses/pairwise.py
@@ -391,32 +391,3 @@ class HingeLoss(PairwiseLoss):
         """
         loss = tf.nn.relu(1 + negatives_scores - positives_scores)
         return loss
-
-
-@LossRegistryMixin.registry.register("adaptive_hinge")
-@tf.keras.utils.register_keras_serializable(package="merlin.models")
-class AdaptiveHingeLoss(PairwiseLoss):
-    """Adaptive hinge pairwise loss. Samples the highest
-    negative scores, as they are closer to violating the
-    expected ranking  where positives should be ranked higher.
-
-    Approximates the idea of Weighted Approximate-Rank Pairwise (WARP) loss [1],
-    inspired by
-    `Spotlight https://maciejkula.github.io/spotlight/losses.html#spotlight.losses.
-    adaptive_hinge_loss`_ implementation.
-
-    References
-    ----------
-    .. [1] Weston, Jason, Samy Bengio, and Nicolas Usunier. "Wsabie:
-       Scaling up to large vocabulary image annotation." IJCAI.
-       Vol. 11. 2011
-    """
-
-    @docstring_parameter(pairwise_losses_compute_docstring=PAIRWISE_LOSSES_COMPUTE_DOCSTRING)
-    def compute(self, positives_scores: tf.Tensor, negatives_scores: tf.Tensor) -> tf.Tensor:
-        """
-        {pairwise_losses_compute_docstring}
-        """
-        max_neg_scores = tf.reduce_max(negatives_scores, axis=-1, keepdims=True)
-        loss = tf.nn.relu(1 + max_neg_scores - positives_scores)
-        return loss

--- a/merlin/models/tf/losses/pairwise.py
+++ b/merlin/models/tf/losses/pairwise.py
@@ -205,7 +205,7 @@ class PairwiseLoss(Loss, LossRegistryMixin):
             Loss with zeroed values for false negatives
         """
         # Setting to zero the loss of false negatives and of rows with no positive sample
-        loss = loss * tf.cast(valid_rows_with_positive_mask, dtype=loss.dtype)
+        loss = loss * tf.cast(tf.expand_dims(valid_rows_with_positive_mask, -1), dtype=loss.dtype)
         if self.valid_negatives_mask is not None:
             loss = loss * tf.cast(self.valid_negatives_mask, dtype=loss.dtype)
         return loss

--- a/merlin/models/tf/prediction_tasks/classification.py
+++ b/merlin/models/tf/prediction_tasks/classification.py
@@ -69,11 +69,6 @@ class BinaryClassificationTask(PredictionTask):
         )
         self.loss = loss_registry.parse(loss)
 
-    def _compute_loss(
-        self, predictions, targets, sample_weight=None, training: bool = False, **kwargs
-    ) -> tf.Tensor:
-        return self.loss(targets, predictions, sample_weight=sample_weight)
-
     def call(self, inputs, training=False, **kwargs):
         return self.output_activation(self.output_layer(inputs))
 
@@ -192,13 +187,6 @@ class MultiClassClassificationTask(PredictionTask):
             loss=loss,
             **kwargs,
         )
-
-    def _compute_loss(
-        self, predictions, targets, sample_weight=None, training: bool = False, **kwargs
-    ) -> tf.Tensor:
-        if getattr(self.loss, "sample_weight", None):
-            return self.loss(targets, predictions, sample_weight=sample_weight)
-        return self.loss(targets, predictions)
 
     def call(self, inputs, training=False, **kwargs):
         return inputs

--- a/merlin/models/tf/prediction_tasks/regression.py
+++ b/merlin/models/tf/prediction_tasks/regression.py
@@ -56,11 +56,6 @@ class RegressionTask(PredictionTask):
         )
         self.loss = loss_registry.parse(loss)
 
-    def _compute_loss(
-        self, predictions, targets, sample_weight=None, training: bool = False, **kwargs
-    ) -> tf.Tensor:
-        return self.loss(targets, predictions, sample_weight=sample_weight)
-
     def call(self, inputs, training=False, **kwargs):
         return self.output_activation(self.logit(inputs))
 

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -128,7 +128,9 @@ def rescore_false_negatives(
         negative_scores,
     )
 
-    return tf.squeeze(negative_scores)
+    valid_negatives_mask = tf.logical_not(false_negatives_mask)
+
+    return tf.squeeze(negative_scores), valid_negatives_mask
 
 
 def extract_topk(k, predictions, labels):
@@ -226,3 +228,23 @@ def df_to_tensor(gdf, dtype=None):
         # for the bug above, so untranspose
         x = tf.transpose(x)
     return x
+
+
+def add_epsilon_to_zeros(tensor: tf.Tensor, epsilon: float = 1e-24) -> tf.Tensor:
+    """Replaces zeros by adding a small epsilon value to them.
+    This is useful to avoid inf and nan errors on math ops
+    like log().
+
+    Parameters
+    ----------
+    tensor : tf.Tensor
+        Tensor to operate on
+    epsilon : float, optional
+        Small value to add to zeros, by default 1e-24
+
+    Returns
+    -------
+    tf.Tensor
+        The tensor without zeros
+    """
+    return tf.where(tf.equal(tensor, 0.0), tensor + epsilon, tensor)

--- a/merlin/models/utils/constants.py
+++ b/merlin/models/utils/constants.py
@@ -17,3 +17,4 @@
 import numpy as np
 
 MIN_FLOAT = np.finfo(np.float16).min / 100.0
+MAX_FLOAT = np.finfo(np.float16).max / 100.0

--- a/tests/tf/losses/test_losses.py
+++ b/tests/tf/losses/test_losses.py
@@ -114,4 +114,4 @@ def test_bpr_multiple_positive():
 
     with pytest.raises(Exception) as excinfo:
         _ = bpr(targets, predictions)
-    assert "Only one positive label is allowed per example" in str(excinfo.value)
+    assert "The batch contains more examples with more than one positive item" in str(excinfo.value)

--- a/tests/tf/losses/test_losses.py
+++ b/tests/tf/losses/test_losses.py
@@ -38,8 +38,6 @@ import merlin.models.tf as ml
         ml.losses.LogisticLoss(),
         "hinge",
         ml.losses.HingeLoss(),
-        "adaptive_hinge",
-        ml.losses.AdaptiveHingeLoss(),
         # Listwise losses
         "sparse_categorical_crossentropy",
         "categorical_crossentropy",

--- a/tests/tf/models/test_retrieval.py
+++ b/tests/tf/models/test_retrieval.py
@@ -32,7 +32,8 @@ def test_two_tower_model(music_streaming_data: Dataset, run_eagerly, num_epochs=
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
-def test_two_tower_retrieval_model_with_metrics(ecommerce_data: Dataset, run_eagerly):
+@pytest.mark.parametrize("loss", ["categorical_crossentropy", "bpr", "binary_crossentropy"])
+def test_two_tower_retrieval_model_with_metrics(ecommerce_data: Dataset, run_eagerly, loss):
     ecommerce_data._schema = ecommerce_data.schema.remove_by_tag(Tags.TARGET)
 
     metrics = [RecallAt(5), MRRAt(5), NDCGAt(5), AvgPrecisionAt(5), PrecisionAt(5)]
@@ -41,7 +42,7 @@ def test_two_tower_retrieval_model_with_metrics(ecommerce_data: Dataset, run_eag
         query_tower=mm.MLPBlock([128, 64]),
         samplers=[mm.InBatchSampler()],
         metrics=metrics,
-        loss="categorical_crossentropy",
+        loss=loss,
     )
     # Setting up evaluation
     model.set_retrieval_candidates_for_evaluation(ecommerce_data)

--- a/tests/tf/models/test_retrieval.py
+++ b/tests/tf/models/test_retrieval.py
@@ -9,7 +9,7 @@ from merlin.schema import Tags
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_matrix_factorization_model(music_streaming_data: Dataset, run_eagerly, num_epochs=2):
-    music_streaming_data._schema = music_streaming_data.schema.remove_by_tag(Tags.TARGET)
+    music_streaming_data.schema = music_streaming_data.schema.remove_by_tag(Tags.TARGET)
 
     model = mm.MatrixFactorizationModel(music_streaming_data.schema, dim=64)
     model.compile(optimizer="adam", run_eagerly=run_eagerly)
@@ -21,7 +21,7 @@ def test_matrix_factorization_model(music_streaming_data: Dataset, run_eagerly, 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_two_tower_model(music_streaming_data: Dataset, run_eagerly, num_epochs=2):
-    music_streaming_data._schema = music_streaming_data.schema.remove_by_tag(Tags.TARGET)
+    music_streaming_data.schema = music_streaming_data.schema.remove_by_tag(Tags.TARGET)
 
     model = mm.TwoTowerModel(music_streaming_data.schema, query_tower=mm.MLPBlock([512, 256]))
     model.compile(optimizer="adam", run_eagerly=run_eagerly)
@@ -34,7 +34,7 @@ def test_two_tower_model(music_streaming_data: Dataset, run_eagerly, num_epochs=
 @pytest.mark.parametrize("run_eagerly", [True, False])
 @pytest.mark.parametrize("loss", ["categorical_crossentropy", "bpr", "binary_crossentropy"])
 def test_two_tower_retrieval_model_with_metrics(ecommerce_data: Dataset, run_eagerly, loss):
-    ecommerce_data._schema = ecommerce_data.schema.remove_by_tag(Tags.TARGET)
+    ecommerce_data.schema = ecommerce_data.schema.remove_by_tag(Tags.TARGET)
 
     metrics = [RecallAt(5), MRRAt(5), NDCGAt(5), AvgPrecisionAt(5), PrecisionAt(5)]
     model = mm.TwoTowerModel(


### PR DESCRIPTION
Closes #316 , closes #252

This PR fixes issues related to pairwise loss:

- [x] Refactory of the pairwise losses to centralize common logic into the parent `PairwiseLoss` class and to make them receive the `valid_negatives_mask` for ignoring the loss of false negatives
- [x] Now `PredictionOutput` named tuple has a method `copy_with_updates()` that creates a copy of the tuple but allowing to update only the necessary attributes. That prevents potential issues where some blocks only change for example the `predictions` or `targets` and forget to include the original `sample_weight` or `valid_negatives_mask` in the new tuple instance
- [x] Fixed error on pairwise losses error when calling `model.evaluate()`
- [x] Solves `NaN` loss when training using pairwise losses with larger batch sizes. The Nan issue was caused by computing log(0) for some predictions of false negatives. Now we add a small epsilon to 0 values before `tf.math.log()`