### PR TITLE
Move masking into the `FeatureContext`

### DIFF
--- a/merlin/models/tf/blocks/core/base.py
+++ b/merlin/models/tf/blocks/core/base.py
@@ -138,14 +138,6 @@ class ModelContext(Layer):
             item = str(item)
         return self.named_variables[f"{item}/embedding"]
 
-    def get_mask(self):
-        mask = self.named_variables.get("mask", None)
-        if mask is None:
-            raise ValueError(
-                "The mask is not stored, " "please make sure that a MaskingBlock was set"
-            )
-        return mask
-
     @property
     def named_variables(self) -> Dict[str, tf.Variable]:
         outputs = {}

--- a/merlin/models/tf/blocks/core/context.py
+++ b/merlin/models/tf/blocks/core/context.py
@@ -14,9 +14,22 @@
 # limitations under the License.
 #
 
+import tensorflow as tf
+
 from merlin.models.config.schema import FeatureCollection
 
 
 class FeatureContext:
-    def __init__(self, features: FeatureCollection):
+    def __init__(self, features: FeatureCollection, mask: tf.Tensor = None):
         self.features = features
+        self._mask = mask
+
+    @property
+    def mask(self):
+        if self._mask is None:
+            raise ValueError("The mask is not stored, " "please make sure that a mask was set")
+        return self._mask
+
+    @mask.setter
+    def mask(self, mask: tf.Tensor):
+        self._mask = mask

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -203,6 +203,8 @@ class Model(tf.keras.Model, LossMixin, MetricsMixin):
             features = FeatureCollection(self.schema, self.as_dense(inputs))
             kwargs["feature_context"] = FeatureContext(features)
 
+        self.feature_context = kwargs["feature_context"]
+
         outputs = call_layer(self.block, inputs, **kwargs)
         return outputs
 
@@ -288,9 +290,9 @@ class Model(tf.keras.Model, LossMixin, MetricsMixin):
             else:
                 targets = None
 
-            predictions = self(inputs, training=True)
             features = FeatureCollection(self.schema, self.as_dense(inputs))
             feature_context = FeatureContext(features)
+            predictions = self(inputs, feature_context=feature_context, training=True)
 
             loss = self.compute_loss(
                 predictions,


### PR DESCRIPTION
### Goals :soccer:
Move masking information from the `ModelContext` (which is a long-lived Tensorflow layer object stored as a model attribute that we're phasing out) into the `FeatureContext` (which is a short-lived plain Python object passed in or created when making predictions with the model that we're phasing in.)

### Implementation Details :construction:
Using a plain Python object containing a raw TF tensor passed in to the various `call()` methods works around issues with Tensorflow's graph mode when storing a full masking layer on the model and reaching for it from inside `call()` methods. TF graph mode really seems to want us to pass things in as parameters instead of accessing external state provided implicitly. 

### Testing Details :mag:
Since the masking implementation has changed in this PR, there are some changes to the masking tests. The user-facing API doesn't change, but the masking tests are testing some internal details of the masking implementation, so we had to make adjustments.
