### PR TITLE
Add common release-drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,19 @@
+name: release-drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - "main"
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  # pull_request_target:
+  #  types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+jobs:
+  update_release_draft:
+    uses: nvidia-merlin/.github/.github/workflows/release-drafter-common.yaml@main


### PR DESCRIPTION
Use the workflow from the organization repo.
This update should help us with creating
release notes.