### PR TITLE
Fix top-k recommender to return correct top-k relevant items. 

### DIFF
--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -717,8 +717,11 @@ class RetrievalModel(Model):
             )
         else:
             topk_index = item_corpus
-        recommender = ModelBlock(self.retrieval_block.query_block().connect(topk_index))
-
+        # Set the blocks for recommenders with built=True to keep pre-trained embeddings
+        recommender_block = self.retrieval_block.query_block().connect(topk_index)
+        recommender_block.built = True
+        recommender = ModelBlock(recommender_block)
+        recommender.built = True
         return recommender
 
 

--- a/tests/tf/blocks/core/test_index.py
+++ b/tests/tf/blocks/core/test_index.py
@@ -16,7 +16,7 @@
 
 import pytest
 
-import merlin.models.tf as ml
+import merlin.models.tf as mm
 from merlin.io.dataset import Dataset
 from merlin.schema import Tags
 
@@ -26,8 +26,8 @@ def test_topk_index(ecommerce_data: Dataset):
 
     from merlin.models.tf.metrics.evaluation import ItemCoverageAt, PopularityBiasAt
 
-    model: ml.RetrievalModel = ml.TwoTowerModel(
-        ecommerce_data.schema, query_tower=ml.MLPBlock([64, 128])
+    model: mm.RetrievalModel = mm.TwoTowerModel(
+        ecommerce_data.schema, query_tower=mm.MLPBlock([64, 128])
     )
     model.compile(run_eagerly=False, optimizer="adam")
     model.fit(ecommerce_data, epochs=1, batch_size=50)
@@ -44,7 +44,7 @@ def test_topk_index(ecommerce_data: Dataset):
         PopularityBiasAt(item_freq_probs=item_frequency, is_prob_distribution=False, k=10),
         ItemCoverageAt(num_unique_items=NUM_ITEMS, k=10),
     ]
-    batch = ml.sample_batch(ecommerce_data, batch_size=10, include_targets=False)
+    batch = mm.sample_batch(ecommerce_data, batch_size=10, include_targets=False)
     _, top_indices = recommender(batch)
     assert top_indices.shape[-1] == 20
     _, top_indices = recommender(batch, k=10)
@@ -59,8 +59,8 @@ def test_topk_index(ecommerce_data: Dataset):
 
 
 def test_topk_index_duplicate_indices(ecommerce_data: Dataset):
-    model: ml.RetrievalModel = ml.TwoTowerModel(
-        ecommerce_data.schema, query_tower=ml.MLPBlock([64, 128])
+    model: mm.RetrievalModel = mm.TwoTowerModel(
+        ecommerce_data.schema, query_tower=mm.MLPBlock([64, 128])
     )
     model.compile(run_eagerly=True, optimizer="adam")
     model.fit(ecommerce_data, epochs=1, batch_size=50)
@@ -71,3 +71,75 @@ def test_topk_index_duplicate_indices(ecommerce_data: Dataset):
     with pytest.raises(ValueError) as excinfo:
         _ = model.to_top_k_recommender(item_dataset, k=20)
     assert "Please make sure that `data` contains unique indices" in str(excinfo.value)
+
+
+def test_topk_recommender_outputs(ecommerce_data: Dataset):
+    import numpy as np
+    import tensorflow as tf
+
+    import merlin.models.tf.dataset as tf_dataloader
+    from merlin.models.tf.blocks.core.index import IndexBlock
+    from merlin.models.utils.dataset import unique_rows_by_features
+
+    def numpy_recall(labels, top_item_ids, k):
+        return np.equal(np.expand_dims(labels, -1), top_item_ids[:, :k]).max(axis=-1).mean()
+
+    model = mm.TwoTowerModel(
+        ecommerce_data.schema,
+        query_tower=mm.MLPBlock(
+            [64],
+        ),
+        samplers=[mm.InBatchSampler()],
+        metrics=[
+            mm.RecallAt(50),
+        ],
+        loss="categorical_crossentropy",
+    )
+    batch_size = 100
+    model.compile("adam", run_eagerly=False)
+
+    model.fit(
+        ecommerce_data,
+        batch_size=batch_size,
+        epochs=3,
+    )
+    eval_metrics = model.evaluate(
+        ecommerce_data, item_corpus=ecommerce_data, batch_size=batch_size, return_dict=True
+    )
+
+    # Manually compute top-k ids for a given batch
+    batch = mm.sample_batch(ecommerce_data, batch_size=batch_size, include_targets=False)
+    item_dataset = unique_rows_by_features(ecommerce_data, Tags.ITEM, Tags.ITEM_ID)
+    candidates_dataset_df = IndexBlock.get_candidates_dataset(
+        block=model.retrieval_block.item_block(), data=item_dataset, id_column="item_id"
+    )
+    item_tower_ids, item_tower_embeddings = IndexBlock.extract_ids_embeddings(
+        candidates_dataset_df, check_unique_ids=True
+    )
+    batch_query_tower_embeddings = model.retrieval_block.query_block()(batch)
+    batch_user_scores_all_items = tf.matmul(
+        batch_query_tower_embeddings, item_tower_embeddings, transpose_b=True
+    )
+    top_scores, top_indices = tf.math.top_k(batch_user_scores_all_items, k=50)
+    top_ids = tf.gather(item_tower_ids, top_indices)
+
+    # Get top-k ids from the topk_recommender_model
+    topk_recommender_model = model.to_top_k_recommender(ecommerce_data, k=50)
+    topk_predictions, topk_items = topk_recommender_model(batch)
+
+    # Assert top-k items from top-k recommender are the same as the manually computed top-k items
+    tf.debugging.assert_equal(top_ids, topk_items)
+
+    # Compute recall using top-k recommender
+    data_dl = tf_dataloader.BatchedDataset(
+        ecommerce_data,
+        batch_size=batch_size,
+        shuffle=False,
+    )
+    topk_output = topk_recommender_model.predict(data_dl)
+    topk_predictions, topk_items = topk_output
+    test_df = ecommerce_data.to_ddf()
+    positive_item_ids = np.array(test_df["item_id"].compute().values.tolist())
+    recall_at_50 = numpy_recall(positive_item_ids, topk_items, k=50)
+
+    np.isclose(recall_at_50, eval_metrics["recall_at_50"], rtol=1e-6)

--- a/tests/tf/blocks/core/test_index.py
+++ b/tests/tf/blocks/core/test_index.py
@@ -91,7 +91,7 @@ def test_topk_recommender_outputs(ecommerce_data: Dataset):
         ),
         samplers=[mm.InBatchSampler()],
         metrics=[
-            mm.RecallAt(50),
+            mm.RecallAt(10),
         ],
         loss="categorical_crossentropy",
     )
