### PR TITLE
Create a basic conda recipe

### DIFF
--- a/conda/recipes/meta.yaml
+++ b/conda/recipes/meta.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.
+
+# Usage:
+#   conda build . -c defaults -c conda-forge -c numba -c rapidsai
+
+{% set version = environ.get('GIT_DESCRIBE_TAG', '0.1').lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
+{% set minor_version = version.split('.')[0] + '.' + version.split('.')[1] %}
+{% set git_revision_count=environ.get('GIT_DESCRIBE_NUMBER', 0) %}
+{% set py_version=environ.get('CONDA_PY', 36) %}
+{% set setup_py_data = load_setup_py_data() %}
+
+package:
+  name: merlin-models
+  version: {{ version }}
+
+source:
+  path: ../../
+
+build:
+  number: {{ git_revision_count }}
+  script: python -m pip install . -vvv
+
+
+requirements:
+  run:
+  {% for req in setup_py_data.get('install_requires', []) %}
+    - {{ req }}
+  {% endfor %}
+    - python
+    - tensorflow
+
+about:
+  home: https://github.com/NVIDIA-Merlin/models
+  license_file: LICENSE
+  summary: Merlin Models is a collection of deep learning recommender system model reference implementations


### PR DESCRIPTION
Adds a conda recipe so that we can publish this, like we do with
nvtabular and merlin-core

Closes #419

