### PR TITLE
Create `FeatureContext` and pass it to model layers with `call_layer`

### DIFF
--- a/merlin/models/tf/blocks/core/combinators.py
+++ b/merlin/models/tf/blocks/core/combinators.py
@@ -14,7 +14,6 @@ from merlin.models.tf.blocks.core.base import (
     is_input_block,
     right_shift_layer,
 )
-from merlin.models.tf.blocks.core.context import FeatureContext
 from merlin.models.tf.blocks.core.tabular import Filter, TabularAggregationType, TabularBlock
 from merlin.models.tf.blocks.core.transformations import AsDenseFeatures
 from merlin.models.tf.utils import tf_utils
@@ -297,12 +296,10 @@ class SequentialBlock(Block):
         return outputs, targets
 
     def call_outputs(
-        self, outputs: PredictionOutput, feature_context: FeatureContext, training=False, **kwargs
+        self, outputs: PredictionOutput, training=False, **kwargs
     ) -> "PredictionOutput":
         for layer in self.layers:
-            outputs = layer.call_outputs(
-                outputs, feature_context=feature_context, training=training, **kwargs
-            )
+            outputs = layer.call_outputs(outputs, training=training, **kwargs)
         return outputs
 
     def get_config(self):

--- a/merlin/models/tf/blocks/core/context.py
+++ b/merlin/models/tf/blocks/core/context.py
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from merlin.models.config.schema import FeatureCollection
+
+
+class FeatureContext:
+    def __init__(self, features: FeatureCollection):
+        self.features = features

--- a/merlin/models/tf/blocks/core/masking.py
+++ b/merlin/models/tf/blocks/core/masking.py
@@ -382,9 +382,13 @@ class MaskingHead(Block):
         self.item_id_feature_name = item_id_feature_name
 
     def call_outputs(
-        self, outputs: PredictionOutput, context: FeatureContext, training: bool = True, **kwargs
+        self,
+        outputs: PredictionOutput,
+        feature_context: FeatureContext,
+        training: bool = True,
+        **kwargs
     ) -> "PredictionOutput":
-        targets = context.features.values[self.item_id_feature_name]
+        targets = feature_context.features.values[self.item_id_feature_name]
         mask = self.context.get_mask()
         targets = tf.where(mask, targets, self.padding_idx)
         return outputs.copy_with_updates(

--- a/merlin/models/tf/blocks/core/masking.py
+++ b/merlin/models/tf/blocks/core/masking.py
@@ -21,6 +21,7 @@ from tensorflow.keras import backend
 from tensorflow.python.ops import array_ops
 
 from merlin.models.tf.blocks.core.base import Block, PredictionOutput
+from merlin.models.tf.blocks.core.context import FeatureContext
 from merlin.models.utils.doc_utils import docstring_parameter
 from merlin.models.utils.registry import Registry
 from merlin.schema import Tags
@@ -123,8 +124,8 @@ class MaskingBlock(Block):
         )
         return inputs
 
-    def call(self, inputs, training=True, **kwargs) -> tf.Tensor:
-        items = self.context[self.schema.select_by_tag(Tags.ITEM_ID)]
+    def call(self, inputs, feature_context=None, training=True, **kwargs) -> tf.Tensor:
+        items = list(feature_context.features.select_by_tag(Tags.ITEM_ID).values.values())[0]
         mask = self.compute_feature_mask(items, training=training)
         inputs = self.apply_mask_to_inputs(inputs, mask)
         return inputs
@@ -138,6 +139,9 @@ class MaskingBlock(Block):
             }
         )
         return config
+
+    def compute_output_shape(self, input_shape):
+        return input_shape
 
 
 @masking_registry.register_with_multiple_names("clm", "causal")
@@ -378,9 +382,9 @@ class MaskingHead(Block):
         self.item_id_feature_name = item_id_feature_name
 
     def call_outputs(
-        self, outputs: PredictionOutput, training: bool = True, **kwargs
+        self, outputs: PredictionOutput, context: FeatureContext, training: bool = True, **kwargs
     ) -> "PredictionOutput":