@@ -140,6 +140,6 @@ def test_topk_recommender_outputs(ecommerce_data: Dataset):
     topk_predictions, topk_items = topk_output
     test_df = ecommerce_data.to_ddf()
     positive_item_ids = np.array(test_df["item_id"].compute().values.tolist())
-    recall_at_50 = numpy_recall(positive_item_ids, topk_items, k=10)
+    recall_at_10 = numpy_recall(positive_item_ids, topk_items, k=10)
 
-    np.isclose(recall_at_50, eval_metrics["recall_at_50"], rtol=1e-6)
+    np.isclose(recall_at_10, eval_metrics["recall_at_10"], rtol=1e-6)

--- a/tests/tf/blocks/core/test_index.py
+++ b/tests/tf/blocks/core/test_index.py
@@ -120,11 +120,11 @@ def test_topk_recommender_outputs(ecommerce_data: Dataset):
     batch_user_scores_all_items = tf.matmul(
         batch_query_tower_embeddings, item_tower_embeddings, transpose_b=True
     )
-    top_scores, top_indices = tf.math.top_k(batch_user_scores_all_items, k=50)
+    top_scores, top_indices = tf.math.top_k(batch_user_scores_all_items, k=10)
     top_ids = tf.gather(item_tower_ids, top_indices)
 
     # Get top-k ids from the topk_recommender_model
-    topk_recommender_model = model.to_top_k_recommender(ecommerce_data, k=50)
+    topk_recommender_model = model.to_top_k_recommender(ecommerce_data, k=10)
     topk_predictions, topk_items = topk_recommender_model(batch)
 
     # Assert top-k items from top-k recommender are the same as the manually computed top-k items
@@ -140,6 +140,6 @@ def test_topk_recommender_outputs(ecommerce_data: Dataset):
     topk_predictions, topk_items = topk_output
     test_df = ecommerce_data.to_ddf()
     positive_item_ids = np.array(test_df["item_id"].compute().values.tolist())
-    recall_at_50 = numpy_recall(positive_item_ids, topk_items, k=50)
+    recall_at_50 = numpy_recall(positive_item_ids, topk_items, k=10)
 
     np.isclose(recall_at_50, eval_metrics["recall_at_50"], rtol=1e-6)


### PR DESCRIPTION
Fixes #387 #287

### Goals :soccer:
Using Gabriel's script, I tried to debug the issue causing the top-k recommender to return random top-k indices.

These are the main findings:  

- The item_embeddings returned by the item block are identical between the manual run ( Step 4 ) and the index values of the topk_recommender_model (Step 3)

- I ran topk_recommender_model twice on the same input (to check if there is any randomness): the outputs are identical

- The top-ids returned by manual iteration do not match the top ids returned by the topk_recommender_model. 

- Digging into the top-k recommender call, I noticed that the query embeddings from the manual calculation do not match the query embeddings returned by the topk_recommender_model.

- After comparing the query-block before and after calling `to_top_k_recommender()`, I noticed that the embeddings weights of the user tower change. 

- This change is due to calling the build method of the query tower after the model was converted. The build method is re-initializing the embeddings features [here](https://github.com/NVIDIA-Merlin/models/blob/d9853020d9e32854b3ad7d37ec79a8b33fa2c438/merlin/models/tf/blocks/core/base.py#L169)


### Implementation Details :construction:
- I set the `built` flag to True after converting the model to a `topk-recommender` to avoid calling the build method when calling the model. 

### Testing Details :mag:
- I added Gabriel's script for debugging as an integration test and added a check that ensures the output of the top-k recommender matches with the manually calculated top-ids. 

These are the scores results from the different tested ideas: 
<img width="587" alt="image" src="https://user-images.githubusercontent.com/17721108/164547578-4a3062f8-83cd-4fc5-989d-ee916bec82c3.png">
