### PR TITLE
Make use of model_test for all ranking- and benchmark-models

### DIFF
--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -551,6 +551,7 @@ class RetrievalBlock(Protocol):
         ...
 
 
+@tf.keras.utils.register_keras_serializable(package="merlin.models")
 class RetrievalModel(Model):
     """Embedding-based retrieval model."""
 

--- a/merlin/models/tf/prediction_tasks/base.py
+++ b/merlin/models/tf/prediction_tasks/base.py
@@ -435,6 +435,7 @@ class PredictionTask(Layer, LossMixin, MetricsMixin, ContextMixin):
             config,
             {
                 "pre": tf.keras.layers.deserialize,
+                "task_block": tf.keras.layers.deserialize,
                 "metrics": tf.keras.metrics.deserialize,
                 "prediction_metrics": tf.keras.metrics.deserialize,
                 "label_metrics": tf.keras.metrics.deserialize,
@@ -449,7 +450,7 @@ class PredictionTask(Layer, LossMixin, MetricsMixin, ContextMixin):
         config = tf_utils.maybe_serialize_keras_objects(
             self,
             config,
-            ["metrics", "prediction_metrics", "label_metrics", "loss_metrics", "pre"],
+            ["metrics", "prediction_metrics", "label_metrics", "loss_metrics", "pre", "task_block"],
         )
 
         # config["summary_type"] = self.sequence_summary.summary_type

--- a/tests/unit/tf/features/test_continuous.py
+++ b/tests/unit/tf/features/test_continuous.py
@@ -52,5 +52,6 @@ def test_continuous_features_yoochoose_model(music_streaming_data: Dataset, run_
 
     inputs = ml.ContinuousFeatures.from_schema(schema, aggregation="concat")
     body = ml.SequentialBlock([inputs, ml.MLPBlock([64])])
+    model = ml.Model(body, ml.BinaryClassificationTask("click"))
 
-    testing_utils.assert_body_works_in_model(music_streaming_data, body, run_eagerly)
+    testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)

--- a/tests/unit/tf/features/test_embedding.py
+++ b/tests/unit/tf/features/test_embedding.py
@@ -82,8 +82,9 @@ def test_embedding_features_yoochoose_model(music_streaming_data: Dataset, run_e
 
     inputs = mm.EmbeddingFeatures.from_schema(schema, aggregation="concat")
     body = mm.SequentialBlock([inputs, mm.MLPBlock([64])])
+    model = mm.Model(body, mm.BinaryClassificationTask("click"))
 
-    testing_utils.assert_body_works_in_model(music_streaming_data, body, run_eagerly)
+    testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
 
 
 def test_embedding_features_yoochoose_custom_dims(testing_data: Dataset):

--- a/tests/unit/tf/features/test_tabular.py
+++ b/tests/unit/tf/features/test_tabular.py
@@ -66,4 +66,6 @@ def test_tabular_features_yoochoose_model(
     )
 
     body = ml.SequentialBlock([inputs, ml.MLPBlock([64])])
-    testing_utils.assert_body_works_in_model(music_streaming_data, body, run_eagerly)
+    model = ml.Model(body, ml.BinaryClassificationTask("click"))
+
+    testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)

--- a/tests/unit/tf/models/test_benchmark.py
+++ b/tests/unit/tf/models/test_benchmark.py
@@ -15,11 +15,14 @@
 # #
 #
 
+import pytest
+
 import merlin.models.tf as ml
 from merlin.models.tf.utils import testing_utils
 
 
-def test_ncf_model_single_task_from_pred_task(ecommerce_data, num_epochs=5, run_eagerly=True):
+@pytest.mark.parametrize("run_eagerly", [True, False])
+def test_ncf_model(ecommerce_data, run_eagerly):
     model = ml.benchmark.NCFModel(
         ecommerce_data.schema,
         embedding_dim=64,
@@ -27,10 +30,4 @@ def test_ncf_model_single_task_from_pred_task(ecommerce_data, num_epochs=5, run_
         prediction_tasks=ml.BinaryClassificationTask("click"),
     )
 
-    model.compile(optimizer="adam", run_eagerly=run_eagerly)
-
-    losses = model.fit(ecommerce_data, batch_size=50, epochs=num_epochs)
-    metrics = model.evaluate(ecommerce_data, batch_size=50, return_dict=True)
-    testing_utils.assert_binary_classification_loss_metrics(
-        losses, metrics, target_name="click", num_epochs=num_epochs
-    )
+    testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)

--- a/tests/unit/tf/models/test_ranking.py
+++ b/tests/unit/tf/models/test_ranking.py
@@ -21,9 +21,8 @@ from merlin.io import Dataset
 from merlin.models.tf.utils import testing_utils
 
 
-# TODO: Fix this test when `run_eagerly=False`
-# @pytest.mark.parametrize("run_eagerly", [True, False])
-def test_simple_model(ecommerce_data: Dataset, num_epochs=5, run_eagerly=True):
+@pytest.mark.parametrize("run_eagerly", [True, False])
+def test_simple_model(ecommerce_data: Dataset, run_eagerly):
     body = ml.InputBlock(ecommerce_data.schema).connect(ml.MLPBlock([64]))
     model = ml.Model(body, ml.BinaryClassificationTask("click"))
     model.compile(optimizer="adam", run_eagerly=run_eagerly)
@@ -32,7 +31,7 @@ def test_simple_model(ecommerce_data: Dataset, num_epochs=5, run_eagerly=True):
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
-def test_mf_model_signle_binary_task(ecommerce_data, run_eagerly):
+def test_mf_model_single_binary_task(ecommerce_data, run_eagerly):
     model = ml.MatrixFactorizationModel(
         ecommerce_data.schema,
         dim=64,
@@ -40,16 +39,11 @@ def test_mf_model_signle_binary_task(ecommerce_data, run_eagerly):
         prediction_tasks=ml.BinaryClassificationTask("click"),
     )
 
-    model.compile(optimizer="adam", run_eagerly=run_eagerly)
-
-    losses = model.fit(ecommerce_data, batch_size=50, epochs=2)
-    metrics = model.evaluate(ecommerce_data, batch_size=50, return_dict=True)
-    testing_utils.assert_binary_classification_loss_metrics(
-        losses, metrics, target_name="click", num_epochs=2
-    )
+    testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)
 
 
-def test_dlrm_model_single_task_from_pred_task(ecommerce_data, num_epochs=5, run_eagerly=True):
+@pytest.mark.parametrize("run_eagerly", [True, False])
+def test_dlrm_model(ecommerce_data, run_eagerly):
     model = ml.DLRMModel(
         ecommerce_data.schema,
         embedding_dim=64,
@@ -58,30 +52,12 @@ def test_dlrm_model_single_task_from_pred_task(ecommerce_data, num_epochs=5, run
         prediction_tasks=ml.BinaryClassificationTask("click"),
     )
 
-    model.compile(optimizer="adam", run_eagerly=run_eagerly)
-
-    testing_utils.model_test(model, ecommerce_data)
-
-
-def test_deep_fm_model_single_task_from_pred_task(ecommerce_data, num_epochs=5, run_eagerly=True):
-    model = ml.DeepFMModel(
-        ecommerce_data.schema,
-        embedding_dim=64,
-    )
-
-    model.compile(optimizer="adam", run_eagerly=run_eagerly)
-
-    losses = model.fit(ecommerce_data, batch_size=50, epochs=num_epochs)
-    metrics = model.evaluate(ecommerce_data, batch_size=50, return_dict=True)
-    testing_utils.assert_binary_classification_loss_metrics(
-        losses, metrics, target_name="click", num_epochs=num_epochs
-    )
+    testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)
 
 
 @pytest.mark.parametrize("stacked", [True, False])
