### PR TITLE
Creating a reg_factor for PopularityLogitsCorrection

### DIFF
--- a/tests/tf/blocks/core/test_transformations.py
+++ b/tests/tf/blocks/core/test_transformations.py
@@ -214,9 +214,9 @@ def test_popularity_logits_correct():
         negative_item_ids=negative_item_ids,
     )
 
-    corrected_logits = PopularityLogitsCorrection(item_frequency, schema=schema).call_outputs(
-        outputs=inputs
-    )
+    corrected_logits = PopularityLogitsCorrection(
+        item_frequency, reg_factor=0.5, schema=schema
+    ).call_outputs(outputs=inputs)
 
     tf.debugging.assert_less_equal(logits, corrected_logits.predictions)
 


### PR DESCRIPTION
- Now `PopularityLogitsCorrection` accepts a `reg_factor` in the constructor to scale the loq correction
- Removes the outdated `SamplingBiasCorrection` implementation