### PR TITLE
Adding the missing logQ correction to sampled softmax

### DIFF
--- a/merlin/models/tf/blocks/core/transformations.py
+++ b/merlin/models/tf/blocks/core/transformations.py
@@ -599,6 +599,8 @@ class PopularityLogitsCorrection(Block):
             self.set_schema(schema)
 
         self.reg_factor = reg_factor
+
+        self._check_items_cardinality(item_freq_probs)
         candidate_probs = get_candidate_probs(item_freq_probs, is_prob_distribution)
 
         self.candidate_probs = tf.Variable(
@@ -680,6 +682,7 @@ class PopularityLogitsCorrection(Block):
             If True, the item_freq_probs should be a probability distribution of the items.
             If False, the item frequencies is converted to probabilities
         """
+        self._check_items_cardinality(item_freq_probs)
         candidate_probs = get_candidate_probs(item_freq_probs, is_prob_distribution)
         self.candidate_probs.assign(candidate_probs)
 

--- a/merlin/models/tf/prediction_tasks/next_item.py
+++ b/merlin/models/tf/prediction_tasks/next_item.py
@@ -121,6 +121,7 @@ def NextItemPredictionTask(
     sampled_softmax: bool = False,
     num_sampled: int = 100,
     min_sampled_id: int = 0,
+    post_logits: Optional[Block] = None,
 ) -> MultiClassClassificationTask:
     """
     Function to create the NextItemPrediction task with the right parameters.
@@ -169,6 +170,10 @@ def NextItemPredictionTask(
             The minimum id value to be sampled. Useful to ignore the first categorical
             encoded ids, which are usually reserved for <nulls>, out-of-vocabulary or padding.
             Defaults to 0.
+        post_logits: Optional[PredictionBlock]
+            Optional extra pre-call block for post-processing the logits, by default None.
+            You can for example use `post_logits = mm.PopularitySamplingBlock(item_fequency)`
+            for populariy sampling correction.
     Returns
     -------
         PredictionTask
@@ -189,6 +194,9 @@ def NextItemPredictionTask(
             prediction_call = ItemsPrediction(schema)
 
         prediction_call = prediction_call.connect(LabelToOneHot())
+
+    if post_logits is not None:
+        prediction_call = prediction_call.connect(post_logits)
 
     if logits_temperature != 1:
         prediction_call = prediction_call.connect(LogitsTemperatureScaler(logits_temperature))

--- a/merlin/models/tf/prediction_tasks/next_item.py
+++ b/merlin/models/tf/prediction_tasks/next_item.py
@@ -26,6 +26,7 @@ from merlin.models.tf.blocks.core.transformations import (
     L2Norm,
     LabelToOneHot,
     LogitsTemperatureScaler,
+    PopularityLogitsCorrection,
     RemovePad3D,
 )
 from merlin.models.tf.blocks.retrieval.base import ItemRetrievalScorer
@@ -52,7 +53,7 @@ class ItemsPrediction(CategFeaturePrediction):
         super(ItemsPrediction, self).__init__(schema, **kwargs)
 
 
-def ItemsPredictionSampled(
+def ItemsPredictionPopSampled(
     schema: Schema,
     num_sampled: int,
     min_id: int = 0,
@@ -62,7 +63,10 @@ def ItemsPredictionSampled(
     Compute the items logits on a subset of sampled candidates to optimize
     training. During inference, the scores are computed over the whole
     catalog of items.
-    Reference of the method can be found at [Jean et al., 2014](http://arxiv.org/abs/1412.2007)
+    The PopularityBasedSampler is used for sampled softmax [1]_ [2]_ [3]_.
+    That implementation does not require the actual item frequencies/probabilities
+    if the item ids are sorted by frequency. The PopularityBasedSampler
+    approximates the item probabilities using the log_uniform (zipfian) distribution.
 
     Parameters:
     -----------
@@ -80,30 +84,44 @@ def ItemsPredictionSampled(
 
     Returns:
     -------
-        targets, logits: tf.Tensor, tf.Tensor
-            During training, return the concatenated tensor of true class
-            and sampled negatives of shape (bs, num_sampled+1), as well as the related logits.
-            During evaluation, returns the input tensor of true class, and the related logits.
+        A SequenceBlock that performs popularity-based sampling of negatives, scores
+        the items and applies the logQ correction for sampled softmax
+
+    References
+    ----------
+    .. [1] Yoshua Bengio and Jean-Sébastien Sénécal. 2003. Quick Training of Probabilistic
+       Neural Nets by Importance Sampling. In Proceedings of the conference on Artificial
+       Intelligence and Statistics (AISTATS).
+
+    .. [2 Y. Bengio and J. S. Senecal. 2008. Adaptive Importance Sampling to Accelerate
+       Training of a Neural Probabilistic Language Model. Trans. Neur. Netw. 19, 4 (April
+       2008), 713–722. https://doi.org/10.1109/TNN.2007.912312
+
+    .. [3] Jean, Sébastien, et al. "On using very large target vocabulary for neural
+        machine translation." arXiv preprint arXiv:1412.2007 (2014).
     """
     item_id_feature_name = schema.select_by_tag(Tags.ITEM_ID).column_names[0]
     item_domain = categorical_domains(schema)[item_id_feature_name]
     num_classes = categorical_cardinalities(schema)[item_id_feature_name]
-    samplers = PopularityBasedSampler(
+    sampler = PopularityBasedSampler(
         max_num_samples=num_sampled,
-        max_id=num_classes,
+        max_id=num_classes - 1,
         min_id=min_id,
         item_id_feature_name=item_id_feature_name,
     )
 
-    logits = ItemRetrievalScorer(
-        samplers=[samplers],
+    retrieval_scorer = ItemRetrievalScorer(
+        samplers=[sampler],
         sampling_downscore_false_negatives=ignore_false_negatives,
         item_id_feature_name=item_id_feature_name,
         item_domain=item_domain,
         sampled_softmax_mode=True,
     )
 
-    return logits
+    expected_items_distribution = sampler.get_distribution_probs()
+    logq_correction = PopularityLogitsCorrection(expected_items_distribution, schema=schema)
+
+    return retrieval_scorer.connect(logq_correction)
 
 
 def NextItemPredictionTask(
@@ -182,7 +200,7 @@ def NextItemPredictionTask(
     item_id_feature_name = schema.select_by_tag(Tags.ITEM_ID).column_names[0]
 
     if sampled_softmax:
-        prediction_call = ItemsPredictionSampled(
+        prediction_call = ItemsPredictionPopSampled(
             schema, num_sampled=num_sampled, min_id=min_sampled_id
         )
 


### PR DESCRIPTION
Closes #161 
This PR adds the missing logQ correction to sampled softmax, which is currently used by the `YouTubeDNNModel`