### PR TITLE
add usecase with pretrained embeddings

### DIFF
--- a/examples/usecases/entertainment-with-pretrained-embeddings.ipynb
+++ b/examples/usecases/entertainment-with-pretrained-embeddings.ipynb
@@ -1,17 +1,59 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92d580b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright 2022 NVIDIA Corporation. All Rights Reserved.\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     http://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions anda\n",
+    "# limitations under the License.\n",
+    "# =============================================================================="
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "697d1452",
    "metadata": {},
    "source": [
+    "<img src=\"http://developer.download.nvidia.com/compute/machine-learning/frameworks/nvidia_logo.png\" style=\"width: 90px; float: right;\">\n",
+    "\n",
+    "# Training with pretrained embeddings\n",
+    "\n",
+    "## Overview\n",
+    "\n",
     "In this use case we will consider how we might train with pretrained embeddings.\n",
     "\n",
     "Pretrained embeddings can allow our model to include information from additional modalities (for instance, we might want to grab CNN descriptors of product images). They can also come from other models that we train on our data. For example, we might train a word2vec model on the sequence of purchased items by a customer and want to include this information in our retrieval or ranking model.\n",
     "\n",
     "The use cases are many, but this particular example will focus on the technical aspects of working with pretrained embeddings.\n",
     "\n",
-    "We will use the MovieLens 100k dataset and emulate a scenario where we would have a pretrained embedding for each of the movies in the train dataset."
+    "We will use the MovieLens 100k dataset and emulate a scenario where we would have a pretrained embedding for each of the movies in the train dataset.\n",
+    "\n",
+    "### Learning objectives\n",
+    "\n",
+    "- Training with pretrained embeddings\n",
+    "- Understanding [the Schema file](https://github.com/NVIDIA-Merlin/core/blob/main/merlin/schema/schema.py)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21edc9aa",
+   "metadata": {},
+   "source": [
+    "## Downloading and preparing the dataset"
    ]
   },
   {
@@ -508,6 +550,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "c913b600",
+   "metadata": {},
+   "source": [
+    "## Building the model"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "22af1945",
@@ -533,6 +583,14 @@
     "        }\n",
     "    )\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b5e6631",
+   "metadata": {},
+   "source": [
+    "## Training"
    ]
   },
   {

--- a/examples/usecases/entertainment-with-pretrained-embeddings.ipynb
+++ b/examples/usecases/entertainment-with-pretrained-embeddings.ipynb
@@ -1,0 +1,408 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3e97432c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/workspace/examples/usecases\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pwd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "028dc96f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "120df1a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.chdir('/workspace')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "697d1452",
+   "metadata": {},
+   "source": [
+    "In this use case we will consider how we might train with pretrained embeddings.\n",
+    "\n",
+    "Pretrained embeddings can allow our model to include information from other modalities (for instance, we might want to grab CNN descriptors of product images). They can also come from other models that we train on our data. For example, we might train a word2vec model on the sequence of purchased items by a customer and want to include this information in our retrieval or ranking model.\n",
+    "\n",
+    "The use cases are many, but this particular example will focus just on the technical aspects of working with pretrained embeddings.\n",
+    "\n",
+    "We will use the MovieLens 100k dataset and emulate a scenario where we would have a pretrained embedding for each of the movies in the train dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e8c63b03",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-06-13 04:02:20.693184: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-13 04:02:20.693584: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-13 04:02:20.693744: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-13 04:02:20.715031: I tensorflow/core/platform/cpu_feature_guard.cc:152] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "2022-06-13 04:02:20.715735: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-13 04:02:20.715924: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-13 04:02:20.716074: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-13 04:02:21.398757: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-13 04:02:21.398961: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-13 04:02:21.399109: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-13 04:02:21.399237: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 24576 MB memory:  -> device: 0, name: Quadro RTX 8000, pci bus id: 0000:08:00.0, compute capability: 7.5\n"
+     ]
+    }
+   ],
+   "source": [
+    "import merlin.models.tf as mm\n",
+    "from merlin.datasets.entertainment import get_movielens\n",
+    "from merlin.schema.tags import Tags\n",
+    "import tensorflow as tf\n",
+    "from merlin.models.tf.prediction_tasks.classification import BinaryClassificationTask\n",
+    "from merlin.models.tf.blocks import *\n",
+    "\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "13fed8bb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.8/dist-packages/cudf/core/dataframe.py:1292: UserWarning: The deep parameter is ignored and is only included for pandas compatibility.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "train, valid = get_movielens(variant=\"ml-100k\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ffcd098e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'rating_binary'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "target_column = train.schema.select_by_tag(Tags.TARGET).column_names[1]\n",
+    "target_column"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d60873da",
+   "metadata": {},
+   "source": [
+    "From the schema, we can tell that there are 1681 known movie ids in the dataset. The movideId to movie mapping is stored in `.//categories/unique.movieId.parquet`. Let's read the file and take a closer look at the situation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d58c9aa5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cudf\n",
+    "\n",
+    "movieIds = cudf.read_parquet('.//categories/unique.movieId.parquet')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "e32b861e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>movieId</th>\n",
+       "      <th>movieId_size</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>50</td>\n",
+       "      <td>495</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>100</td>\n",
+       "      <td>443</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>181</td>\n",
+       "      <td>439</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>258</td>\n",
+       "      <td>412</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1676</th>\n",
+       "      <td>1678</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1677</th>\n",
+       "      <td>1679</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1678</th>\n",
+       "      <td>1680</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1679</th>\n",
+       "      <td>1681</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1680</th>\n",
+       "      <td>1682</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>1681 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     movieId  movieId_size\n",
+       "0       <NA>             0\n",
+       "1         50           495\n",
+       "2        100           443\n",
+       "3        181           439\n",
+       "4        258           412\n",
+       "...      ...           ...\n",
+       "1676    1678             1\n",
+       "1677    1679             1\n",
+       "1678    1680             1\n",
+       "1679    1681             1\n",
+       "1680    1682             1\n",
+       "\n",
+       "[1681 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "movieIds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26d624d4",
+   "metadata": {},
+   "source": [
+    "The highest movie id in the train dataset is 1682 with movie ID 0 being left for movies not seen in the train set.\n",
+    "\n",
+    "Let's create a mock embedding matrix. In a regular scenario, that is where our pretrained embeddings would go."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cc919e80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pretrained_movie_embs = np.random.random((1682, 64))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45dec89b",
+   "metadata": {},
+   "source": [
+    "Let us now feed this into our model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "22af1945",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-06-13 04:02:21.868740: W tensorflow/python/util/util.cc:368] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = mm.DCNModel(\n",
+    "train.schema,\n",
+    "    depth=2,\n",
+    "    deep_block=mm.MLPBlock([64, 32]),\n",
+    "    prediction_tasks=mm.BinaryClassificationTask(target_column),\n",
+    "    embedding_options=mm.EmbeddingOptions(\n",
+    "        embeddings_initializers={\n",
+    "            \"movieId\": mm.TensorInitializer(pretrained_movie_embs),\n",
+    "        }\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "f9d78213",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/10\n",
+      "89/89 [==============================] - 3s 9ms/step - loss: 0.6272 - auc: 0.6957 - val_loss: 0.6297 - val_auc: 0.6856\n",
+      "Epoch 2/10\n",
+      "89/89 [==============================] - 1s 6ms/step - loss: 0.6159 - auc: 0.7136 - val_loss: 0.6318 - val_auc: 0.6870\n",
+      "Epoch 3/10\n",
+      "89/89 [==============================] - 1s 6ms/step - loss: 0.6138 - auc: 0.7162 - val_loss: 0.6323 - val_auc: 0.6888\n",
+      "Epoch 4/10\n",
+      "89/89 [==============================] - 1s 6ms/step - loss: 0.6111 - auc: 0.7198 - val_loss: 0.6346 - val_auc: 0.6920\n",
+      "Epoch 5/10\n",
+      "89/89 [==============================] - 1s 6ms/step - loss: 0.6045 - auc: 0.7277 - val_loss: 0.6242 - val_auc: 0.6989\n",
+      "Epoch 6/10\n",
+      "89/89 [==============================] - 1s 6ms/step - loss: 0.5895 - auc: 0.7456 - val_loss: 0.6092 - val_auc: 0.7096\n",
+      "Epoch 7/10\n",
+      "89/89 [==============================] - 1s 6ms/step - loss: 0.5771 - auc: 0.7599 - val_loss: 0.6026 - val_auc: 0.7189\n",
+      "Epoch 8/10\n",
+      "89/89 [==============================] - 1s 5ms/step - loss: 0.5698 - auc: 0.7679 - val_loss: 0.5973 - val_auc: 0.7258\n",
+      "Epoch 9/10\n",
+      "89/89 [==============================] - 1s 6ms/step - loss: 0.5664 - auc: 0.7717 - val_loss: 0.5990 - val_auc: 0.7311\n",
+      "Epoch 10/10\n",
+      "89/89 [==============================] - 1s 6ms/step - loss: 0.5636 - auc: 0.7746 - val_loss: 0.5907 - val_auc: 0.7354\n",
+      "CPU times: user 13 s, sys: 1.15 s, total: 14.2 s\n",
+      "Wall time: 8.7 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<keras.callbacks.History at 0x7fe3a516d910>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "opt = tf.keras.optimizers.Adagrad(learning_rate=1e-1)\n",
+    "model.compile(optimizer=opt, run_eagerly=False, metrics=[tf.keras.metrics.AUC()])\n",
+    "model.fit(train, validation_data=valid, batch_size=1024, epochs=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb96ac21",
+   "metadata": {},
+   "source": [
+    "The model trains and we have utilized pretrained embeddings "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/usecases/entertainment-with-pretrained-embeddings.ipynb
+++ b/examples/usecases/entertainment-with-pretrained-embeddings.ipynb
@@ -66,18 +66,18 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-06-20 23:18:09.855239: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 23:18:09.855574: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 23:18:09.855716: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 23:18:09.877888: I tensorflow/core/platform/cpu_feature_guard.cc:152] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
+      "2022-06-23 04:16:53.178231: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-23 04:16:53.178616: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-23 04:16:53.178776: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-23 04:16:53.200029: I tensorflow/core/platform/cpu_feature_guard.cc:152] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2022-06-20 23:18:09.878993: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 23:18:09.879181: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 23:18:09.879319: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 23:18:10.575950: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 23:18:10.576147: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 23:18:10.576294: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 23:18:10.576422: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 24576 MB memory:  -> device: 0, name: Quadro RTX 8000, pci bus id: 0000:08:00.0, compute capability: 7.5\n"
+      "2022-06-23 04:16:53.201040: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-23 04:16:53.201216: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-23 04:16:53.201355: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-23 04:16:53.875404: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-23 04:16:53.875589: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-23 04:16:53.875729: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-23 04:16:53.875855: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 24576 MB memory:  -> device: 0, name: Quadro RTX 8000, pci bus id: 0000:08:00.0, compute capability: 7.5\n"
      ]
     }
    ],
@@ -140,235 +140,8 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>name</th>\n",
-       "      <th>tags</th>\n",
-       "      <th>dtype</th>\n",
-       "      <th>is_list</th>\n",
-       "      <th>is_ragged</th>\n",
-       "      <th>properties.freq_threshold</th>\n",
-       "      <th>properties.max_size</th>\n",
-       "      <th>properties.embedding_sizes.dimension</th>\n",
-       "      <th>properties.embedding_sizes.cardinality</th>\n",
-       "      <th>properties.cat_path</th>\n",
-       "      <th>properties.num_buckets</th>\n",
-       "      <th>properties.start_index</th>\n",
-       "      <th>properties.domain.min</th>\n",
-       "      <th>properties.domain.max</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>movieId</td>\n",
-       "      <td>(Tags.CATEGORICAL, Tags.ITEM, Tags.ITEM_ID)</td>\n",
-       "      <td>int32</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>102.0</td>\n",
-       "      <td>1680.0</td>\n",
-       "      <td>.//categories/unique.movieId.parquet</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>1680.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>userId</td>\n",
-       "      <td>(Tags.USER, Tags.CATEGORICAL, Tags.USER_ID)</td>\n",
-       "      <td>int32</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>74.0</td>\n",
-       "      <td>943.0</td>\n",
-       "      <td>.//categories/unique.userId.parquet</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>943.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>genres</td>\n",
-       "      <td>(Tags.CATEGORICAL, Tags.ITEM)</td>\n",
-       "      <td>int32</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>32.0</td>\n",
-       "      <td>216.0</td>\n",
-       "      <td>.//categories/unique.genres.parquet</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>216.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>TE_movieId_rating</td>\n",
-       "      <td>(Tags.CONTINUOUS)</td>\n",
-       "      <td>float64</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>userId_count</td>\n",
-       "      <td>(Tags.CONTINUOUS)</td>\n",
-       "      <td>float32</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>gender</td>\n",
-       "      <td>(Tags.USER, Tags.CATEGORICAL)</td>\n",
-       "      <td>int32</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>16.0</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>.//categories/unique.gender.parquet</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>2.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>zip_code</td>\n",
-       "      <td>(Tags.USER, Tags.CATEGORICAL)</td>\n",
-       "      <td>int32</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>67.0</td>\n",
-       "      <td>795.0</td>\n",
-       "      <td>.//categories/unique.zip_code.parquet</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>795.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>rating</td>\n",
-       "      <td>(Tags.TARGET, Tags.REGRESSION)</td>\n",
-       "      <td>int64</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>rating_binary</td>\n",
-       "      <td>(Tags.BINARY_CLASSIFICATION, Tags.TARGET)</td>\n",
-       "      <td>int32</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>age</td>\n",
-       "      <td>(Tags.USER, Tags.CATEGORICAL)</td>\n",
-       "      <td>int32</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>16.0</td>\n",
-       "      <td>8.0</td>\n",
-       "      <td>.//categories/unique.age.parquet</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>8.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>title</td>\n",
-       "      <td>()</td>\n",
-       "      <td>float64</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
       "text/plain": [
-       "[{'name': 'movieId', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM: 'item'>, <Tags.ITEM_ID: 'item_id'>}, 'properties': {'freq_threshold': 0.0, 'max_size': 0.0, 'embedding_sizes': {'dimension': 102.0, 'cardinality': 1680.0}, 'cat_path': './/categories/unique.movieId.parquet', 'num_buckets': None, 'start_index': 0.0, 'domain': {'min': 0, 'max': 1680}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'userId', 'tags': {<Tags.USER: 'user'>, <Tags.CATEGORICAL: 'categorical'>, <Tags.USER_ID: 'user_id'>}, 'properties': {'embedding_sizes': {'cardinality': 943.0, 'dimension': 74.0}, 'num_buckets': None, 'max_size': 0.0, 'start_index': 0.0, 'freq_threshold': 0.0, 'cat_path': './/categories/unique.userId.parquet', 'domain': {'min': 0, 'max': 943}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'genres', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM: 'item'>}, 'properties': {'max_size': 0.0, 'start_index': 0.0, 'num_buckets': None, 'freq_threshold': 0.0, 'embedding_sizes': {'cardinality': 216.0, 'dimension': 32.0}, 'cat_path': './/categories/unique.genres.parquet', 'domain': {'min': 0, 'max': 216}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'TE_movieId_rating', 'tags': {<Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}, {'name': 'userId_count', 'tags': {<Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float32'), 'is_list': False, 'is_ragged': False}, {'name': 'gender', 'tags': {<Tags.USER: 'user'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'max_size': 0.0, 'freq_threshold': 0.0, 'embedding_sizes': {'dimension': 16.0, 'cardinality': 2.0}, 'num_buckets': None, 'start_index': 0.0, 'cat_path': './/categories/unique.gender.parquet', 'domain': {'min': 0, 'max': 2}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'zip_code', 'tags': {<Tags.USER: 'user'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'embedding_sizes': {'cardinality': 795.0, 'dimension': 67.0}, 'freq_threshold': 0.0, 'max_size': 0.0, 'cat_path': './/categories/unique.zip_code.parquet', 'start_index': 0.0, 'num_buckets': None, 'domain': {'min': 0, 'max': 795}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'rating', 'tags': {<Tags.TARGET: 'target'>, <Tags.REGRESSION: 'regression'>}, 'properties': {}, 'dtype': dtype('int64'), 'is_list': False, 'is_ragged': False}, {'name': 'rating_binary', 'tags': {<Tags.BINARY_CLASSIFICATION: 'binary_classification'>, <Tags.TARGET: 'target'>}, 'properties': {}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'age', 'tags': {<Tags.USER: 'user'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'embedding_sizes': {'dimension': 16.0, 'cardinality': 8.0}, 'max_size': 0.0, 'start_index': 0.0, 'num_buckets': None, 'cat_path': './/categories/unique.age.parquet', 'freq_threshold': 0.0, 'domain': {'min': 0, 'max': 8}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'title', 'tags': set(), 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}]"
+       "1680.0"
       ]
      },
      "execution_count": 5,
