### PR TITLE
quick fix in aliccp schema

### DIFF
--- a/merlin/models/data/ecommerce/aliccp/raw/schema.pbtxt
+++ b/merlin/models/data/ecommerce/aliccp/raw/schema.pbtxt
@@ -39,7 +39,7 @@ feature {
   type: INT
   annotation {
     tag: "target"
-    tag: "Tags.BINARY_CLASSIFICATION"
+    tag: "binary_classification"
     extra_metadata {
       type_url: "type.googleapis.com/google.protobuf.Struct"
       value: "\n\034\n\017dtype_item_size\022\t\021\000\000\000\000\000\000P@\n\017\n\tis_ragged\022\002 \000\n\r\n\007is_list\022\002 \000"

--- a/merlin/models/data/ecommerce/aliccp/transformed/schema.pbtxt
+++ b/merlin/models/data/ecommerce/aliccp/transformed/schema.pbtxt
@@ -277,7 +277,7 @@ feature {
   type: INT
   annotation {
     tag: "target"
-    tag: "Tags.BINARY_CLASSIFICATION"
+    tag: "binary_classification"
     extra_metadata {
       type_url: "type.googleapis.com/google.protobuf.Struct"
       value: "\n\017\n\tis_ragged\022\002 \000\n\034\n\017dtype_item_size\022\t\021\000\000\000\000\000\000P@\n\r\n\007is_list\022\002 \000"
@@ -289,7 +289,7 @@ feature {
   type: INT
   annotation {
     tag: "target"
-    tag: "Tags.BINARY_CLASSIFICATION"
+    tag: "binary_classification"
     extra_metadata {
       type_url: "type.googleapis.com/google.protobuf.Struct"
       value: "\n\017\n\tis_ragged\022\002 \000\n\r\n\007is_list\022\002 \000\n\034\n\017dtype_item_size\022\t\021\000\000\000\000\000\000P@"

--- a/tests/data/test_ecommerce.py
+++ b/tests/data/test_ecommerce.py
@@ -16,6 +16,7 @@ def test_synthetic_aliccp_data():
     assert isinstance(dataset, merlin.io.Dataset)
     assert dataset.num_rows == 100
     assert len(dataset.schema) == 20
+    assert dataset.compute()["click"].sum() > 0
 
 
 def test_synthetic_aliccp_raw_data():


### PR DESCRIPTION
Fixes the string representation of the binary tag in the AliCCP dataset. 