### PR TITLE
Update `testbook` tests to use absolute notebook paths

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,12 +17,12 @@
 
 from __future__ import absolute_import
 
-import pytest
 from pathlib import Path
+
+import pytest
 
 from merlin.datasets.synthetic import generate_data
 from merlin.io import Dataset
-
 
 REPO_ROOT = Path(__file__).parent.parent
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,9 +18,13 @@
 from __future__ import absolute_import
 
 import pytest
+from pathlib import Path
 
 from merlin.datasets.synthetic import generate_data
 from merlin.io import Dataset
+
+
+REPO_ROOT = Path(__file__).parent.parent
 
 
 @pytest.fixture

--- a/tests/tf/examples/__init__.py
+++ b/tests/tf/examples/__init__.py
@@ -1,1 +1,0 @@
-import pytest

--- a/tests/tf/examples/__init__.py
+++ b/tests/tf/examples/__init__.py
@@ -1,3 +1,1 @@
 import pytest
-
-pytestmark = pytest.mark.example

--- a/tests/tf/examples/test_01_getting_started.py
+++ b/tests/tf/examples/test_01_getting_started.py
@@ -1,10 +1,9 @@
-import pytest
 from testbook import testbook
 
-pytestmark = pytest.mark.example
+from tests.conftest import REPO_ROOT
 
 
-@testbook("examples/01-Getting-started.ipynb", execute=False)
+@testbook(REPO_ROOT / "examples/01-Getting-started.ipynb", execute=False)
 def test_func(tb):
     tb.inject(
         """

--- a/tests/tf/examples/test_02_dataschema.py
+++ b/tests/tf/examples/test_02_dataschema.py
@@ -1,10 +1,9 @@
-import pytest
 from testbook import testbook
 
-pytestmark = pytest.mark.example
+from tests.conftest import REPO_ROOT
 
 
-@testbook("examples/02-Merlin-Models-and-NVTabular-integration.ipynb", execute=False)
+@testbook(REPO_ROOT / "examples/02-Merlin-Models-and-NVTabular-integration.ipynb", execute=False)
 def test_func(tb):
     tb.inject(
         """

--- a/tests/tf/examples/test_04_export_ranking_models.py
+++ b/tests/tf/examples/test_04_export_ranking_models.py
@@ -1,12 +1,11 @@
 import os
 
-import pytest
 from testbook import testbook
 
-pytestmark = pytest.mark.example
+from tests.conftest import REPO_ROOT
 
 
-@testbook("examples/04-Exporting-ranking-models.ipynb", execute=False)
+@testbook(REPO_ROOT / "examples/04-Exporting-ranking-models.ipynb", execute=False)
 def test_func(tb):
     tb.inject(
         """

--- a/tests/tf/examples/test_05_export_retrieval_model.py
+++ b/tests/tf/examples/test_05_export_retrieval_model.py
@@ -1,12 +1,11 @@
 import os
 
-import pytest
 from testbook import testbook
 
-pytestmark = pytest.mark.example
+from tests.conftest import REPO_ROOT
 
 
-@testbook("examples/05-Retrieval-Model.ipynb", execute=False)
+@testbook(REPO_ROOT / "examples/05-Retrieval-Model.ipynb", execute=False)
 def test_func(tb):
     tb.inject(
         """

--- a/tests/tf/examples/test_06_advanced_own_architecture.py
+++ b/tests/tf/examples/test_06_advanced_own_architecture.py
@@ -5,7 +5,9 @@ from testbook import testbook
 from tests.conftest import REPO_ROOT
 
 
-@testbook(REPO_ROOT / "examples/06-Define-your-own-architecture-with-Merlin-Models.ipynb", execute=False)
+@testbook(
+    REPO_ROOT / "examples/06-Define-your-own-architecture-with-Merlin-Models.ipynb", execute=False
+)
 def test_func(tb):
     tb.inject(
         """

--- a/tests/tf/examples/test_06_advanced_own_architecture.py
+++ b/tests/tf/examples/test_06_advanced_own_architecture.py
@@ -1,12 +1,11 @@
 import os
 
-import pytest
 from testbook import testbook
 
-pytestmark = pytest.mark.example
+from tests.conftest import REPO_ROOT
 
 
-@testbook("examples/06-Define-your-own-architecture-with-Merlin-Models.ipynb", execute=False)
+@testbook(REPO_ROOT / "examples/06-Define-your-own-architecture-with-Merlin-Models.ipynb", execute=False)
 def test_func(tb):
     tb.inject(
         """


### PR DESCRIPTION
### Goals :soccer:
This makes it easier to run the tests as part of a container validation suite when building the Merlin TF/Torch containers.

### Implementation Details :construction:
Adds a `ROOT_DIR` constant to `conftest.py` that the tests can use to find the absolute path to the root of the models repo.

### Testing Details :mag:
This modifies the Testbook example tests.