@@ -377,7 +150,7 @@
     }
    ],
    "source": [
-    "train.schema"
+    "train.schema['movieId'].properties['embedding_sizes']['cardinality']"
    ]
   },
   {
@@ -385,33 +158,14 @@
    "id": "d60873da",
    "metadata": {},
    "source": [
-    "From the schema, we can tell that the cardinality of `movieId` is 1680. Embedding with `id` of 0 will be used in case an unknown `movieId` is encountered, thus we need to create an embedding table of size 1681."
+    "From the schema, we can tell that the cardinality of `movieId` is 1680. Index 0 will be used in case an unknown `movieId` is encountered\n",
+    "\n",
+    "In order to accommodate this, we initialize our embedding table of dimensionality 1681 by 64."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "631b669c",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1680.0"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "train.schema.column_schemas['movieId'].properties['embedding_sizes']['cardinality']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
    "id": "cc919e80",
    "metadata": {},
    "outputs": [],
@@ -421,10 +175,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45dec89b",
+   "id": "a5beff74",
    "metadata": {},
    "source": [
-    "Let us now feed this into our model."
+    "This is only a mock up embedding table. In reality, this is where we would pass our embeddings from another model.\n",
+    "\n",
+    "The dimensionality of each embedding, that of 64, is arbitrary. We could have specified some other value here, though generally multiples of 8 tend to work well.\n",
+    "\n",
+    "Let us now feed our embedding table into our model."
    ]
   },
   {
@@ -436,8 +194,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "8536b88b",
+   "metadata": {},
+   "source": [
+    "We now have everything we need to construct a model and train on our custom embeddings. In order to do so, we will leverage the `TensorInitializer`."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "22af1945",
    "metadata": {},
    "outputs": [
@@ -445,7 +211,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-06-20 23:18:10.978589: W tensorflow/python/util/util.cc:368] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
+      "2022-06-23 04:16:54.257546: W tensorflow/python/util/util.cc:368] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
      ]
     }
    ],
