### PR TITLE
rm git pull cmd in test unit

### DIFF
--- a/ci/test_unit.sh
+++ b/ci/test_unit.sh
@@ -19,7 +19,6 @@ set -e
 
 # Get latest models version
 cd /models/
-git pull origin main
 
 container=$1
 


### PR DESCRIPTION
removing the git pull origin main... which forces always using the ToT instead of currently checked out code.