### PR TITLE
Add common release-drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,28 @@
+categories:
+- title: '⚠ Breaking Changes'
+  labels:
+  - 'breaking'
+- title: '🐜 Bug Fixes'
+  labels:
+  - 'bug'
+- title: '🚀 Features'
+  labels:
+  - 'feature'
+  - 'enhancement'
+- title: '📄 Documentation'
+  labels:
+  - 'documentation'
+  - 'examples'
+- title: '🔧 Maintenance'
+  labels:
+  - 'build'
+  - 'dependencies'
+  - 'chore'
+  - 'ci'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+exclude-labels:
+  - 'skip-changelog'
+template: |
+  ## What’s Changed
+
+  $CHANGES

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     hooks:
       - id: prettier
         types: [yaml]
-        exclude: ^.github/workflows/|^conda
+        exclude: ^.github|^conda
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0
     hooks:


### PR DESCRIPTION
Introduce release-drafter consistently
across the organization repositories.
This change should enable us to produce
release notes.
