### PR TITLE
Remove single-use abstractions `RetrievalBlock` and `RetrievalMixin`

### DIFF
--- a/merlin/models/tf/blocks/retrieval/base.py
+++ b/merlin/models/tf/blocks/retrieval/base.py
@@ -50,16 +50,6 @@ class TowerBlock(ModelBlock):
     pass
 
 
-class RetrievalMixin:
-    def query_block(self) -> TowerBlock:
-        """Method to return the query tower from a RetrievalModel instance"""
-        raise NotImplementedError()
-
-    def item_block(self) -> TowerBlock:
-        """Method to return the item tower from a RetrievalModel instance"""
-        raise NotImplementedError()
-
-
 @tf.keras.utils.register_keras_serializable(package="merlin.models")
 class DualEncoderBlock(ParallelBlock):
     def __init__(

--- a/merlin/models/tf/blocks/retrieval/two_tower.py
+++ b/merlin/models/tf/blocks/retrieval/two_tower.py
@@ -20,7 +20,7 @@ from typing import Optional
 import tensorflow as tf
 
 from merlin.models.tf.blocks.core.base import Block, BlockType
-from merlin.models.tf.blocks.retrieval.base import DualEncoderBlock, RetrievalMixin
+from merlin.models.tf.blocks.retrieval.base import DualEncoderBlock
 from merlin.models.tf.inputs.base import InputBlock
 from merlin.models.tf.inputs.embedding import EmbeddingOptions
 from merlin.schema import Schema, Tags
@@ -29,7 +29,7 @@ LOG = logging.getLogger("merlin_models")
 
 
 @tf.keras.utils.register_keras_serializable(package="merlin_models")
-class TwoTowerBlock(DualEncoderBlock, RetrievalMixin):
+class TwoTowerBlock(DualEncoderBlock):
     """
     Builds the Two-tower architecture, as proposed in the following
     `paper https://doi.org/10.1145/3298689.3346996`_ [Xinyang19].

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Sequence as SequenceCollection
-from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Union, runtime_checkable
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import tensorflow as tf
 from tensorflow.python.keras.engine import data_adapter
@@ -13,6 +13,7 @@ from merlin.models.tf.blocks.core.base import Block, ModelContext, PredictionOut
 from merlin.models.tf.blocks.core.combinators import SequentialBlock
 from merlin.models.tf.blocks.core.context import FeatureContext
 from merlin.models.tf.blocks.core.transformations import AsDenseFeatures
+from merlin.models.tf.blocks.retrieval.base import DualEncoderBlock
 from merlin.models.tf.losses.base import loss_registry
 from merlin.models.tf.metrics.ranking import RankingMetric
 from merlin.models.tf.prediction_tasks.base import ParallelPredictionBlock, PredictionTask
@@ -626,15 +627,6 @@ class Model(tf.keras.Model):
         return {"block": tf.keras.utils.serialize_keras_object(self.block)}
 
 
-@runtime_checkable
-class RetrievalBlock(Protocol):
-    def query_block(self) -> Block:
-        ...
-
-    def item_block(self) -> Block:
-        ...
-
-
 @tf.keras.utils.register_keras_serializable(package="merlin_models")
 class RetrievalModel(Model):
     """Embedding-based retrieval model."""
@@ -719,8 +711,8 @@ class RetrievalModel(Model):
         )
 
     @property
-    def retrieval_block(self) -> RetrievalBlock:
-        return next(b for b in self.block if isinstance(b, RetrievalBlock))
+    def retrieval_block(self) -> DualEncoderBlock:
+        return next(b for b in self.block if isinstance(b, DualEncoderBlock))
 
     def query_embeddings(
         self,

--- a/merlin/models/tf/models/retrieval.py
+++ b/merlin/models/tf/models/retrieval.py
@@ -315,5 +315,5 @@ def YoutubeDNNRetrievalModel(
     )
 
     # TODO: Figure out how to make this fit as
-    # a RetrievalModel (which must have a RetrievalBlock)
+    # a RetrievalModel (which must have a DualEncoderBlock)
     return Model(inputs, top_block, task)


### PR DESCRIPTION
### Goals :soccer:
It's possible we'll want to have a way to share code across retrieval models in the future, but we're currently only using these abstractions in one place each, which means that they're an unnecessary layer of indirection right now.

### Implementation Details :construction:
Since `DualEncoderBlock` and `RetrievalMixin` were the only classes that matched the `RetrievalProtocol` and `DualEncoderBlock` was the only class using `RetrievalMixin`, we can consolidate references to all three to use `DualEncoderBlock` directly and remove the other two.

### Testing Details :mag:
Covered by existing tests.
