### PR TITLE
Fixes and improvements in embeddings export for MatrixFactorizationModel and TwoTowerModel

### DIFF
--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -150,6 +150,7 @@ __all__ = [
     "ParallelPredictionBlock",
     "TwoTowerBlock",
     "MatrixFactorizationBlock",
+    "QueryItemIdsEmbeddingsBlock",
     "AsDenseFeatures",
     "AsSparseFeatures",
     "CategoricalOneHot",

--- a/merlin/models/tf/blocks/retrieval/matrix_factorization.py
+++ b/merlin/models/tf/blocks/retrieval/matrix_factorization.py
@@ -82,18 +82,22 @@ class QueryItemIdsEmbeddingsBlock(DualEncoderBlock):
             **kwargs,
         )
 
-    def export_embedding_table(self, table_name: Union[str, Tags], export_path: str, gpu=True):
+    def export_embedding_table(
+        self, table_name: Union[str, Tags], export_path: str, l2_normalization=False, gpu=True
+    ):
         return self.embeddings[str(table_name)].export_embedding_table(
-            table_name, export_path, l2_norm=True, gpu=gpu
+            table_name, export_path, l2_normalization=l2_normalization, gpu=gpu
         )
 
-    def embedding_table_df(self, table_name: Union[str, Tags], l2_norm=True, gpu=True):
+    def embedding_table_df(self, table_name: Union[str, Tags], l2_normalization=False, gpu=True):
         return self.embeddings[str(table_name)].embedding_table_df(
-            table_name, l2_norm=l2_norm, gpu=gpu
+            table_name, l2_normalization=l2_normalization, gpu=gpu
         )
 
-    def get_embedding_table(self, table_name: Union[str, Tags], l2_norm=True):
-        return self.embeddings[str(table_name)].get_embedding_table(table_name, l2_norm=l2_norm)
+    def get_embedding_table(self, table_name: Union[str, Tags], l2_normalization=False):
+        return self.embeddings[str(table_name)].get_embedding_table(
+            table_name, l2_normalization=l2_normalization
+        )
 
 
 def MatrixFactorizationBlock(

--- a/merlin/models/tf/blocks/retrieval/matrix_factorization.py
+++ b/merlin/models/tf/blocks/retrieval/matrix_factorization.py
@@ -87,10 +87,13 @@ class QueryItemIdsEmbeddingsBlock(DualEncoderBlock):
             table_name, export_path, l2_norm=True, gpu=gpu
         )
 
-    def embedding_table_df(self, table_name: Union[str, Tags], gpu=True):
+    def embedding_table_df(self, table_name: Union[str, Tags], l2_norm=True, gpu=True):
         return self.embeddings[str(table_name)].embedding_table_df(
-            table_name, l2_norm=True, gpu=gpu
+            table_name, l2_norm=l2_norm, gpu=gpu
         )
+
+    def embedding_vector(self, table_name: Union[str, Tags], l2_norm=True):
+        return self.embeddings[str(table_name)].embedding_vector(table_name, l2_norm=l2_norm)
 
 
 def MatrixFactorizationBlock(

--- a/merlin/models/tf/blocks/retrieval/matrix_factorization.py
+++ b/merlin/models/tf/blocks/retrieval/matrix_factorization.py
@@ -92,8 +92,8 @@ class QueryItemIdsEmbeddingsBlock(DualEncoderBlock):
             table_name, l2_norm=l2_norm, gpu=gpu
         )
 