@@ -465,10 +231,51 @@
   },
   {
    "cell_type": "markdown",
+   "id": "73bdd67d",
+   "metadata": {},
+   "source": [
+    "We could have created the model without passing anything for the `embedding_options`. The model would still be able to infer how to construct itself (what should be the dimensionality of the input layer and so on) from the information contained in the schema.\n",
+    "\n",
+    "Passing a `TensorInitializer` as part of the `embedding_options` tells our model to use our embedding table (`pretrained_movie_embs`) for that particular column of our dataset (`movieId`) as opposed to the model randomly initializing a brand new embedding matrix. For categorical columns where we do not provide this information, the model will go with the standard initialization logic, which is to create an embedding table of appropriate size and perform random preinitialization."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "dbb0df47",
    "metadata": {},
    "source": [
     "## Training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4cdb0c1",
+   "metadata": {},
+   "source": [
+    "We train our model with `AUC` as our metric.\n",
+    "\n",
+    "As we use synthetic data, the AUC score will not improve significantly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "0b96fc50",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 8.02 ms, sys: 24 µs, total: 8.04 ms\n",
+      "Wall time: 7.49 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "opt = tf.keras.optimizers.Adagrad(learning_rate=1e-1)\n",
+    "model.compile(optimizer=opt, run_eagerly=False, metrics=[tf.keras.metrics.AUC()])"
    ]
   },
   {
@@ -482,33 +289,31 @@
      "output_type": "stream",
      "text": [
       "Epoch 1/10\n",
-      "98/98 [==============================] - 3s 5ms/step - loss: 0.6938 - auc: 0.5001 - regularization_loss: 0.0000e+00\n",
+      "98/98 [==============================] - 3s 5ms/step - loss: 0.6938 - auc: 0.5015 - regularization_loss: 0.0000e+00\n",
       "Epoch 2/10\n",
-      "98/98 [==============================] - 1s 5ms/step - loss: 0.6932 - auc: 0.5058 - regularization_loss: 0.0000e+00\n",
+      "98/98 [==============================] - 0s 5ms/step - loss: 0.6932 - auc: 0.5059 - regularization_loss: 0.0000e+00\n",
       "Epoch 3/10\n",
-      "98/98 [==============================] - 0s 5ms/step - loss: 0.6931 - auc: 0.5062 - regularization_loss: 0.0000e+00\n",
+      "98/98 [==============================] - 0s 5ms/step - loss: 0.6930 - auc: 0.5089 - regularization_loss: 0.0000e+00\n",
       "Epoch 4/10\n",
-      "98/98 [==============================] - 1s 5ms/step - loss: 0.6930 - auc: 0.5090 - regularization_loss: 0.0000e+00\n",
+      "98/98 [==============================] - 0s 5ms/step - loss: 0.6929 - auc: 0.5123 - regularization_loss: 0.0000e+00\n",
       "Epoch 5/10\n",
-      "98/98 [==============================] - 1s 5ms/step - loss: 0.6930 - auc: 0.5109 - regularization_loss: 0.0000e+00\n",
+      "98/98 [==============================] - 0s 5ms/step - loss: 0.6929 - auc: 0.5118 - regularization_loss: 0.0000e+00\n",
       "Epoch 6/10\n",
-      "98/98 [==============================] - 1s 5ms/step - loss: 0.6929 - auc: 0.5120 - regularization_loss: 0.0000e+00\n",
+      "98/98 [==============================] - 0s 5ms/step - loss: 0.6928 - auc: 0.5137 - regularization_loss: 0.0000e+00\n",
       "Epoch 7/10\n",
-      "98/98 [==============================] - 1s 5ms/step - loss: 0.6928 - auc: 0.5148 - regularization_loss: 0.0000e+00\n",
+      "98/98 [==============================] - 1s 5ms/step - loss: 0.6928 - auc: 0.5149 - regularization_loss: 0.0000e+00\n",
       "Epoch 8/10\n",
-      "98/98 [==============================] - 0s 5ms/step - loss: 0.6928 - auc: 0.5144 - regularization_loss: 0.0000e+00\n",
+      "98/98 [==============================] - 0s 5ms/step - loss: 0.6926 - auc: 0.5176 - regularization_loss: 0.0000e+00\n",
       "Epoch 9/10\n",
-      "98/98 [==============================] - 0s 5ms/step - loss: 0.6927 - auc: 0.5164 - regularization_loss: 0.0000e+00\n",
+      "98/98 [==============================] - 0s 5ms/step - loss: 0.6926 - auc: 0.5177 - regularization_loss: 0.0000e+00\n",
       "Epoch 10/10\n",
-      "98/98 [==============================] - 0s 5ms/step - loss: 0.6927 - auc: 0.5170 - regularization_loss: 0.0000e+00\n",
-      "CPU times: user 13.6 s, sys: 1.5 s, total: 15.1 s\n",
-      "Wall time: 8.23 s\n"
+      "98/98 [==============================] - 0s 5ms/step - loss: 0.6926 - auc: 0.5181 - regularization_loss: 0.0000e+00\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<keras.callbacks.History at 0x7f9abfc2a310>"
+       "<keras.callbacks.History at 0x7f4620746b20>"
       ]
      },
      "execution_count": 9,
@@ -517,9 +322,6 @@
     }
    ],
    "source": [
-    "%%time\n",
-    "opt = tf.keras.optimizers.Adagrad(learning_rate=1e-1)\n",
-    "model.compile(optimizer=opt, run_eagerly=False, metrics=[tf.keras.metrics.AUC()])\n",
     "model.fit(train, batch_size=1024, epochs=10)"
    ]
   },

--- a/examples/usecases/entertainment-with-pretrained-embeddings.ipynb
+++ b/examples/usecases/entertainment-with-pretrained-embeddings.ipynb
@@ -2,8 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "92d580b6",
+   "execution_count": 1,
+   "id": "a556f660",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
     "\n",
     "The use cases are many, but this particular example will focus on the technical aspects of working with pretrained embeddings.\n",
     "\n",
