### PR TITLE
Quick fix to simplify DLRM when there are no continuous features

### DIFF
--- a/merlin/models/tf/blocks/dlrm.py
+++ b/merlin/models/tf/blocks/dlrm.py
@@ -101,11 +101,15 @@ def DLRMBlock(
         interaction_inputs = ParallelBlock({"embeddings": embeddings, "bottom_block": bottom_block})
     else:
         interaction_inputs = embeddings  # type: ignore
+        bottom_block = None
 
     interaction_inputs = interaction_inputs.connect(Debug())
 
     if not top_block:
         return interaction_inputs.connect(DotProductInteractionBlock())
+
+    if not bottom_block:
+        return interaction_inputs.connect(DotProductInteractionBlock(), top_block)
 
     top_block_inputs = interaction_inputs.connect_with_shortcut(
         DotProductInteractionBlock(), shortcut_filter=Filter("bottom_block"), aggregation="concat"

--- a/tests/unit/tf/models/test_ranking.py
+++ b/tests/unit/tf/models/test_ranking.py
@@ -43,11 +43,23 @@ def test_mf_model_single_binary_task(ecommerce_data, run_eagerly):
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
-def test_dlrm_model(ecommerce_data, run_eagerly):
+def test_dlrm_model(music_streaming_data, run_eagerly):
+    model = ml.DLRMModel(
+        music_streaming_data.schema,
+        embedding_dim=64,
+        bottom_block=ml.MLPBlock([64]),
+        top_block=ml.MLPBlock([32]),
+        prediction_tasks=ml.BinaryClassificationTask("click"),
+    )
+
+    testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
+
+
+@pytest.mark.parametrize("run_eagerly", [True, False])
+def test_dlrm_model_without_continuous_features(ecommerce_data, run_eagerly):
     model = ml.DLRMModel(
         ecommerce_data.schema,
         embedding_dim=64,
-        bottom_block=ml.MLPBlock([64]),
         top_block=ml.MLPBlock([32]),
         prediction_tasks=ml.BinaryClassificationTask("click"),
     )


### PR DESCRIPTION
### Goals :soccer:
This PR adds a quick-fix to our `DLRMBlock`, when there are no continuous-features we don’t need the shortcut connection.