-    def embedding_vector(self, table_name: Union[str, Tags], l2_norm=True):
-        return self.embeddings[str(table_name)].embedding_vector(table_name, l2_norm=l2_norm)
+    def get_embedding_table(self, table_name: Union[str, Tags], l2_norm=True):
+        return self.embeddings[str(table_name)].get_embedding_table(table_name, l2_norm=l2_norm)
 
 
 def MatrixFactorizationBlock(

--- a/merlin/models/tf/features/embedding.py
+++ b/merlin/models/tf/features/embedding.py
@@ -249,7 +249,7 @@ class EmbeddingFeatures(TabularBlock):
     def table_config(self, feature_name: str):
         return self.feature_config[feature_name].table
 
-    def get_embedding_table(self, table_name: Union[str, Tags], l2_norm: bool = False):
+    def get_embedding_table(self, table_name: Union[str, Tags], l2_normalization: bool = False):
         if isinstance(table_name, Tags):
             feature_names = self.schema.select_by_tag(table_name).column_names
             if len(feature_names) == 1:
@@ -262,15 +262,15 @@ class EmbeddingFeatures(TabularBlock):
                 raise ValueError(f"Could not find a feature associated to the tag {table_name}")
 
         embeddings = self.embedding_tables[table_name]
-        if l2_norm:
+        if l2_normalization:
             embeddings = tf.linalg.l2_normalize(embeddings, axis=-1)
 
         return embeddings
 
     def embedding_table_df(
-        self, table_name: Union[str, Tags], l2_norm: bool = False, gpu: bool = True
+        self, table_name: Union[str, Tags], l2_normalization: bool = False, gpu: bool = True
     ):
-        embeddings = self.get_embedding_table(table_name, l2_norm)
+        embeddings = self.get_embedding_table(table_name, l2_normalization)
         if gpu:
             import cudf
 
@@ -287,7 +287,7 @@ class EmbeddingFeatures(TabularBlock):
         return df
 
     def embedding_table_dataset(
-        self, table_name: Union[str, Tags], l2_norm: bool = False, gpu=True
+        self, table_name: Union[str, Tags], l2_normalization: bool = False, gpu=True
     ) -> merlin.io.Dataset:
         """Creates a Dataset for the embedding table
 
@@ -295,7 +295,7 @@ class EmbeddingFeatures(TabularBlock):
         ----------
         table_name : Union[str, Tags]
             Tag or name of the embedding table
-        l2_norm : bool, optional
+        l2_normalization : bool, optional
             Whether the L2-normalization should be applied to
             embeddings (common approach for Matrix Factorization
             and Retrieval models in general), by default False
@@ -307,10 +307,14 @@ class EmbeddingFeatures(TabularBlock):
         merlin.io.Dataset
             Returns a Dataset with the embeddings
         """
-        return merlin.io.Dataset(self.embedding_table_df(table_name, l2_norm, gpu))
+        return merlin.io.Dataset(self.embedding_table_df(table_name, l2_normalization, gpu))
 
     def export_embedding_table(
-        self, table_name: Union[str, Tags], export_path: str, l2_norm: bool = False, gpu=True
+        self,
+        table_name: Union[str, Tags],
+        export_path: str,
+        l2_normalization: bool = False,
+        gpu=True,
     ):
         """Exports the embedding table to parquet file
 
@@ -320,14 +324,14 @@ class EmbeddingFeatures(TabularBlock):
             Tag or name of the embedding table
         export_path : str
             Path for the generated parquet file
-        l2_norm : bool, optional
+        l2_normalization : bool, optional
             Whether the L2-normalization should be applied to
             embeddings (common approach for Matrix Factorization
             and Retrieval models in general), by default False
         gpu : bool, optional
             Whether or not should use GPU, by default True
         """
-        df = self.embedding_table_df(table_name, l2_norm, gpu=gpu)
+        df = self.embedding_table_df(table_name, l2_normalization, gpu=gpu)
         df.to_parquet(export_path)
 
     def get_config(self):

--- a/merlin/models/tf/features/embedding.py
+++ b/merlin/models/tf/features/embedding.py
@@ -249,7 +249,7 @@ class EmbeddingFeatures(TabularBlock):
     def table_config(self, feature_name: str):
         return self.feature_config[feature_name].table
 
-    def embedding_vector(self, table_name: Union[str, Tags], l2_norm: bool = False):
+    def get_embedding_table(self, table_name: Union[str, Tags], l2_norm: bool = False):
         if isinstance(table_name, Tags):
             feature_names = self.schema.select_by_tag(table_name).column_names
             if len(feature_names) == 1:
@@ -270,7 +270,7 @@ class EmbeddingFeatures(TabularBlock):
     def embedding_table_df(
         self, table_name: Union[str, Tags], l2_norm: bool = False, gpu: bool = True
     ):
-        embeddings = self.embedding_vector(table_name, l2_norm)
+        embeddings = self.get_embedding_table(table_name, l2_norm)
         if gpu:
             import cudf
 

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -605,24 +605,28 @@ class RetrievalModel(Model):
     def query_embeddings(
         self,
         dataset: merlin.io.Dataset,
-        query_tag=Tags.USER,
-        query_id_tag=Tags.USER_ID,
-        batch_size=None,
+        batch_size: int,
+        query_tag: Union[str, Tags] = Tags.USER,
+        query_id_tag: Union[str, Tags] = Tags.USER_ID,
     ) -> merlin.io.Dataset:
         """Export query embeddings from the model.
+
         Parameters
         ----------
-        dataset: merlin.io.Dataset
+        dataset : merlin.io.Dataset
             Dataset to export embeddings from.
-        query_tag: str
-            Tag to use for the query.
-        query_id_tag: str
-            Tag to use for the query id.
-        batch_size: int
+        batch_size : int
             Batch size to use for embedding extraction.
+        query_tag: Union[str, Tags], optional
+            Tag to use for the query.
+        query_id_tag: Union[str, Tags], optional
+            Tag to use for the query id.
+
         Returns
         -------
         merlin.io.Dataset
+            Dataset with the user/query features and the embeddings
+            (one dim per column in the data frame)
         """
         from merlin.models.tf.utils.batch_utils import QueryEmbeddings
 
@@ -636,24 +640,28 @@ class RetrievalModel(Model):
     def item_embeddings(
         self,
         dataset: merlin.io.Dataset,
-        item_tag=Tags.ITEM,
-        item_id_tag=Tags.ITEM_ID,
-        batch_size=None,
+        batch_size: int,
+        item_tag: Union[str, Tags] = Tags.ITEM,
+        item_id_tag: Union[str, Tags] = Tags.ITEM_ID,
     ) -> merlin.io.Dataset:
         """Export item embeddings from the model.
+
         Parameters
         ----------
-        dataset: merlin.io.Dataset
+        dataset : merlin.io.Dataset
             Dataset to export embeddings from.
-        item_tag: str
-            Tag to use for the item.
-        item_id_tag: str
-            Tag to use for the item id.
-        batch_size: int
+        batch_size : int
             Batch size to use for embedding extraction.
+        item_tag : Union[str, Tags], optional
+            Tag to use for the item.
+        item_id_tag : Union[str, Tags], optional
+            Tag to use for the item id, by default Tags.ITEM_ID
+
         Returns
         -------
         merlin.io.Dataset
+            Dataset with the item features and the embeddings
+            (one dim per column in the data frame)
         """
         from merlin.models.tf.utils.batch_utils import ItemEmbeddings
 

--- a/merlin/models/tf/models/retrieval.py
+++ b/merlin/models/tf/models/retrieval.py
@@ -209,7 +209,7 @@ def YoutubeDNNRetrievalModel(
     num_sampled: int = 100,
     loss: Optional[LossType] = "categorical_crossentropy",
     metrics=ranking_metrics(top_ks=[10]),
-    normalize: bool = True,
+    l2_normalization: bool = True,
     extra_pre_call: Optional[Block] = None,
     task_block: Optional[Block] = None,
     logits_temperature: float = 1.0,
@@ -247,8 +247,8 @@ def YoutubeDNNRetrievalModel(
     metrics: List[Metric]
         List of metrics to use.
         Defaults to `ranking_metrics(top_ks=[10])`
-    normalize: bool
-        Whether to normalize the embeddings.
+    l2_normalization: bool
+        Whether to apply L2 normalization before computing dot interactions.
         Defaults to True.
     extra_pre_call: Optional[Block]
         The optional `Block` to apply before the model.
@@ -281,7 +281,7 @@ def YoutubeDNNRetrievalModel(
         extra_pre_call=extra_pre_call,
         task_block=task_block,
         logits_temperature=logits_temperature,
-        l2_normalization=normalize,
+        l2_normalization=l2_normalization,
         num_sampled=num_sampled,
     )
 

--- a/tests/tf/blocks/retrieval/test_matrix_factorization.py
+++ b/tests/tf/blocks/retrieval/test_matrix_factorization.py
@@ -45,10 +45,10 @@ def test_matrix_factorization_embedding_export(music_streaming_data: Dataset, tm
 
     model.fit(music_streaming_data, epochs=5, batch_size=100)
 
-    user_embeddings = mf.embedding_vector(Tags.USER_ID)
+    user_embeddings = mf.get_embedding_table(Tags.USER_ID)
     tf.debugging.assert_shapes([(user_embeddings, (10001, 128))])
 
-    item_embeddings = mf.embedding_vector(Tags.ITEM_ID)
+    item_embeddings = mf.get_embedding_table(Tags.ITEM_ID)
     tf.debugging.assert_shapes([(item_embeddings, (10001, 128))])
 
     # Checking if embeddings are unit norm (after L2-normalization)

--- a/tests/tf/utils/test_batch.py
+++ b/tests/tf/utils/test_batch.py
@@ -31,12 +31,12 @@ def test_two_tower_embedding_extraction(ecommerce_data: Dataset):
     model.compile(run_eagerly=True, optimizer="adam")
     model.fit(ecommerce_data, batch_size=50, epochs=1)
 
-    item_embs = model.item_embeddings(ecommerce_data, batch_size=10)
+    item_embs = model.item_embeddings(ecommerce_data, 10)
     item_embs_ddf = item_embs.compute(scheduler="synchronous")
 
     assert len(list(item_embs_ddf.columns)) == 5 + 128
 
-    user_embs = model.query_embeddings(ecommerce_data, batch_size=10)
+    user_embs = model.query_embeddings(ecommerce_data, 10)
     user_embs_ddf = user_embs.compute(scheduler="synchronous")
 
     assert len(list(user_embs_ddf.columns)) == 13 + 128


### PR DESCRIPTION
- [x] Created a method to export the embedding vectors as a Tensor, in particular for MatrixFactorization.
- [x] Ensuring that when using RetrievalModel.query_embeddings() and .item_embeddings() the batch size is provided, as it is required to build the BatchedDataset under-the-hood