-    "We will use the MovieLens 100k dataset and emulate a scenario where we would have a pretrained embedding for each of the movies in the train dataset.\n",
+    "We will use a synthetic version of the MovieLens 100k dataset and emulate a scenario where we would have a pretrained embedding for each of the movies in the dataset.\n",
     "\n",
     "### Learning objectives\n",
     "\n",
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21edc9aa",
+   "id": "1cccd005",
    "metadata": {},
    "source": [
     "## Downloading and preparing the dataset"
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "e8c63b03",
    "metadata": {},
    "outputs": [
@@ -66,54 +66,45 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-06-20 21:53:41.425846: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 21:53:41.426187: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 21:53:41.426330: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 21:53:41.447601: I tensorflow/core/platform/cpu_feature_guard.cc:152] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
+      "2022-06-20 22:59:07.349291: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 22:59:07.349672: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 22:59:07.349814: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 22:59:07.371153: I tensorflow/core/platform/cpu_feature_guard.cc:152] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2022-06-20 21:53:41.448630: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 21:53:41.448815: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 21:53:41.448955: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 21:53:42.147476: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 21:53:42.147681: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 21:53:42.147825: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 21:53:42.147955: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 24576 MB memory:  -> device: 0, name: Quadro RTX 8000, pci bus id: 0000:08:00.0, compute capability: 7.5\n"
+      "2022-06-20 22:59:07.372053: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 22:59:07.372248: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 22:59:07.372388: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 22:59:08.070431: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 22:59:08.070625: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 22:59:08.070768: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 22:59:08.070899: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 24576 MB memory:  -> device: 0, name: Quadro RTX 8000, pci bus id: 0000:08:00.0, compute capability: 7.5\n"
      ]
     }
    ],
    "source": [
     "import merlin.models.tf as mm\n",
-    "from merlin.datasets.entertainment import get_movielens\n",
     "from merlin.schema.tags import Tags\n",
     "import tensorflow as tf\n",
     "from merlin.models.tf.prediction_tasks.classification import BinaryClassificationTask\n",
     "from merlin.models.tf.blocks import *\n",
+    "from merlin.datasets.synthetic import generate_data\n",
     "\n",
     "import numpy as np"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "13fed8bb",
+   "execution_count": 3,
+   "id": "e16e1ec1",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/lib/python3.8/dist-packages/cudf/core/dataframe.py:1292: UserWarning: The deep parameter is ignored and is only included for pandas compatibility.\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "train, valid = get_movielens(variant=\"ml-100k\")"
+    "train = generate_data('movielens-100k', num_rows=100_000)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "e5400a9a",
    "metadata": {},
    "outputs": [
@@ -123,7 +114,7 @@
        "'rating_binary'"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -134,8 +125,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "35fdb65b",
+   "metadata": {},
+   "source": [
+    "The schema holds vital information about our dataset. We can extract the embedding table size for the `moveId` column from it."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "3955ab52",
    "metadata": {},
    "outputs": [
@@ -165,13 +164,13 @@
        "      <th>dtype</th>\n",
        "      <th>is_list</th>\n",
        "      <th>is_ragged</th>\n",
-       "      <th>properties.num_buckets</th>\n",
        "      <th>properties.freq_threshold</th>\n",
        "      <th>properties.max_size</th>\n",
-       "      <th>properties.start_index</th>\n",
-       "      <th>properties.cat_path</th>\n",
-       "      <th>properties.embedding_sizes.cardinality</th>\n",
        "      <th>properties.embedding_sizes.dimension</th>\n",
+       "      <th>properties.embedding_sizes.cardinality</th>\n",
+       "      <th>properties.cat_path</th>\n",
+       "      <th>properties.num_buckets</th>\n",
+       "      <th>properties.start_index</th>\n",
        "      <th>properties.domain.min</th>\n",
        "      <th>properties.domain.max</th>\n",
        "    </tr>\n",
@@ -184,49 +183,49 @@
        "      <td>int32</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>102.0</td>\n",
+       "      <td>1680.0</td>\n",
+       "      <td>.//categories/unique.movieId.parquet</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>.//categories/unique.movieId.parquet</td>\n",
-       "      <td>1681.0</td>\n",
-       "      <td>102.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>1681.0</td>\n",
+       "      <td>1680.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>userId</td>\n",
-       "      <td>(Tags.CATEGORICAL, Tags.USER, Tags.USER_ID)</td>\n",
+       "      <td>(Tags.USER, Tags.CATEGORICAL, Tags.USER_ID)</td>\n",
        "      <td>int32</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>74.0</td>\n",
+       "      <td>943.0</td>\n",
+       "      <td>.//categories/unique.userId.parquet</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>.//categories/unique.userId.parquet</td>\n",
-       "      <td>944.0</td>\n",
-       "      <td>74.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>944.0</td>\n",
+       "      <td>943.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>genres</td>\n",
-       "      <td>(Tags.CATEGORICAL, Tags.ITEM)</td>\n",
+       "      <td>(Tags.ITEM, Tags.CATEGORICAL)</td>\n",
        "      <td>int32</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>32.0</td>\n",
+       "      <td>216.0</td>\n",
+       "      <td>.//categories/unique.genres.parquet</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>.//categories/unique.genres.parquet</td>\n",
-       "      <td>217.0</td>\n",
-       "      <td>33.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>217.0</td>\n",
+       "      <td>216.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -265,36 +264,36 @@
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>gender</td>\n",
-       "      <td>(Tags.CATEGORICAL, Tags.USER)</td>\n",
+       "      <td>(Tags.USER, Tags.CATEGORICAL)</td>\n",
        "      <td>int32</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>16.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>.//categories/unique.gender.parquet</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>.//categories/unique.gender.parquet</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>16.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>3.0</td>\n",
+       "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
        "      <td>zip_code</td>\n",
-       "      <td>(Tags.CATEGORICAL, Tags.USER)</td>\n",
+       "      <td>(Tags.USER, Tags.CATEGORICAL)</td>\n",
        "      <td>int32</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>67.0</td>\n",
+       "      <td>795.0</td>\n",
+       "      <td>.//categories/unique.zip_code.parquet</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>.//categories/unique.zip_code.parquet</td>\n",
-       "      <td>796.0</td>\n",
-       "      <td>67.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>796.0</td>\n",
+       "      <td>795.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
@@ -316,7 +315,7 @@
        "    <tr>\n",
        "      <th>8</th>\n",
        "      <td>rating_binary</td>\n",
-       "      <td>(Tags.TARGET, Tags.BINARY_CLASSIFICATION)</td>\n",
+       "      <td>(Tags.BINARY_CLASSIFICATION, Tags.TARGET)</td>\n",
        "      <td>int32</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
@@ -333,19 +332,19 @@
        "    <tr>\n",
        "      <th>9</th>\n",
        "      <td>age</td>\n",
-       "      <td>(Tags.CATEGORICAL, Tags.USER)</td>\n",
+       "      <td>(Tags.USER, Tags.CATEGORICAL)</td>\n",
        "      <td>int32</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>16.0</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>.//categories/unique.age.parquet</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>.//categories/unique.age.parquet</td>\n",
-       "      <td>9.0</td>\n",
-       "      <td>16.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>9.0</td>\n",
+       "      <td>8.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>10</th>\n",
@@ -369,10 +368,10 @@
        "</div>"
       ],
       "text/plain": [
-       "[{'name': 'movieId', 'tags': {<Tags.ITEM: 'item'>, <Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM_ID: 'item_id'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'max_size': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.movieId.parquet', 'embedding_sizes': {'cardinality': 1681.0, 'dimension': 102.0}, 'domain': {'min': 0, 'max': 1681}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'userId', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.USER: 'user'>, <Tags.USER_ID: 'user_id'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'max_size': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.userId.parquet', 'embedding_sizes': {'cardinality': 944.0, 'dimension': 74.0}, 'domain': {'min': 0, 'max': 944}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'genres', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM: 'item'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'max_size': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.genres.parquet', 'embedding_sizes': {'cardinality': 217.0, 'dimension': 33.0}, 'domain': {'min': 0, 'max': 217}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'TE_movieId_rating', 'tags': {<Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}, {'name': 'userId_count', 'tags': {<Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float32'), 'is_list': False, 'is_ragged': False}, {'name': 'gender', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.USER: 'user'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'max_size': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.gender.parquet', 'embedding_sizes': {'cardinality': 3.0, 'dimension': 16.0}, 'domain': {'min': 0, 'max': 3}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'zip_code', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.USER: 'user'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'max_size': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.zip_code.parquet', 'embedding_sizes': {'cardinality': 796.0, 'dimension': 67.0}, 'domain': {'min': 0, 'max': 796}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'rating', 'tags': {<Tags.TARGET: 'target'>, <Tags.REGRESSION: 'regression'>}, 'properties': {}, 'dtype': dtype('int64'), 'is_list': False, 'is_ragged': False}, {'name': 'rating_binary', 'tags': {<Tags.TARGET: 'target'>, <Tags.BINARY_CLASSIFICATION: 'binary_classification'>}, 'properties': {}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'age', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.USER: 'user'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'max_size': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.age.parquet', 'embedding_sizes': {'cardinality': 9.0, 'dimension': 16.0}, 'domain': {'min': 0, 'max': 9}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'title', 'tags': set(), 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}]"
+       "[{'name': 'movieId', 'tags': {<Tags.ITEM: 'item'>, <Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM_ID: 'item_id'>}, 'properties': {'freq_threshold': 0.0, 'max_size': 0.0, 'embedding_sizes': {'dimension': 102.0, 'cardinality': 1680.0}, 'cat_path': './/categories/unique.movieId.parquet', 'num_buckets': None, 'start_index': 0.0, 'domain': {'min': 0, 'max': 1680}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'userId', 'tags': {<Tags.USER: 'user'>, <Tags.CATEGORICAL: 'categorical'>, <Tags.USER_ID: 'user_id'>}, 'properties': {'embedding_sizes': {'cardinality': 943.0, 'dimension': 74.0}, 'num_buckets': None, 'max_size': 0.0, 'start_index': 0.0, 'freq_threshold': 0.0, 'cat_path': './/categories/unique.userId.parquet', 'domain': {'min': 0, 'max': 943}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'genres', 'tags': {<Tags.ITEM: 'item'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'max_size': 0.0, 'start_index': 0.0, 'num_buckets': None, 'freq_threshold': 0.0, 'embedding_sizes': {'cardinality': 216.0, 'dimension': 32.0}, 'cat_path': './/categories/unique.genres.parquet', 'domain': {'min': 0, 'max': 216}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'TE_movieId_rating', 'tags': {<Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}, {'name': 'userId_count', 'tags': {<Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float32'), 'is_list': False, 'is_ragged': False}, {'name': 'gender', 'tags': {<Tags.USER: 'user'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'max_size': 0.0, 'freq_threshold': 0.0, 'embedding_sizes': {'dimension': 16.0, 'cardinality': 2.0}, 'num_buckets': None, 'start_index': 0.0, 'cat_path': './/categories/unique.gender.parquet', 'domain': {'min': 0, 'max': 2}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'zip_code', 'tags': {<Tags.USER: 'user'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'embedding_sizes': {'cardinality': 795.0, 'dimension': 67.0}, 'freq_threshold': 0.0, 'max_size': 0.0, 'cat_path': './/categories/unique.zip_code.parquet', 'start_index': 0.0, 'num_buckets': None, 'domain': {'min': 0, 'max': 795}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'rating', 'tags': {<Tags.TARGET: 'target'>, <Tags.REGRESSION: 'regression'>}, 'properties': {}, 'dtype': dtype('int64'), 'is_list': False, 'is_ragged': False}, {'name': 'rating_binary', 'tags': {<Tags.BINARY_CLASSIFICATION: 'binary_classification'>, <Tags.TARGET: 'target'>}, 'properties': {}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'age', 'tags': {<Tags.USER: 'user'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'embedding_sizes': {'dimension': 16.0, 'cardinality': 8.0}, 'max_size': 0.0, 'start_index': 0.0, 'num_buckets': None, 'cat_path': './/categories/unique.age.parquet', 'freq_threshold': 0.0, 'domain': {'min': 0, 'max': 8}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'title', 'tags': set(), 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -386,130 +385,19 @@
    "id": "d60873da",
    "metadata": {},
    "source": [
-    "From the schema, we can tell that there are 1681 known movie ids in the dataset.\n",
-    "\n",
-    "Let's us read the file storing the mapping of moveIds to movies and take a closer look at the situation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "d58c9aa5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import cudf\n",
-    "\n",
-    "movieIds = cudf.read_parquet(train.schema.column_schemas['movieId'].properties['cat_path'])"
+    "From the schema, we can tell that the cardinality of `movieId` is 1680. Embedding with `id` of 0 will be used in case an unknown `movieId` is encountered, thus we need to create an embedding table of size 1681."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "e32b861e",
+   "id": "631b669c",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>movieId</th>\n",
-       "      <th>movieId_size</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>50</td>\n",
-       "      <td>495</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>100</td>\n",
-       "      <td>443</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>181</td>\n",
-       "      <td>439</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>258</td>\n",
-       "      <td>412</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1676</th>\n",
-       "      <td>1678</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1677</th>\n",
-       "      <td>1679</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1678</th>\n",
-       "      <td>1680</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1679</th>\n",
-       "      <td>1681</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1680</th>\n",
-       "      <td>1682</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>1681 rows × 2 columns</p>\n",
-       "</div>"
-      ],
       "text/plain": [
-       "     movieId  movieId_size\n",
-       "0       <NA>             0\n",
-       "1         50           495\n",
-       "2        100           443\n",
-       "3        181           439\n",
-       "4        258           412\n",
-       "...      ...           ...\n",
-       "1676    1678             1\n",
-       "1677    1679             1\n",
-       "1678    1680             1\n",
-       "1679    1681             1\n",
-       "1680    1682             1\n",
-       "\n",
-       "[1681 rows x 2 columns]"
+       "1680.0"
       ]
      },
      "execution_count": 6,
@@ -518,17 +406,7 @@
     }
    ],
    "source": [
-    "movieIds"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "26d624d4",
-   "metadata": {},
-   "source": [
-    "The highest movie id in the train dataset is 1682 with movie ID 0 being left for movies not seen in the train set.\n",
-    "\n",
-    "Let's create a mock embedding matrix. In a regular scenario, that is where our pretrained embeddings would go."
+    "train.schema.column_schemas['movieId'].properties['embedding_sizes']['cardinality']"
    ]
   },
   {
@@ -538,7 +416,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pretrained_movie_embs = np.random.random((1682, 64))"
+    "pretrained_movie_embs = np.random.random((1681, 64))"
    ]
   },
   {
@@ -551,7 +429,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c913b600",
+   "id": "f575b14b",
    "metadata": {},
    "source": [
     "## Building the model"
@@ -567,7 +445,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-06-20 21:53:42.628823: W tensorflow/python/util/util.cc:368] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
+      "2022-06-20 22:59:08.470789: W tensorflow/python/util/util.cc:368] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
      ]
     }
    ],