-        targets = self.context[self.item_id_feature_name]
+        targets = context.features.values[self.item_id_feature_name]
         mask = self.context.get_mask()
         targets = tf.where(mask, targets, self.padding_idx)
         return outputs.copy_with_updates(

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -10,6 +10,7 @@ from merlin.models.config.schema import FeatureCollection
 from merlin.models.tf.blocks.core.base import Block, ModelContext
 from merlin.models.tf.blocks.core.combinators import SequentialBlock
 from merlin.models.tf.blocks.core.context import FeatureContext
+from merlin.models.tf.blocks.core.transformations import AsDenseFeatures
 from merlin.models.tf.metrics.ranking import RankingMetric
 from merlin.models.tf.prediction_tasks.base import ParallelPredictionBlock, PredictionTask
 from merlin.models.tf.typing import TabularData
@@ -186,6 +187,8 @@ class Model(tf.keras.Model, LossMixin, MetricsMixin):
         ]
         self.schema = sum(input_block_schemas, Schema())
 
+        self.as_dense = AsDenseFeatures()
+
         # Initializing model control flags controlled by MetricsComputeCallback()
         self._should_compute_train_metrics_for_batch = tf.Variable(
             dtype=tf.bool,
@@ -196,7 +199,7 @@ class Model(tf.keras.Model, LossMixin, MetricsMixin):
         )
 
     def call(self, inputs, **kwargs):
-        features = FeatureCollection(self.schema, inputs)
+        features = FeatureCollection(self.schema, self.as_dense(inputs))
         context = FeatureContext(features)
         outputs = call_layer(self.block, inputs, context=context, **kwargs)
         return outputs

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -6,12 +6,15 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Union, runtime
 import tensorflow as tf
 
 import merlin.io
+from merlin.models.config.schema import FeatureCollection
 from merlin.models.tf.blocks.core.base import Block, ModelContext
 from merlin.models.tf.blocks.core.combinators import SequentialBlock
+from merlin.models.tf.blocks.core.context import FeatureContext
 from merlin.models.tf.metrics.ranking import RankingMetric
 from merlin.models.tf.prediction_tasks.base import ParallelPredictionBlock, PredictionTask
 from merlin.models.tf.typing import TabularData
 from merlin.models.tf.utils.mixins import LossMixin, MetricsMixin, ModelLikeBlock
+from merlin.models.tf.utils.tf_utils import call_layer
 from merlin.models.utils.dataset import unique_rows_by_features
 from merlin.schema import Schema, Tags
 
@@ -178,6 +181,11 @@ class Model(tf.keras.Model, LossMixin, MetricsMixin):
         self.context = context
         self._is_fitting = False
 
+        input_block_schemas = [
+            block.schema for block in self.block.submodules if getattr(block, "is_input", False)
+        ]
+        self.schema = sum(input_block_schemas, Schema())
+
         # Initializing model control flags controlled by MetricsComputeCallback()
         self._should_compute_train_metrics_for_batch = tf.Variable(
             dtype=tf.bool,
@@ -188,12 +196,10 @@ class Model(tf.keras.Model, LossMixin, MetricsMixin):
         )
 
     def call(self, inputs, **kwargs):
-        outputs = self.block(inputs, **kwargs)
+        features = FeatureCollection(self.schema, inputs)
+        context = FeatureContext(features)
+        outputs = call_layer(self.block, inputs, context=context, **kwargs)
         return outputs
-
-    # @property
-    # def inputs(self):
-    #     return self.block.inputs
 
     @property
     def first(self):
@@ -206,10 +212,6 @@ class Model(tf.keras.Model, LossMixin, MetricsMixin):
     @property
     def loss_block(self) -> ModelLikeBlock:
         return self.block.last if isinstance(self.block, SequentialBlock) else self.block
