### PR TITLE
Fix pytest marker for integration tests.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,5 +58,6 @@ markers = [
     "implicit",
     "xgboost",
     "example",
-    "integration"
+    "integration",
+    "unit",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ filterwarnings = [
 markers = [
     "datasets",
     "tensorflow",
-    "tensorflow_example",
     "torch",
     "lightfm",
     "implicit",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,21 +78,21 @@ except ModuleNotFoundError:
 def pytest_collection_modifyitems(items):
     for item in items:
         path = item.location[0]
-        if path.startswith("tests/integration"):
+        if "/integration/" in path:
             item.add_marker(pytest.mark.integration)
-        elif path.startswith("tests/unit"):
+        if "/unit/" in path:
             item.add_marker(pytest.mark.unit)
-        if path.startswith("tests/unit/tf"):
+        if "/tf/" in path:
             item.add_marker(pytest.mark.tensorflow)
-            if path.startswith("tests/unit/tf/examples"):
-                item.add_marker(pytest.mark.example)
-        elif path.startswith("tests/unit/torch"):
+        if "/examples/" in path:
+            item.add_marker(pytest.mark.example)
+        if "/torch/" in path:
             item.add_marker(pytest.mark.torch)
-        elif path.startswith("tests/unit/implicit"):
+        if "/implicit/" in path:
             item.add_marker(pytest.mark.implicit)
-        elif path.startswith("tests/unit/lightfm"):
+        if "/lightfm/" in path:
             item.add_marker(pytest.mark.lightfm)
-        elif path.startswith("tests/unit/xgb"):
+        if "/xgb/" in path:
             item.add_marker(pytest.mark.xgboost)
-        elif path.startswith("tests/unit/datasets"):
+        if "/datasets/" in path:
             item.add_marker(pytest.mark.datasets)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,12 +78,14 @@ except ModuleNotFoundError:
 def pytest_collection_modifyitems(items):
     for item in items:
         path = item.location[0]
+        if path.startswith("tests/integration"):
+            item.add_marker(pytest.mark.integration)
+        elif path.startswith("tests/unit"):
+            item.add_marker(pytest.mark.unit)
         if path.startswith("tests/unit/tf"):
             item.add_marker(pytest.mark.tensorflow)
             if path.startswith("tests/unit/tf/examples"):
                 item.add_marker(pytest.mark.example)
-            if path.startswith("tests/unit/tf/integration"):
-                item.add_marker(pytest.mark.integration)
         elif path.startswith("tests/unit/torch"):
             item.add_marker(pytest.mark.torch)
         elif path.startswith("tests/unit/implicit"):


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Follow-up to #474 . The integration test markers were not being set correctly. Looks like they were previously a subdirectory of the unit tests and was moved without updating the marker configuration in conftest.

- Fix markers for integration tests
- Replace `startswith` checks with string in checks to make the markers more robust to directory structure changes.
- Remove unused `tensorflow_example` marker from config in `pyproject.toml`