@@ -587,7 +465,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b5e6631",
+   "id": "dbb0df47",
    "metadata": {},
    "source": [
     "## Training"
@@ -600,49 +478,22 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 1/10\n",
-      "89/89 [==============================] - 3s 9ms/step - loss: 0.6258 - auc: 0.6985 - val_loss: 0.6295 - val_auc: 0.6875\n",
-      "Epoch 2/10\n",
-      "89/89 [==============================] - 1s 6ms/step - loss: 0.6152 - auc: 0.7145 - val_loss: 0.6282 - val_auc: 0.6892\n",
-      "Epoch 3/10\n",
-      "89/89 [==============================] - 1s 6ms/step - loss: 0.6129 - auc: 0.7176 - val_loss: 0.6318 - val_auc: 0.6913\n",
-      "Epoch 4/10\n",
-      "89/89 [==============================] - 1s 5ms/step - loss: 0.6070 - auc: 0.7248 - val_loss: 0.6232 - val_auc: 0.6959\n",
-      "Epoch 5/10\n",
-      "89/89 [==============================] - 0s 5ms/step - loss: 0.5961 - auc: 0.7375 - val_loss: 0.6170 - val_auc: 0.7055\n",
-      "Epoch 6/10\n",
-      "89/89 [==============================] - 1s 6ms/step - loss: 0.5831 - auc: 0.7531 - val_loss: 0.6062 - val_auc: 0.7149\n",
-      "Epoch 7/10\n",
-      "89/89 [==============================] - 1s 5ms/step - loss: 0.5736 - auc: 0.7638 - val_loss: 0.6041 - val_auc: 0.7230\n",
-      "Epoch 8/10\n",
-      "89/89 [==============================] - 1s 6ms/step - loss: 0.5683 - auc: 0.7697 - val_loss: 0.5951 - val_auc: 0.7293\n",
-      "Epoch 9/10\n",
-      "89/89 [==============================] - 1s 6ms/step - loss: 0.5650 - auc: 0.7733 - val_loss: 0.5933 - val_auc: 0.7341\n",
-      "Epoch 10/10\n",
-      "89/89 [==============================] - 1s 6ms/step - loss: 0.5630 - auc: 0.7756 - val_loss: 0.5881 - val_auc: 0.7383\n",
-      "CPU times: user 13.1 s, sys: 1.21 s, total: 14.3 s\n",
-      "Wall time: 8.65 s\n"
+     "ename": "NameError",
+     "evalue": "name 'tf' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "File \u001b[0;32m<timed exec>:1\u001b[0m, in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'tf' is not defined"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<keras.callbacks.History at 0x7f0f31131790>"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
     "%%time\n",
     "opt = tf.keras.optimizers.Adagrad(learning_rate=1e-1)\n",
     "model.compile(optimizer=opt, run_eagerly=False, metrics=[tf.keras.metrics.AUC()])\n",
-    "model.fit(train, validation_data=valid, batch_size=1024, epochs=10)"
+    "model.fit(train, batch_size=1024, epochs=10)"
    ]
   },
   {

--- a/examples/usecases/entertainment-with-pretrained-embeddings.ipynb
+++ b/examples/usecases/entertainment-with-pretrained-embeddings.ipynb
@@ -1,60 +1,22 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "3e97432c",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/workspace/examples/usecases\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "!pwd"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "028dc96f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "120df1a2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "os.chdir('/workspace')"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "697d1452",
    "metadata": {},
    "source": [
     "In this use case we will consider how we might train with pretrained embeddings.\n",
     "\n",
-    "Pretrained embeddings can allow our model to include information from other modalities (for instance, we might want to grab CNN descriptors of product images). They can also come from other models that we train on our data. For example, we might train a word2vec model on the sequence of purchased items by a customer and want to include this information in our retrieval or ranking model.\n",
+    "Pretrained embeddings can allow our model to include information from additional modalities (for instance, we might want to grab CNN descriptors of product images). They can also come from other models that we train on our data. For example, we might train a word2vec model on the sequence of purchased items by a customer and want to include this information in our retrieval or ranking model.\n",
     "\n",
-    "The use cases are many, but this particular example will focus just on the technical aspects of working with pretrained embeddings.\n",
+    "The use cases are many, but this particular example will focus on the technical aspects of working with pretrained embeddings.\n",
     "\n",
     "We will use the MovieLens 100k dataset and emulate a scenario where we would have a pretrained embedding for each of the movies in the train dataset."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 1,
    "id": "e8c63b03",
    "metadata": {},
    "outputs": [
@@ -62,18 +24,18 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-06-13 04:02:20.693184: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-13 04:02:20.693584: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-13 04:02:20.693744: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-13 04:02:20.715031: I tensorflow/core/platform/cpu_feature_guard.cc:152] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
+      "2022-06-20 21:53:41.425846: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 21:53:41.426187: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 21:53:41.426330: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 21:53:41.447601: I tensorflow/core/platform/cpu_feature_guard.cc:152] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2022-06-13 04:02:20.715735: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-13 04:02:20.715924: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-13 04:02:20.716074: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-13 04:02:21.398757: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-13 04:02:21.398961: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-13 04:02:21.399109: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-13 04:02:21.399237: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 24576 MB memory:  -> device: 0, name: Quadro RTX 8000, pci bus id: 0000:08:00.0, compute capability: 7.5\n"
+      "2022-06-20 21:53:41.448630: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 21:53:41.448815: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 21:53:41.448955: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 21:53:42.147476: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 21:53:42.147681: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 21:53:42.147825: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 21:53:42.147955: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 24576 MB memory:  -> device: 0, name: Quadro RTX 8000, pci bus id: 0000:08:00.0, compute capability: 7.5\n"
      ]
     }
    ],
