### PR TITLE
Making evaluation of retrieval models work differently during fit(validation_data) and evaluate(item_corpus)

### DIFF
--- a/merlin/models/tf/blocks/core/combinators.py
+++ b/merlin/models/tf/blocks/core/combinators.py
@@ -209,19 +209,19 @@ class SequentialBlock(Block):
 
         outputs = inputs
         for i, layer in enumerate(self.layers):
-            if i == len(self.layers) - 1:
-                filtered_kwargs = filter_kwargs(kwargs, layer, filter_positional_or_keyword=False)
-                filtered_kwargs.update(
-                    filter_kwargs(
-                        {**dict(training=training), **kwargs},
-                        layer.call,
-                        filter_positional_or_keyword=False,
-                    )
+            filtered_kwargs = filter_kwargs(
+                {**dict(training=training), **kwargs},
+                layer,
+                cascade_kwargs_if_possible=True,
+            )
+            filtered_kwargs.update(
+                filter_kwargs(
+                    {**dict(training=training), **kwargs},
+                    layer.call,
+                    cascade_kwargs_if_possible=True,
                 )
-            else:
-                filtered_kwargs = filter_kwargs(
-                    dict(training=training), layer, filter_positional_or_keyword=False
-                )
+            )
+
             outputs = layer(outputs, **filtered_kwargs)
 
         return outputs

--- a/merlin/models/tf/blocks/mlp.py
+++ b/merlin/models/tf/blocks/mlp.py
@@ -25,6 +25,7 @@ from merlin.models.tf.utils.tf_utils import (
     maybe_deserialize_keras_objects,
     maybe_serialize_keras_objects,
 )
+from merlin.models.utils.misc_utils import filter_kwargs
 from merlin.schema import Schema, Tags
 
 InitializerType = Union[str, tf.keras.initializers.Initializer]
@@ -213,7 +214,8 @@ class _Dense(tf.keras.layers.Layer):
         if isinstance(inputs, dict):
             inputs = tabular_aggregation_registry.parse(self.pre_aggregation)(inputs)
 
-        return self.dense(inputs, **kwargs)
+        filtered_kwargs = filter_kwargs(kwargs, self.dense)
+        return self.dense(inputs, **filtered_kwargs)
 
     def compute_output_shape(self, input_shape):
         if isinstance(input_shape, dict):

--- a/merlin/models/tf/prediction_tasks/base.py
+++ b/merlin/models/tf/prediction_tasks/base.py
@@ -677,9 +677,7 @@ class ParallelPredictionBlock(ParallelBlock, LossMixin, MetricsMixin):
         if isinstance(inputs, dict) and not all(
             name in inputs for name in list(self.parallel_dict.keys())
         ):
-            filtered_kwargs = filter_kwargs(
-                dict(training=training), self, filter_positional_or_keyword=False
-            )
+            filtered_kwargs = filter_kwargs(dict(training=training), self)
             predictions = self(inputs, **filtered_kwargs)
         else:
             predictions = inputs

--- a/merlin/models/utils/misc_utils.py
+++ b/merlin/models/utils/misc_utils.py
@@ -25,20 +25,17 @@ from typing import Any, Dict
 logger = logging.getLogger(__name__)
 
 
-def filter_kwargs(kwargs, thing_with_kwargs, filter_positional_or_keyword=True):
-    sig = inspect.signature(thing_with_kwargs)
-    if filter_positional_or_keyword:
-        filter_keys = [
-            param.name
-            for param in sig.parameters.values()
-            if param.kind == param.POSITIONAL_OR_KEYWORD
-        ]
+def filter_kwargs(kwargs, thing_with_kwargs, cascade_kwargs_if_possible=False):
+    # sig = inspect.signature(thing_with_kwargs)
+    arg_spec = inspect.getfullargspec(thing_with_kwargs)
+    if cascade_kwargs_if_possible and arg_spec.varkw is not None:
+        return kwargs
     else:
-        filter_keys = [param.name for param in sig.parameters.values()]
-    filtered_dict = {
-        filter_key: kwargs[filter_key] for filter_key in filter_keys if filter_key in kwargs
-    }
-    return filtered_dict
+        filter_keys = arg_spec.args
+        filtered_dict = {
+            filter_key: kwargs[filter_key] for filter_key in filter_keys if filter_key in kwargs
+        }
+        return filtered_dict
 
 
 def safe_json(data):


### PR DESCRIPTION
This is a draft PR trying to fix #373 . The issue root cause is that  `model.evaluate()` is called by `model.fit()` when `validation_data` argument is passed, but can be also be called by the user explicitly. 
For `RetrievalModel`, the evaluation is done differently during `model.fit()` and `model.evaluate()` calls. During fit, we use the `ItemRetrievalScorer` to sample negative items for evaluation as we do for training (so that we can compare train and validation metrics, but during evaluation we set a `pre_eval_topk` with a `TopKIndexBlock` which scores the top-k items and return them and the candidate samples. 
The issue happens in graph mode, when calling `model.fit(validation_data=...)` and then `model.evaluate(item_corpus=...)`. The reason is that model.evaluate() is going to be called first by `model.fit()` when `pre_eval_topk` is not set yet. Then, when `model.evaluate(item_corpus=...)` is explicitly called by the user, it is going to use the sampled negatives instead of `TopKIndexBlock`. That is why in issue #373 the accuracy matrix vary according to the eval batch size (because when using in-batch negative sampling, the larger the batch sizes, the more negative samples are provided)