-def test_dcn_model_single_task_from_pred_task(
-    ecommerce_data, stacked, num_epochs=5, run_eagerly=True
-):
+@pytest.mark.parametrize("run_eagerly", [True, False])
+def test_dcn_model(ecommerce_data, stacked, run_eagerly):
     model = ml.DCNModel(
         ecommerce_data.schema,
         depth=3,
@@ -96,18 +72,11 @@ def test_dcn_model_single_task_from_pred_task(
         prediction_tasks=ml.BinaryClassificationTask("click"),
     )
 
-    model.compile(optimizer="adam", run_eagerly=run_eagerly)
-
-    losses = model.fit(ecommerce_data, batch_size=50, epochs=num_epochs)
-    metrics = model.evaluate(ecommerce_data, batch_size=50, return_dict=True)
-    testing_utils.assert_binary_classification_loss_metrics(
-        losses, metrics, target_name="click", num_epochs=num_epochs
-    )
+    testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)
 
 
-def test_dlrm_model_single_head_multiple_tasks(
-    music_streaming_data, num_epochs=5, run_eagerly=True
-):
+@pytest.mark.parametrize("run_eagerly", [True, False])
+def test_dlrm_model_multi_task(music_streaming_data, run_eagerly):
     dlrm_body = ml.DLRMBlock(
         music_streaming_data.schema,
         embedding_dim=64,
@@ -120,21 +89,11 @@ def test_dlrm_model_single_head_multiple_tasks(
     prediction_tasks = ml.PredictionTasks(
         music_streaming_data.schema,
         task_blocks=tasks_blocks,
-        task_weight_dict={"click": 2.0, "play_percentage": 1.0},
     )
 
     model = ml.Model(dlrm_body, ml.MLPBlock([64]), prediction_tasks)
 
-    model.compile(optimizer="adam", run_eagerly=run_eagerly)
-
-    losses = model.fit(music_streaming_data, batch_size=50, epochs=num_epochs)
-    metrics = model.evaluate(music_streaming_data, batch_size=50, return_dict=True)
-    testing_utils.assert_binary_classification_loss_metrics(
-        losses, metrics, target_name="click", num_epochs=num_epochs
-    )
-    testing_utils.assert_regression_loss_metrics(
-        losses, metrics, target_name="play_percentage", num_epochs=num_epochs
-    )
+    testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
 
 
 @pytest.mark.parametrize("prediction_task", [ml.BinaryClassificationTask, ml.RegressionTask])
@@ -142,32 +101,4 @@ def test_serialization_model(ecommerce_data: Dataset, prediction_task):
     body = ml.InputBlock(ecommerce_data.schema).connect(ml.MLPBlock([64]))
     model = ml.Model(body, prediction_task("click"))
 
-    copy_model = testing_utils.assert_serialization(model)
-    testing_utils.assert_loss_and_metrics_are_valid(
-        copy_model, ml.sample_batch(ecommerce_data, batch_size=100)
-    )
-
-
-@pytest.mark.parametrize("prediction_task", [None, ml.BinaryClassificationTask, ml.RegressionTask])
-@pytest.mark.parametrize("run_eagerly", [True, False])
-@pytest.mark.parametrize("model_name", ["mlp", "dlrm"])
-def test_resume_training(ecommerce_data: Dataset, prediction_task, run_eagerly, model_name):
-    from merlin.models.tf.utils import testing_utils
-
-    if prediction_task:
-        prediction_task = prediction_task("click")
-    else:
-        # Do multi-task learning if no prediction task is provided
-        prediction_task = ml.PredictionTasks(ecommerce_data.schema)
-
-    if model_name == "dlrm":
-        body = ml.DLRMBlock(ecommerce_data.schema, embedding_dim=64, bottom_block=ml.MLPBlock([64]))
-    else:
-        body = ml.InputBlock(ecommerce_data.schema).connect(ml.MLPBlock([64]))
-    model = ml.Model(body, prediction_task)
-
-    copy_model = testing_utils.assert_model_is_retrainable(
-        model, ecommerce_data, run_eagerly=run_eagerly
-    )
-
-    assert copy_model is not None
+    testing_utils.model_test(model, ecommerce_data)

--- a/tests/unit/tf/prediction_tasks/test_classification.py
+++ b/tests/unit/tf/prediction_tasks/test_classification.py
@@ -13,31 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-import tensorflow as tf
+import pytest
 
 import merlin.models.tf as ml
 from merlin.io import Dataset
-
-targets = {"target": tf.cast(tf.random.uniform((100,), maxval=2, dtype=tf.int32), tf.float32)}
-
-
-def test_binary_classification_head(testing_data: Dataset):
-    from merlin.models.tf.utils import testing_utils
-
-    body = ml.InputBlock(testing_data.schema).connect(ml.MLPBlock([64]))
-    model = ml.Model(body, ml.BinaryClassificationTask("target"))
-
-    batch = (ml.sample_batch(testing_data, batch_size=100, include_targets=False), targets)
-    testing_utils.assert_loss_and_metrics_are_valid(model, batch)
+from merlin.models.tf.utils import testing_utils
 
 
-def test_serialization_binary_classification_head(testing_data: Dataset):
-    from merlin.models.tf.utils import testing_utils
+@pytest.mark.parametrize("run_eagerly", [True, False])
+def test_binary_classification_head(ecommerce_data: Dataset, run_eagerly):
+    body = ml.InputBlock(ecommerce_data.schema).connect(ml.MLPBlock([64]))
+    model = ml.Model(body, ml.BinaryClassificationTask("click"))
 
-    body = ml.InputBlock(testing_data.schema).connect(ml.MLPBlock([64]))
-    model = ml.Model(body, ml.BinaryClassificationTask("target"))
-
-    copy_model = testing_utils.assert_serialization(model)
-    batch = (ml.sample_batch(testing_data, batch_size=100, include_targets=False), targets)
-    testing_utils.assert_loss_and_metrics_are_valid(copy_model, batch)
+    testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)

--- a/tests/unit/tf/prediction_tasks/test_regression.py
+++ b/tests/unit/tf/prediction_tasks/test_regression.py
@@ -13,31 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-import tensorflow as tf
+import pytest
 
 import merlin.models.tf as ml
 from merlin.io import Dataset
-
-targets = {"target": tf.cast(tf.random.uniform((100,), maxval=2, dtype=tf.int32), tf.float32)}
-
-
-def test_regression_head(testing_data: Dataset):
-    from merlin.models.tf.utils import testing_utils
-
-    body = ml.InputBlock(testing_data.schema).connect(ml.MLPBlock([64]))
-    model = ml.Model(body, ml.RegressionTask("target"))
-
-    batch = (ml.sample_batch(testing_data, batch_size=100, include_targets=False), targets)
-    testing_utils.assert_loss_and_metrics_are_valid(model, batch)
+from merlin.models.tf.utils import testing_utils
 
 
-def test_serialization_regression_head(testing_data: Dataset):
-    from merlin.models.tf.utils import testing_utils
+@pytest.mark.parametrize("run_eagerly", [True, False])
+def test_regression_head(ecommerce_data: Dataset, run_eagerly):
+    body = ml.InputBlock(ecommerce_data.schema).connect(ml.MLPBlock([64]))
+    model = ml.Model(body, ml.RegressionTask("click"))
 
-    body = ml.InputBlock(testing_data.schema).connect(ml.MLPBlock([64]))
-    model = ml.Model(body, ml.RegressionTask("target"))
-
-    copy_model = testing_utils.assert_serialization(model)
-    batch = (ml.sample_batch(testing_data, batch_size=100, include_targets=False), targets)
-    testing_utils.assert_loss_and_metrics_are_valid(copy_model, batch)
+    testing_utils.model_test(model, ecommerce_data)


### PR DESCRIPTION
### Goals :soccer:
Use the newly introduced `model_test` in all ranking- and benchmark-tests in order to ensure our models can be fitted, saved to disk & retrained.

### Implementation Details :construction:
This PR contains some bug-fixes in order to make sure models like DCN can be saved & restored.