@@ -90,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "id": "13fed8bb",
    "metadata": {},
    "outputs": [
@@ -109,8 +71,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "ffcd098e",
+   "execution_count": 3,
+   "id": "e5400a9a",
    "metadata": {},
    "outputs": [
     {
@@ -119,7 +81,7 @@
        "'rating_binary'"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -130,28 +92,278 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3955ab52",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>name</th>\n",
+       "      <th>tags</th>\n",
+       "      <th>dtype</th>\n",
+       "      <th>is_list</th>\n",
+       "      <th>is_ragged</th>\n",
+       "      <th>properties.num_buckets</th>\n",
+       "      <th>properties.freq_threshold</th>\n",
+       "      <th>properties.max_size</th>\n",
+       "      <th>properties.start_index</th>\n",
+       "      <th>properties.cat_path</th>\n",
+       "      <th>properties.embedding_sizes.cardinality</th>\n",
+       "      <th>properties.embedding_sizes.dimension</th>\n",
+       "      <th>properties.domain.min</th>\n",
+       "      <th>properties.domain.max</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>movieId</td>\n",
+       "      <td>(Tags.ITEM, Tags.CATEGORICAL, Tags.ITEM_ID)</td>\n",
+       "      <td>int32</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>.//categories/unique.movieId.parquet</td>\n",
+       "      <td>1681.0</td>\n",
+       "      <td>102.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1681.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>userId</td>\n",
+       "      <td>(Tags.CATEGORICAL, Tags.USER, Tags.USER_ID)</td>\n",
+       "      <td>int32</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>.//categories/unique.userId.parquet</td>\n",
+       "      <td>944.0</td>\n",
+       "      <td>74.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>944.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>genres</td>\n",
+       "      <td>(Tags.CATEGORICAL, Tags.ITEM)</td>\n",
+       "      <td>int32</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>.//categories/unique.genres.parquet</td>\n",
+       "      <td>217.0</td>\n",
+       "      <td>33.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>217.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>TE_movieId_rating</td>\n",
+       "      <td>(Tags.CONTINUOUS)</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>userId_count</td>\n",
+       "      <td>(Tags.CONTINUOUS)</td>\n",
+       "      <td>float32</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>gender</td>\n",
+       "      <td>(Tags.CATEGORICAL, Tags.USER)</td>\n",
+       "      <td>int32</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>.//categories/unique.gender.parquet</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>16.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>3.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>zip_code</td>\n",
+       "      <td>(Tags.CATEGORICAL, Tags.USER)</td>\n",
+       "      <td>int32</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>.//categories/unique.zip_code.parquet</td>\n",
+       "      <td>796.0</td>\n",
+       "      <td>67.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>796.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>rating</td>\n",
+       "      <td>(Tags.TARGET, Tags.REGRESSION)</td>\n",
+       "      <td>int64</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>rating_binary</td>\n",
+       "      <td>(Tags.TARGET, Tags.BINARY_CLASSIFICATION)</td>\n",
+       "      <td>int32</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>age</td>\n",
+       "      <td>(Tags.CATEGORICAL, Tags.USER)</td>\n",
+       "      <td>int32</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>.//categories/unique.age.parquet</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>16.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>9.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>title</td>\n",
+       "      <td>()</td>\n",
+       "      <td>float64</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "[{'name': 'movieId', 'tags': {<Tags.ITEM: 'item'>, <Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM_ID: 'item_id'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'max_size': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.movieId.parquet', 'embedding_sizes': {'cardinality': 1681.0, 'dimension': 102.0}, 'domain': {'min': 0, 'max': 1681}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'userId', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.USER: 'user'>, <Tags.USER_ID: 'user_id'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'max_size': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.userId.parquet', 'embedding_sizes': {'cardinality': 944.0, 'dimension': 74.0}, 'domain': {'min': 0, 'max': 944}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'genres', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM: 'item'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'max_size': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.genres.parquet', 'embedding_sizes': {'cardinality': 217.0, 'dimension': 33.0}, 'domain': {'min': 0, 'max': 217}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'TE_movieId_rating', 'tags': {<Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}, {'name': 'userId_count', 'tags': {<Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float32'), 'is_list': False, 'is_ragged': False}, {'name': 'gender', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.USER: 'user'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'max_size': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.gender.parquet', 'embedding_sizes': {'cardinality': 3.0, 'dimension': 16.0}, 'domain': {'min': 0, 'max': 3}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'zip_code', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.USER: 'user'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'max_size': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.zip_code.parquet', 'embedding_sizes': {'cardinality': 796.0, 'dimension': 67.0}, 'domain': {'min': 0, 'max': 796}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'rating', 'tags': {<Tags.TARGET: 'target'>, <Tags.REGRESSION: 'regression'>}, 'properties': {}, 'dtype': dtype('int64'), 'is_list': False, 'is_ragged': False}, {'name': 'rating_binary', 'tags': {<Tags.TARGET: 'target'>, <Tags.BINARY_CLASSIFICATION: 'binary_classification'>}, 'properties': {}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'age', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.USER: 'user'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0.0, 'max_size': 0.0, 'start_index': 0.0, 'cat_path': './/categories/unique.age.parquet', 'embedding_sizes': {'cardinality': 9.0, 'dimension': 16.0}, 'domain': {'min': 0, 'max': 9}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'title', 'tags': set(), 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train.schema"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "d60873da",
    "metadata": {},
    "source": [
-    "From the schema, we can tell that there are 1681 known movie ids in the dataset. The movideId to movie mapping is stored in `.//categories/unique.movieId.parquet`. Let's read the file and take a closer look at the situation."
+    "From the schema, we can tell that there are 1681 known movie ids in the dataset.\n",
+    "\n",
+    "Let's us read the file storing the mapping of moveIds to movies and take a closer look at the situation."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "d58c9aa5",
    "metadata": {},
    "outputs": [],
    "source": [
     "import cudf\n",
     "\n",
-    "movieIds = cudf.read_parquet('.//categories/unique.movieId.parquet')"
+    "movieIds = cudf.read_parquet(train.schema.column_schemas['movieId'].properties['cat_path'])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "e32b861e",
    "metadata": {},
    "outputs": [
@@ -258,7 +470,7 @@
        "[1681 rows x 2 columns]"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -279,7 +491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "cc919e80",
    "metadata": {},
    "outputs": [],
@@ -297,7 +509,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "id": "22af1945",
    "metadata": {},
    "outputs": [
@@ -305,13 +517,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-06-13 04:02:21.868740: W tensorflow/python/util/util.cc:368] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
+      "2022-06-20 21:53:42.628823: W tensorflow/python/util/util.cc:368] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
      ]
     }
    ],
    "source": [
     "model = mm.DCNModel(\n",
-    "train.schema,\n",
+    "    train.schema,\n",
     "    depth=2,\n",
     "    deep_block=mm.MLPBlock([64, 32]),\n",
     "    prediction_tasks=mm.BinaryClassificationTask(target_column),\n",
@@ -325,7 +537,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "id": "f9d78213",
    "metadata": {},
    "outputs": [
@@ -334,36 +546,36 @@
      "output_type": "stream",
      "text": [
       "Epoch 1/10\n",
-      "89/89 [==============================] - 3s 9ms/step - loss: 0.6272 - auc: 0.6957 - val_loss: 0.6297 - val_auc: 0.6856\n",
+      "89/89 [==============================] - 3s 9ms/step - loss: 0.6258 - auc: 0.6985 - val_loss: 0.6295 - val_auc: 0.6875\n",
       "Epoch 2/10\n",
-      "89/89 [==============================] - 1s 6ms/step - loss: 0.6159 - auc: 0.7136 - val_loss: 0.6318 - val_auc: 0.6870\n",
+      "89/89 [==============================] - 1s 6ms/step - loss: 0.6152 - auc: 0.7145 - val_loss: 0.6282 - val_auc: 0.6892\n",
       "Epoch 3/10\n",
-      "89/89 [==============================] - 1s 6ms/step - loss: 0.6138 - auc: 0.7162 - val_loss: 0.6323 - val_auc: 0.6888\n",
+      "89/89 [==============================] - 1s 6ms/step - loss: 0.6129 - auc: 0.7176 - val_loss: 0.6318 - val_auc: 0.6913\n",
       "Epoch 4/10\n",
-      "89/89 [==============================] - 1s 6ms/step - loss: 0.6111 - auc: 0.7198 - val_loss: 0.6346 - val_auc: 0.6920\n",
+      "89/89 [==============================] - 1s 5ms/step - loss: 0.6070 - auc: 0.7248 - val_loss: 0.6232 - val_auc: 0.6959\n",
       "Epoch 5/10\n",
-      "89/89 [==============================] - 1s 6ms/step - loss: 0.6045 - auc: 0.7277 - val_loss: 0.6242 - val_auc: 0.6989\n",
+      "89/89 [==============================] - 0s 5ms/step - loss: 0.5961 - auc: 0.7375 - val_loss: 0.6170 - val_auc: 0.7055\n",
       "Epoch 6/10\n",
-      "89/89 [==============================] - 1s 6ms/step - loss: 0.5895 - auc: 0.7456 - val_loss: 0.6092 - val_auc: 0.7096\n",
+      "89/89 [==============================] - 1s 6ms/step - loss: 0.5831 - auc: 0.7531 - val_loss: 0.6062 - val_auc: 0.7149\n",
       "Epoch 7/10\n",
-      "89/89 [==============================] - 1s 6ms/step - loss: 0.5771 - auc: 0.7599 - val_loss: 0.6026 - val_auc: 0.7189\n",
+      "89/89 [==============================] - 1s 5ms/step - loss: 0.5736 - auc: 0.7638 - val_loss: 0.6041 - val_auc: 0.7230\n",
       "Epoch 8/10\n",
-      "89/89 [==============================] - 1s 5ms/step - loss: 0.5698 - auc: 0.7679 - val_loss: 0.5973 - val_auc: 0.7258\n",
+      "89/89 [==============================] - 1s 6ms/step - loss: 0.5683 - auc: 0.7697 - val_loss: 0.5951 - val_auc: 0.7293\n",
       "Epoch 9/10\n",
-      "89/89 [==============================] - 1s 6ms/step - loss: 0.5664 - auc: 0.7717 - val_loss: 0.5990 - val_auc: 0.7311\n",
+      "89/89 [==============================] - 1s 6ms/step - loss: 0.5650 - auc: 0.7733 - val_loss: 0.5933 - val_auc: 0.7341\n",
       "Epoch 10/10\n",
-      "89/89 [==============================] - 1s 6ms/step - loss: 0.5636 - auc: 0.7746 - val_loss: 0.5907 - val_auc: 0.7354\n",
-      "CPU times: user 13 s, sys: 1.15 s, total: 14.2 s\n",
-      "Wall time: 8.7 s\n"
+      "89/89 [==============================] - 1s 6ms/step - loss: 0.5630 - auc: 0.7756 - val_loss: 0.5881 - val_auc: 0.7383\n",
+      "CPU times: user 13.1 s, sys: 1.21 s, total: 14.3 s\n",
+      "Wall time: 8.65 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<keras.callbacks.History at 0x7fe3a516d910>"
+       "<keras.callbacks.History at 0x7f0f31131790>"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/usecases/entertainment-with-pretrained-embeddings.ipynb
+++ b/examples/usecases/entertainment-with-pretrained-embeddings.ipynb
@@ -66,18 +66,18 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-06-20 22:59:07.349291: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 22:59:07.349672: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 22:59:07.349814: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 22:59:07.371153: I tensorflow/core/platform/cpu_feature_guard.cc:152] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
+      "2022-06-20 23:18:09.855239: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 23:18:09.855574: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 23:18:09.855716: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 23:18:09.877888: I tensorflow/core/platform/cpu_feature_guard.cc:152] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2022-06-20 22:59:07.372053: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 22:59:07.372248: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 22:59:07.372388: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 22:59:08.070431: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 22:59:08.070625: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 22:59:08.070768: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2022-06-20 22:59:08.070899: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 24576 MB memory:  -> device: 0, name: Quadro RTX 8000, pci bus id: 0000:08:00.0, compute capability: 7.5\n"
+      "2022-06-20 23:18:09.878993: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 23:18:09.879181: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 23:18:09.879319: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 23:18:10.575950: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 23:18:10.576147: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 23:18:10.576294: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:952] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2022-06-20 23:18:10.576422: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 24576 MB memory:  -> device: 0, name: Quadro RTX 8000, pci bus id: 0000:08:00.0, compute capability: 7.5\n"
      ]
     }
    ],
@@ -179,7 +179,7 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>movieId</td>\n",
-       "      <td>(Tags.ITEM, Tags.CATEGORICAL, Tags.ITEM_ID)</td>\n",
+       "      <td>(Tags.CATEGORICAL, Tags.ITEM, Tags.ITEM_ID)</td>\n",
        "      <td>int32</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
@@ -213,7 +213,7 @@
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>genres</td>\n",
-       "      <td>(Tags.ITEM, Tags.CATEGORICAL)</td>\n",
+       "      <td>(Tags.CATEGORICAL, Tags.ITEM)</td>\n",
        "      <td>int32</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
@@ -368,7 +368,7 @@
        "</div>"
       ],
       "text/plain": [
-       "[{'name': 'movieId', 'tags': {<Tags.ITEM: 'item'>, <Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM_ID: 'item_id'>}, 'properties': {'freq_threshold': 0.0, 'max_size': 0.0, 'embedding_sizes': {'dimension': 102.0, 'cardinality': 1680.0}, 'cat_path': './/categories/unique.movieId.parquet', 'num_buckets': None, 'start_index': 0.0, 'domain': {'min': 0, 'max': 1680}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'userId', 'tags': {<Tags.USER: 'user'>, <Tags.CATEGORICAL: 'categorical'>, <Tags.USER_ID: 'user_id'>}, 'properties': {'embedding_sizes': {'cardinality': 943.0, 'dimension': 74.0}, 'num_buckets': None, 'max_size': 0.0, 'start_index': 0.0, 'freq_threshold': 0.0, 'cat_path': './/categories/unique.userId.parquet', 'domain': {'min': 0, 'max': 943}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'genres', 'tags': {<Tags.ITEM: 'item'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'max_size': 0.0, 'start_index': 0.0, 'num_buckets': None, 'freq_threshold': 0.0, 'embedding_sizes': {'cardinality': 216.0, 'dimension': 32.0}, 'cat_path': './/categories/unique.genres.parquet', 'domain': {'min': 0, 'max': 216}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'TE_movieId_rating', 'tags': {<Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}, {'name': 'userId_count', 'tags': {<Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float32'), 'is_list': False, 'is_ragged': False}, {'name': 'gender', 'tags': {<Tags.USER: 'user'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'max_size': 0.0, 'freq_threshold': 0.0, 'embedding_sizes': {'dimension': 16.0, 'cardinality': 2.0}, 'num_buckets': None, 'start_index': 0.0, 'cat_path': './/categories/unique.gender.parquet', 'domain': {'min': 0, 'max': 2}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'zip_code', 'tags': {<Tags.USER: 'user'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'embedding_sizes': {'cardinality': 795.0, 'dimension': 67.0}, 'freq_threshold': 0.0, 'max_size': 0.0, 'cat_path': './/categories/unique.zip_code.parquet', 'start_index': 0.0, 'num_buckets': None, 'domain': {'min': 0, 'max': 795}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'rating', 'tags': {<Tags.TARGET: 'target'>, <Tags.REGRESSION: 'regression'>}, 'properties': {}, 'dtype': dtype('int64'), 'is_list': False, 'is_ragged': False}, {'name': 'rating_binary', 'tags': {<Tags.BINARY_CLASSIFICATION: 'binary_classification'>, <Tags.TARGET: 'target'>}, 'properties': {}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'age', 'tags': {<Tags.USER: 'user'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'embedding_sizes': {'dimension': 16.0, 'cardinality': 8.0}, 'max_size': 0.0, 'start_index': 0.0, 'num_buckets': None, 'cat_path': './/categories/unique.age.parquet', 'freq_threshold': 0.0, 'domain': {'min': 0, 'max': 8}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'title', 'tags': set(), 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}]"
+       "[{'name': 'movieId', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM: 'item'>, <Tags.ITEM_ID: 'item_id'>}, 'properties': {'freq_threshold': 0.0, 'max_size': 0.0, 'embedding_sizes': {'dimension': 102.0, 'cardinality': 1680.0}, 'cat_path': './/categories/unique.movieId.parquet', 'num_buckets': None, 'start_index': 0.0, 'domain': {'min': 0, 'max': 1680}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'userId', 'tags': {<Tags.USER: 'user'>, <Tags.CATEGORICAL: 'categorical'>, <Tags.USER_ID: 'user_id'>}, 'properties': {'embedding_sizes': {'cardinality': 943.0, 'dimension': 74.0}, 'num_buckets': None, 'max_size': 0.0, 'start_index': 0.0, 'freq_threshold': 0.0, 'cat_path': './/categories/unique.userId.parquet', 'domain': {'min': 0, 'max': 943}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'genres', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM: 'item'>}, 'properties': {'max_size': 0.0, 'start_index': 0.0, 'num_buckets': None, 'freq_threshold': 0.0, 'embedding_sizes': {'cardinality': 216.0, 'dimension': 32.0}, 'cat_path': './/categories/unique.genres.parquet', 'domain': {'min': 0, 'max': 216}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'TE_movieId_rating', 'tags': {<Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}, {'name': 'userId_count', 'tags': {<Tags.CONTINUOUS: 'continuous'>}, 'properties': {}, 'dtype': dtype('float32'), 'is_list': False, 'is_ragged': False}, {'name': 'gender', 'tags': {<Tags.USER: 'user'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'max_size': 0.0, 'freq_threshold': 0.0, 'embedding_sizes': {'dimension': 16.0, 'cardinality': 2.0}, 'num_buckets': None, 'start_index': 0.0, 'cat_path': './/categories/unique.gender.parquet', 'domain': {'min': 0, 'max': 2}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'zip_code', 'tags': {<Tags.USER: 'user'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'embedding_sizes': {'cardinality': 795.0, 'dimension': 67.0}, 'freq_threshold': 0.0, 'max_size': 0.0, 'cat_path': './/categories/unique.zip_code.parquet', 'start_index': 0.0, 'num_buckets': None, 'domain': {'min': 0, 'max': 795}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'rating', 'tags': {<Tags.TARGET: 'target'>, <Tags.REGRESSION: 'regression'>}, 'properties': {}, 'dtype': dtype('int64'), 'is_list': False, 'is_ragged': False}, {'name': 'rating_binary', 'tags': {<Tags.BINARY_CLASSIFICATION: 'binary_classification'>, <Tags.TARGET: 'target'>}, 'properties': {}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'age', 'tags': {<Tags.USER: 'user'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'embedding_sizes': {'dimension': 16.0, 'cardinality': 8.0}, 'max_size': 0.0, 'start_index': 0.0, 'num_buckets': None, 'cat_path': './/categories/unique.age.parquet', 'freq_threshold': 0.0, 'domain': {'min': 0, 'max': 8}}, 'dtype': dtype('int32'), 'is_list': False, 'is_ragged': False}, {'name': 'title', 'tags': set(), 'properties': {}, 'dtype': dtype('float64'), 'is_list': False, 'is_ragged': False}]"
       ]
      },
      "execution_count": 5,
@@ -445,7 +445,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-06-20 22:59:08.470789: W tensorflow/python/util/util.cc:368] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
+      "2022-06-20 23:18:10.978589: W tensorflow/python/util/util.cc:368] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n"
      ]
     }
    ],