-
-    @property
-    def schema(self) -> Schema:
-        return self.block.schema
 
     @classmethod
     def from_block(

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -287,9 +287,13 @@ class Model(tf.keras.Model, LossMixin, MetricsMixin):
                 targets = None
 
             predictions = self(inputs, training=True)
+            features = FeatureCollection(self.schema, self.as_dense(inputs))
+            feature_context = FeatureContext(features)
+
             loss = self.compute_loss(
                 predictions,
                 targets,
+                feature_context=feature_context,
                 training=True,
                 compute_metrics=self._should_compute_train_metrics_for_batch,
             )
@@ -345,7 +349,12 @@ class Model(tf.keras.Model, LossMixin, MetricsMixin):
         else:
             targets = None
 
-        loss = self.compute_loss_metrics(inputs, targets, training=False, compute_metrics=True)
+        features = FeatureCollection(self.schema, self.as_dense(inputs))
+        feature_context = FeatureContext(features)
+
+        loss = self.compute_loss_metrics(
+            inputs, targets, feature_context=feature_context, training=False, compute_metrics=True
+        )
 
         # Casting regularization loss to fp16 if needed to match the main loss
         regularization_loss = tf.cast(tf.reduce_sum(self.losses), loss.dtype)

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -199,9 +199,11 @@ class Model(tf.keras.Model, LossMixin, MetricsMixin):
         )
 
     def call(self, inputs, **kwargs):
-        features = FeatureCollection(self.schema, self.as_dense(inputs))
-        feature_context = FeatureContext(features)
-        outputs = call_layer(self.block, inputs, feature_context=feature_context, **kwargs)
+        if not kwargs.get("feature_context", None):
+            features = FeatureCollection(self.schema, self.as_dense(inputs))
+            kwargs["feature_context"] = FeatureContext(features)
+
+        outputs = call_layer(self.block, inputs, **kwargs)
         return outputs
 
     @property

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -200,8 +200,8 @@ class Model(tf.keras.Model, LossMixin, MetricsMixin):
 
     def call(self, inputs, **kwargs):
         features = FeatureCollection(self.schema, self.as_dense(inputs))
-        context = FeatureContext(features)
-        outputs = call_layer(self.block, inputs, context=context, **kwargs)
+        feature_context = FeatureContext(features)
+        outputs = call_layer(self.block, inputs, feature_context=feature_context, **kwargs)
         return outputs
 
     @property

--- a/tests/tf/blocks/core/test_masking.py
+++ b/tests/tf/blocks/core/test_masking.py
@@ -19,6 +19,9 @@ import tensorflow as tf
 
 import merlin.models.tf as ml
 from merlin.io import Dataset
+from merlin.models.config.schema import FeatureCollection
+from merlin.models.tf.blocks.core.context import FeatureContext
+from merlin.models.tf.blocks.core.transformations import AsDenseFeatures
 from merlin.schema import Tags
 
 
@@ -30,7 +33,9 @@ def test_masking_block(sequence_testing_data: Dataset, mask_block):
     block = embedding_block.connect(mask_block(), context=ml.ModelContext())
 
     batch = ml.sample_batch(sequence_testing_data, batch_size=100, include_targets=False)
-    masked_input = block(batch)
+    feature_context = FeatureContext(FeatureCollection(schema_list, AsDenseFeatures()(batch)))
+    masked_input = block(batch, feature_context=feature_context)
+
     assert masked_input.shape[-1] == 148
     assert masked_input.shape[1] == 4
 


### PR DESCRIPTION
### Goals :soccer:
Since Keras is particular about where the tensors used in `call` methods come from and wants them all to be passed in as function arguments (to make graph mode work properly), we can't store the raw input tensors in the `ModelContext` and have instead been forced to copy the values into Tensorflow variables (which are usually used for layer parameters.) This comes at a cost in terms of both complexity and memory usage, which we'd like to avoid.

### Implementation Details :construction:
Instead of using the `ModelContext` layer and its associated variables to store the input values, here we're passing an extra `feature_context` argument into the `call` methods of blocks, which contains the input tensors packaged together with their schema information as a `FeatureCollection` object and wrapped inside a `FeatureContext`. In order to make this change seamlessly and incrementally, we use a `call_layer` method that checks what args and kwargs each block's `call` method accepts and only forwards those. This allows us to introduce the `feature_context` argument wherever it's useful without having to change every `call` method in the library simultaneously.

### Testing Details :mag:
Needs some tests for:

- Checking that aggregating input block schemas into model schemas works as expected

### Authors  📝 

Co-authored-by: Marc Romeyn <marcromeyn@gmail.com>
Co-authored-by: Julio Perez <jperez999@users.noreply.github.com>