### PR TITLE
Remove `.python-version` file

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,0 @@
-merlin-models


### PR DESCRIPTION
This is a piece of cruft left over from my original models work way back when, before Merlin Models was really a thing yet. It shouldn't have been committed to the repo in the first place. Oops!