@@ -478,15 +478,42 @@
    "metadata": {},
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'tf' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "File \u001b[0;32m<timed exec>:1\u001b[0m, in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'tf' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/10\n",
+      "98/98 [==============================] - 3s 5ms/step - loss: 0.6938 - auc: 0.5001 - regularization_loss: 0.0000e+00\n",
+      "Epoch 2/10\n",
+      "98/98 [==============================] - 1s 5ms/step - loss: 0.6932 - auc: 0.5058 - regularization_loss: 0.0000e+00\n",
+      "Epoch 3/10\n",
+      "98/98 [==============================] - 0s 5ms/step - loss: 0.6931 - auc: 0.5062 - regularization_loss: 0.0000e+00\n",
+      "Epoch 4/10\n",
+      "98/98 [==============================] - 1s 5ms/step - loss: 0.6930 - auc: 0.5090 - regularization_loss: 0.0000e+00\n",
+      "Epoch 5/10\n",
+      "98/98 [==============================] - 1s 5ms/step - loss: 0.6930 - auc: 0.5109 - regularization_loss: 0.0000e+00\n",
+      "Epoch 6/10\n",
+      "98/98 [==============================] - 1s 5ms/step - loss: 0.6929 - auc: 0.5120 - regularization_loss: 0.0000e+00\n",
+      "Epoch 7/10\n",
+      "98/98 [==============================] - 1s 5ms/step - loss: 0.6928 - auc: 0.5148 - regularization_loss: 0.0000e+00\n",
+      "Epoch 8/10\n",
+      "98/98 [==============================] - 0s 5ms/step - loss: 0.6928 - auc: 0.5144 - regularization_loss: 0.0000e+00\n",
+      "Epoch 9/10\n",
+      "98/98 [==============================] - 0s 5ms/step - loss: 0.6927 - auc: 0.5164 - regularization_loss: 0.0000e+00\n",
+      "Epoch 10/10\n",
+      "98/98 [==============================] - 0s 5ms/step - loss: 0.6927 - auc: 0.5170 - regularization_loss: 0.0000e+00\n",
+      "CPU times: user 13.6 s, sys: 1.5 s, total: 15.1 s\n",
+      "Wall time: 8.23 s\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<keras.callbacks.History at 0x7f9abfc2a310>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [

