### PR TITLE
Add local installtion instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,9 @@ pip install merlin-models
 
 ```
 sudo apt update -y --fix-missing
-sudo apt install -y --no-install-recommends libexpat1-dev libsasl2-2 libssl-dev graphviz openssl protobuf-compiler software-properties-common
-sudo apt autoremove -y
-sudo apt clean
-sudo rm -rf /var/lib/apt/lists/*
+sudo apt install -y --no-install-recommends libexpat1-dev libsasl2-2 libssl-dev graphviz openssl software-properties-common
 
 pip install betterproto graphviz pybind11 pydot pytest mpi4py transformers==4.12
-pip install --upgrade notebook
-pip install --upgrade ipython
 pip install nvidia-pyindex
 pip install tritonclient[all] grpcio-channelz
 pip install numba==0.55.1

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ pip install merlin-models
 > The following script can be used for installing dependencies locally, however due to the intricacies of individual setups, we are only able to help you troubleshoot any issues you might encounter when running Merlin Models inside one of the provided docker containers.
 
 ```
-sudo apt update -y --fix-missing
 sudo apt install -y --no-install-recommends libexpat1-dev libsasl2-2 libssl-dev graphviz openssl software-properties-common
 
 pip install betterproto graphviz pybind11 pydot pytest mpi4py transformers==4.12

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pip install merlin-models
 
 > Installing Merlin Models with `pip` does not install some additional GPU dependencies, such as the CUDA Toolkit.
 > It is best to use the highly optimized Docker containers with dependencies installed.
-> The following script can be used for installing dependencies locally, however due to the intricacies of individual setups, we are only able to help you troubleshoot any issues you might encounter when running merlin-models inside one of the provided docker containers.
+> The following script can be used for installing dependencies locally, however due to the intricacies of individual setups, we are only able to help you troubleshoot any issues you might encounter when running Merlin Models inside one of the provided docker containers.
 
 ```
 sudo apt update -y --fix-missing
@@ -73,7 +73,7 @@ pip install git+https://github.com/rapidsai/asvdb.git@main
 pip install merlin-models
 ```
 
-You can consult the following [docker file](https://github.com/NVIDIA-Merlin/Merlin/tree/main/docker) for further details on the most up to date steps on installing dependencies.
+Please consult the Dockerfiles [here](https://github.com/NVIDIA-Merlin/Merlin/tree/main/docker) for further details on the most up to date steps for installing dependencies.
 
 #### Docker Containers that include Merlin Models
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,27 @@ pip install merlin-models
 ```
 
 > Installing Merlin Models with `pip` does not install some additional GPU dependencies, such as the CUDA Toolkit.
-> When you run Merlin Models in one of our Docker containers, the dependencies are already installed.
+> It is best to use the highly optimized Docker containers with dependencies installed.
+> The following script can be used for installing dependencies locally, however due to the intricacies of individual setups, we are only able to help you troubleshoot any issues you might encounter when running merlin-models inside one of the provided docker containers.
+
+```
+sudo apt update -y --fix-missing
+sudo apt install -y --no-install-recommends libexpat1-dev libsasl2-2 libssl-dev graphviz openssl protobuf-compiler software-properties-common
+sudo apt autoremove -y
+sudo apt clean
+sudo rm -rf /var/lib/apt/lists/*
+
+pip install betterproto graphviz pybind11 pydot pytest mpi4py transformers==4.12
+pip install --upgrade notebook
+pip install --upgrade ipython
+pip install nvidia-pyindex
+pip install tritonclient[all] grpcio-channelz
+pip install numba==0.55.1
+pip install git+https://github.com/rapidsai/asvdb.git@main
+pip install merlin-models
+```
+
+You can consult the following [docker file](https://github.com/NVIDIA-Merlin/Merlin/tree/main/docker) for further details on the most up to date steps on installing dependencies.
 
 #### Docker Containers that include Merlin Models
 


### PR DESCRIPTION
I believe that for many of our potential users using docker might be problematic.

Many even very good data scientists don't have docker in their toolbelt. Other people (including very successful folks) are very opinionated about their setups. Plus they might want to integrate Merlin tools with other libraries of their choice that do not come preinstalled in our containers (or are not at the version they want to use).

Additionally, developing against docker containers is not a very enjoyable experience (for instance, I couldn't get `pip -e .[all]` with a mounted directory to work with Merlin Models, which made it harder to figure out how things work, in the end I decided to install it locally). 

Not to mention that if people will not know how to do this, they won't be able to run our code on Kaggle/collab/paperspace/easily on GCP&AWS (Kaggle is especially amazing for fostering adoption).

Just wanted to open sharing directions for local installation up for discussion 🙂  (this might seem a no brainer that you can figure out how to install stuff locally via looking at dockerfiles but most people wouldn't make the connection due to lack of experience with docker plus they might not know where to find our dockerfiles)

(BTW have just gotten `nvtabular` to work on kaggle 🥳 just had to add the below)
```
sudo apt-get update
sudo apt-get install -y libopenmpi-dev
```

![image](https://user-images.githubusercontent.com/2444926/171795623-2ae83d4b-0d98-42aa-8613-454a3979f5b1.png)