### PR TITLE
Add a GA workflow that requires labels on PR's

### DIFF
--- a/.github/workflows/require-label.yaml
+++ b/.github/workflows/require-label.yaml
@@ -1,0 +1,9 @@
+name: Require PR Labels
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+jobs:
+  check-labels:
+    uses: nvidia-merlin/.github/.github/workflows/require-label.yaml@main


### PR DESCRIPTION
This adds a github actions workflow that requires PR's to be
labelled as described in:

https://github.com/NVIDIA-Merlin/Merlin/blob/main/CONTRIBUTING.md#label-your-prs

Unlabelled PR's will get failed by this workflow, and once we make this
required they won't be able to be merged.