--- a/tests/unit/tf/examples/test_usecase_pretrained_embeddings.py
+++ b/tests/unit/tf/examples/test_usecase_pretrained_embeddings.py
@@ -1,11 +1,11 @@
-import os
-
 from testbook import testbook
 
 from tests.conftest import REPO_ROOT
 
 
-@testbook(REPO_ROOT / "examples/usecases/entertainment-with-pretrained-embeddings.ipynb", execute=False)
+@testbook(
+    REPO_ROOT / "examples/usecases/entertainment-with-pretrained-embeddings.ipynb", execute=False
+)
 def test_usecase_pretrained_embeddings(tb):
     tb.execute()
     model = tb.ref("model")

--- a/tests/unit/tf/examples/test_usecase_pretrained_embeddings.py
+++ b/tests/unit/tf/examples/test_usecase_pretrained_embeddings.py
@@ -1,0 +1,12 @@
+import os
+
+from testbook import testbook
+
+from tests.conftest import REPO_ROOT
+
+
+@testbook(REPO_ROOT / "examples/usecases/entertainment-with-pretrained-embeddings.ipynb", execute=False)
+def test_usecase_pretrained_embeddings(tb):
+    tb.execute()
+    model = tb.ref("model")
+    assert set(model.history.history.keys()) == set(["auc", "loss", "regularization_loss"])


### PR DESCRIPTION
Following the great advice from @rnyak (thank you!!!) I was able to create a use case around using pretrained embeddings.

I use `TensorInitializer` to provide the model with pretrained embeddings for the movies.
```
model = mm.DCNModel(
train.schema,
    depth=2,
    deep_block=mm.MLPBlock([64, 32]),
    prediction_tasks=mm.BinaryClassificationTask(target_column),
    embedding_options=mm.EmbeddingOptions(
        embeddings_initializers={
            "movieId": mm.TensorInitializer(pretrained_movie_embs),
        }
    )
)
```

But while this works, I am not sure that this is what this functionality should look like (I am using preexisting pieces that probably were developed for some other purpose).

The full-blown scenario IMHO should look a little bit more like this:

 - you still can train embeddings from scratch for each of your categorical variables
 - but you can also specify any number of pretrained embedding matrices for any of your categorical features

For instance, in an extreme scenario where you have 3 different shots for each product, you should be able to train a regular embedding for that product, and then feed in each of the 3 pretrained image embeddings for each item.

Something like this
```
    embedding_options=mm.EmbeddingOptions(
        embedding_dims={'product_id': 128}
        embeddings_initializers={
            "product_id_shot_A": mm.TensorInitializer(pretrained_product_id_embs_A),
            "product_id_shot_B": mm.TensorInitializer(pretrained_product_id_embs_B),
            "product_id_shot_C": mm.TensorInitializer(pretrained_product_id_embs_C),
        }
    )
```

where the model would still be able to tie each of the embeddings to the `product_id` (to know which row to fetch for a given example).

This is by all means not finished, just probably another step in the conversation.

resolves #421 