### PR TITLE
Refactored top-k metrics and created TopKMetricsAggregator for optimized metrics computation

### DIFF
--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -93,7 +93,6 @@ from merlin.models.tf.metrics.topk import (
     PrecisionAt,
     RecallAt,
     TopKMetricsAggregator,
-    topk_metrics_default,
 )
 from merlin.models.tf.models import benchmark
 from merlin.models.tf.models.base import Model, RetrievalModel
@@ -180,7 +179,6 @@ __all__ = [
     "AvgPrecisionAt",
     "RecallAt",
     "TopKMetricsAggregator",
-    "topk_metrics_default",
     "Model",
     "RetrievalModel",
     "InputBlock",

--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -86,13 +86,13 @@ from merlin.models.tf.inputs.embedding import (
     TableConfig,
 )
 from merlin.models.tf.losses import LossType
-from merlin.models.tf.metrics.ranking import (
+from merlin.models.tf.metrics.topk import (
     AvgPrecisionAt,
     MRRAt,
     NDCGAt,
     PrecisionAt,
     RecallAt,
-    ranking_metrics,
+    topk_metrics_default,
 )
 from merlin.models.tf.models import benchmark
 from merlin.models.tf.models.base import Model, RetrievalModel
@@ -178,7 +178,7 @@ __all__ = [
     "MRRAt",
     "AvgPrecisionAt",
     "RecallAt",
-    "ranking_metrics",
+    "topk_metrics_default",
     "Model",
     "RetrievalModel",
     "InputBlock",

--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -92,6 +92,7 @@ from merlin.models.tf.metrics.topk import (
     NDCGAt,
     PrecisionAt,
     RecallAt,
+    TopKMetricsAggregator,
     topk_metrics_default,
 )
 from merlin.models.tf.models import benchmark
@@ -178,6 +179,7 @@ __all__ = [
     "MRRAt",
     "AvgPrecisionAt",
     "RecallAt",
+    "TopKMetricsAggregator",
     "topk_metrics_default",
     "Model",
     "RetrievalModel",

--- a/merlin/models/tf/metrics/topk.py
+++ b/merlin/models/tf/metrics/topk.py
@@ -15,13 +15,13 @@
 #
 
 # Adapted from source code: https://github.com/karlhigley/ranking-metrics-torch
-from typing import List, Optional, Sequence
+from typing import List, Optional, Sequence, Union
 
 import tensorflow as tf
 from keras.utils import losses_utils, metrics_utils
 from keras.utils.tf_utils import is_tensor_or_variable
 from tensorflow.keras import backend
-from tensorflow.keras.metrics import Mean
+from tensorflow.keras.metrics import Mean, Metric
 from tensorflow.keras.metrics import get as get_metric
 
 from merlin.models.tf.metrics import metrics_registry
@@ -184,30 +184,45 @@ def mrr_at(
     return results
 
 
+class TopkMetricWithLabelRelevantCountsMixin:
+    @property
+    def label_relevant_counts(self) -> tf.Tensor:
+        return self._label_relevant_counts
+
+    @label_relevant_counts.setter
+    def label_relevant_counts(self, new_value: tf.Tensor):
+        self._label_relevant_counts = new_value
+
+
 @tf.keras.utils.register_keras_serializable(package="merlin.models")
-class RankingMetric(Mean):
+class TopkMetric(Mean, TopkMetricWithLabelRelevantCountsMixin):
     def __init__(self, fn, k=5, pre_sorted=True, name=None, dtype=None, **kwargs):
         if name is not None:
             name = f"{name}_{k}"
         super().__init__(name=name, dtype=dtype)
         self._fn = fn
         self.k = k
-        self.pre_sorted = pre_sorted
+        self._pre_sorted = pre_sorted
         self._fn_kwargs = kwargs
+        self.label_relevant_counts = None
+
+    @property
+    def pre_sorted(self):
+        return self._pre_sorted
+
+    @pre_sorted.setter
+    def pre_sorted(self, new_value):
+        self._pre_sorted = new_value
 
     def update_state(
         self,
         y_true: tf.Tensor,
         y_pred: tf.Tensor,
-        label_relevant_counts: Optional[tf.Tensor] = None,
         sample_weight: Optional[tf.Tensor] = None,
     ):
         y_true, y_pred = self.check_cast_inputs(y_true, y_pred)
         (
-            [
-                y_true,
-                y_pred,
-            ],
+            [y_true, y_pred],
             sample_weight,
         ) = metrics_utils.ragged_assert_compatible_and_get_flat_values(
             [y_true, y_pred], sample_weight
@@ -217,12 +232,12 @@ class RankingMetric(Mean):
         tf.debugging.assert_greater_equal(
             tf.shape(y_true)[1],
             self.k,
-            f"The ranking metric ({self.name}) cutoff ({self.k}) cannot be smaller than "
+            f"The TopkMetric {self.name} cutoff ({self.k}) cannot be smaller than "
             f"the number of predictions per example",
         )
 
         y_pred, y_true, label_relevant_counts = self._maybe_sort_top_k(
-            y_pred, y_true, label_relevant_counts
+            y_pred, y_true, self.label_relevant_counts
         )
 
         ag_fn = tf.__internal__.autograph.tf_convert(
@@ -264,7 +279,7 @@ class RankingMetric(Mean):
     def get_config(self):
         config = {}
 
-        if type(self) is RankingMetric:
+        if type(self) is TopkMetric:
             # Only include function argument when the object is of a subclass.
             config["fn"] = self._fn
             config["k"] = self.k
@@ -272,7 +287,7 @@ class RankingMetric(Mean):
 
             for k, v in self._fn_kwargs.items():
                 config[k] = backend.eval(v) if is_tensor_or_variable(v) else v
-            base_config = super(RankingMetric, self).get_config()
+            base_config = super(TopkMetric, self).get_config()
             return dict(list(base_config.items()) + list(config.items()))
 
         return {}
@@ -282,43 +297,126 @@ class RankingMetric(Mean):
         fn = config.pop("fn", None)
         k = config.pop("k", None)
         pre_sorted = config.pop("pre_sorted", None)
-        if cls is RankingMetric:
+        if cls is TopkMetric:
             return cls(get_metric(fn), k=k, pre_sorted=pre_sorted, **config)
-        return super(RankingMetric, cls).from_config(config)
+        return super(TopkMetric, cls).from_config(config)
 
 
 @metrics_registry.register_with_multiple_names("recall_at", "recall")
-class RecallAt(RankingMetric):
+class RecallAt(TopkMetric):
     def __init__(self, k=10, pre_sorted=False, name="recall_at"):
         super().__init__(recall_at, k=k, pre_sorted=pre_sorted, name=name)
 
 
 @metrics_registry.register_with_multiple_names("precision_at", "precision")
-class PrecisionAt(RankingMetric):
+class PrecisionAt(TopkMetric):
     def __init__(self, k=10, pre_sorted=False, name="precision_at"):
         super().__init__(precision_at, k=k, pre_sorted=pre_sorted, name=name)
 
 
 @metrics_registry.register_with_multiple_names("map_at", "map")
-class AvgPrecisionAt(RankingMetric):
+class AvgPrecisionAt(TopkMetric):
     def __init__(self, k=10, pre_sorted=False, name="map_at"):
         super().__init__(average_precision_at, k=k, pre_sorted=pre_sorted, name=name)
 
 
 @metrics_registry.register_with_multiple_names("mrr_at", "mrr")
-class MRRAt(RankingMetric):
+class MRRAt(TopkMetric):
     def __init__(self, k=10, pre_sorted=False, name="mrr_at"):
         super().__init__(mrr_at, k=k, pre_sorted=pre_sorted, name=name)
 
 
 @metrics_registry.register_with_multiple_names("ndcg_at", "ndcg")
-class NDCGAt(RankingMetric):
+class NDCGAt(TopkMetric):
     def __init__(self, k=10, pre_sorted=False, name="ndcg_at"):
         super().__init__(ndcg_at, k=k, pre_sorted=pre_sorted, name=name)
 
 
-def ranking_metrics(top_ks: Sequence[int], **kwargs) -> Sequence[RankingMetric]:
-    metrics: List[RankingMetric] = []
+class TopKMetricsAggregator(Metric, TopkMetricWithLabelRelevantCountsMixin):
+    """Aggregator for top-k metrics (TopkMetric) that is optimized
+    to sort top-k predictions only once for all metrics.
+
+    topk_metrics : Sequence[TopkMetric]
+        Multiple arguments with TopkMetric instances
+    """
+
+    def __init__(self, topk_metrics: Sequence[TopkMetric]):
+        super(TopKMetricsAggregator, self).__init__()
+        assert len(topk_metrics) > 0, "At least one topk_metrics should be provided"
+        assert all(
+            isinstance(m, TopkMetric) for m in topk_metrics
+        ), "All provided metrics should inherit from TopkMetric"
+        self.topk_metrics = list(topk_metrics)
+
+        # Setting the `pre_sorted` of topk metrics so that
+        # prediction scores are not sorted again for each metric
+        for metric in self.topk_metrics:
+            metric.pre_sorted = True
+
+        self.k = max([m.k for m in self.topk_metrics])
+
+        self.label_relevant_counts = None
+
+    def update_state(
+        self, y_true: tf.Tensor, y_pred: tf.Tensor, sample_weight: Optional[tf.Tensor] = None
+    ):
+        # Extractubg sorted top-k prediction scores and labels only ONCE
+        # so that sorting does not need to happen for each individual metric
+        # (as the top-k metrics have been set with pre_sorted=True in this constructor
+        y_pred, y_true, label_relevant_counts_from_targets = extract_topk(self.k, y_pred, y_true)
+
+        # If label_relevant_counts is not set by a block (e.g. TopKIndexBlock) that
+        # has already extracted the top-k predictions, it is assumed that
+        # y_true contains all items
+        label_relevant_counts = self.label_relevant_counts
+        if label_relevant_counts is None:
+            label_relevant_counts = label_relevant_counts_from_targets
+
+        for metric in self.topk_metrics:
+            # Sets the label_relevant_counts using a property,
+            # as metric.update_state() should have standard signature
+            # for better compatibility with Keras
+            metric.label_relevant_counts = label_relevant_counts
+            metric.update_state(y_true, y_pred, sample_weight)
+
+    def result(self):
+        outputs = {}
+        for metric in self.topk_metrics:
+            outputs[metric.name] = metric.result()
+
+        return outputs
+
+
+def topk_metrics_default(top_ks: Sequence[int], **kwargs) -> Sequence[TopkMetric]:
+    metrics: List[TopkMetric] = []
     for k in top_ks:
         metrics.extend([RecallAt(k), MRRAt(k), NDCGAt(k), AvgPrecisionAt(k), PrecisionAt(k)])
-    return metrics
+    # Using Top-k metrics aggregator provides better performance than having top-k
+    # metrics computed separately, as prediction scores are sorted only once for all metrics
+    aggregator = TopKMetricsAggregator(metrics)
+    return [aggregator]
+
+
+def filter_topk_metrics(
+    metrics: Sequence[Metric],
+) -> List[Union[TopkMetric, TopKMetricsAggregator]]:
+    """Returns only top-k metrics from the list of metrics
+
+    Parameters
+    ----------
+    metrics : List[Metric]
+        List of metrics
+
+    Returns
+    -------
+    List[Union[TopkMetric, TopKMetricsAggregator]]
+        List with the top-k metrics in the list of input metrics
+    """
+    topk_metrics = list(
+        [
+            metric
+            for metric in metrics
+            if isinstance(metric, TopkMetric) or isinstance(metric, TopKMetricsAggregator)
+        ]
+    )
+    return topk_metrics

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -17,7 +17,7 @@ from merlin.models.tf.blocks.core.transformations import AsDenseFeatures
 from merlin.models.tf.dataset import BatchedDataset
 from merlin.models.tf.inputs.base import InputBlock
 from merlin.models.tf.losses.base import loss_registry
-from merlin.models.tf.metrics.ranking import RankingMetric
+from merlin.models.tf.metrics.topk import filter_topk_metrics
 from merlin.models.tf.models.utils import parse_prediction_tasks
 from merlin.models.tf.prediction_tasks.base import ParallelPredictionBlock, PredictionTask
 from merlin.models.tf.utils.search_utils import find_all_instances_in_layers
@@ -465,9 +465,7 @@ class Model(tf.keras.Model):
         # Run backwards pass.
         self.optimizer.minimize(loss, self.trainable_variables, tape=tape)
 
-        metrics = self.compute_metrics(
-            x, outputs.targets, outputs.predictions, sample_weight, training=True
-        )
+        metrics = self.compute_metrics(outputs, sample_weight, training=True)
         # Adding regularization loss to metrics
         metrics["regularization_loss"] = tf.reduce_sum(cast_losses_to_common_dtype(self.losses))
 
@@ -485,9 +483,7 @@ class Model(tf.keras.Model):
             outputs = self.pre_eval_topk.call_outputs(outputs)
 
         self.compute_loss(x, outputs.targets, outputs.predictions, sample_weight)
-        metrics = self.compute_metrics(
-            x, outputs.targets, outputs.predictions, sample_weight, training=False
-        )
+        metrics = self.compute_metrics(outputs, sample_weight, training=False)
         # Adding regularization loss to metrics
         metrics["regularization_loss"] = tf.reduce_sum(cast_losses_to_common_dtype(self.losses))
 
@@ -496,25 +492,18 @@ class Model(tf.keras.Model):
     @tf.function
     def compute_metrics(
         self,
-        x: tf.Tensor,
-        y: tf.Tensor,
-        y_pred: tf.Tensor,
+        prediction_outputs: PredictionOutput,
         sample_weight: tf.Tensor,
         training: bool,
     ) -> Dict[str, tf.Tensor]:
-        """Overrides default Keras Model.compute_metrics()
-           to compute metrics each N steps (and not for all steps)
-           during training
+        """Overrides Model.compute_metrics() for some custom behaviour
+           like compute metrics each N steps during training
+           and allowing to feed additional information required by specific metrics
 
         Parameters
         ----------
-        x : tf.Tensor
-            Input features. Not used, and kept only to align with the signature
-            of super Model.compute_metrics()
-        y : tf.Tensor
-            Target values
-        y_pred : tf.Tensor
-            Predictions values
+        prediction_outputs : PredictionOutput
+            Contains properties with targets and predictions
         sample_weight : tf.Tensor
             Sample weights for weighted metrics
         training : bool
@@ -526,10 +515,26 @@ class Model(tf.keras.Model):
         Dict[str, tf.Tensor]
             Dict with the metrics values
         """
-        del x
-        # During training updates metric states each N steps
-        if self._should_compute_train_metrics_for_batch or not training:
-            self.compiled_metrics.update_state(y, y_pred, sample_weight)
+
+        should_compute_metrics = self._should_compute_train_metrics_for_batch or not training
+        if should_compute_metrics:
+
+            # This ensures that compiled metrics are built
+            # to make self.compiled_metrics.metrics available
+            if not self.compiled_metrics.built:
+                self.compiled_metrics.build(
+                    prediction_outputs.predictions, prediction_outputs.targets
+                )
+
+            # Providing label_relevant_counts for TopkMetrics, as metric.update_state()
+            # should have standard signature for better compatibility with Keras methods
+            # like self.compiled_metrics.update_state()
+            for topk_metric in filter_topk_metrics(self.compiled_metrics.metrics):
+                topk_metric.label_relevant_counts = prediction_outputs.label_relevant_counts
+
+            self.compiled_metrics.update_state(
+                prediction_outputs.targets, prediction_outputs.predictions, sample_weight
+            )
         # Returns the current value of metrics
         metrics = self.metrics_results()
         return metrics
@@ -733,7 +738,6 @@ class RetrievalModel(Model):
         return_dict=False,
         **kwargs,
     ):
-        self.has_ranking_metric = any(isinstance(m, RankingMetric) for m in self.metrics)
         self.has_item_corpus = False
 
         if item_corpus:
@@ -748,13 +752,18 @@ class RetrievalModel(Model):
                 item_block = self.retrieval_block.item_block()
 
                 if not getattr(self, "pre_eval_topk", None):
-                    ranking_metrics = list(
-                        [metric for metric in self.metrics if isinstance(metric, RankingMetric)]
-                    )
+                    topk_metrics = filter_topk_metrics(self.metrics)
+                    if len(topk_metrics) == 0:
+                        # TODO: Decouple the evaluation of RetrievalModel from the need of using
+                        # at least one TopkMetric (how to infer the k for TopKIndexBlock?)
+                        raise ValueError(
+                            "RetrievalModel evaluation requires at least "
+                            "one TopkMetric (e.g., RecallAt(5), NDCGAt(10))."
+                        )
                     self.pre_eval_topk = TopKIndexBlock.from_block(
                         item_block,
                         data=item_corpus,
-                        k=tf.reduce_max([metric.k for metric in ranking_metrics]),
+                        k=tf.reduce_max([metric.k for metric in topk_metrics]),
                         context=self.context,
                         **kwargs,
                     )
@@ -892,11 +901,9 @@ class RetrievalModel(Model):
 
         if isinstance(item_corpus, merlin.io.Dataset):
             if not k:
-                ranking_metrics = list(
-                    [metric for metric in self.metrics if isinstance(metric, RankingMetric)]
-                )
-                if ranking_metrics:
-                    k = tf.reduce_max([metric.k for metric in ranking_metrics])
+                topk_metrics = filter_topk_metrics(self.metrics)
+                if topk_metrics:
+                    k = tf.reduce_max([metric.k for metric in topk_metrics])
                 else:
                     raise ValueError("You must specify a k for the Top-k Recommender.")
 

--- a/merlin/models/tf/prediction_tasks/retrieval.py
+++ b/merlin/models/tf/prediction_tasks/retrieval.py
@@ -23,7 +23,7 @@ from merlin.models.tf.blocks.core.transformations import LogitsTemperatureScaler
 from merlin.models.tf.blocks.retrieval.base import ItemRetrievalScorer
 from merlin.models.tf.blocks.sampling.base import ItemSampler
 from merlin.models.tf.blocks.sampling.in_batch import InBatchSampler
-from merlin.models.tf.metrics.ranking import ranking_metrics
+from merlin.models.tf.metrics.topk import topk_metrics_default
 from merlin.models.tf.prediction_tasks.classification import MultiClassClassificationTask
 from merlin.models.utils import schema_utils
 from merlin.schema import Schema, Tags
@@ -62,7 +62,7 @@ class ItemRetrievalTask(MultiClassClassificationTask):
     """
 
     DEFAULT_LOSS = "categorical_crossentropy"
-    DEFAULT_METRICS = ranking_metrics(top_ks=[10])
+    DEFAULT_METRICS = topk_metrics_default(top_ks=[10])
 
     def __init__(
         self,

--- a/merlin/models/tf/prediction_tasks/retrieval.py
+++ b/merlin/models/tf/prediction_tasks/retrieval.py
@@ -23,7 +23,7 @@ from merlin.models.tf.blocks.core.transformations import LogitsTemperatureScaler
 from merlin.models.tf.blocks.retrieval.base import ItemRetrievalScorer
 from merlin.models.tf.blocks.sampling.base import ItemSampler
 from merlin.models.tf.blocks.sampling.in_batch import InBatchSampler
-from merlin.models.tf.metrics.topk import topk_metrics_default
+from merlin.models.tf.metrics.topk import TopKMetricsAggregator
 from merlin.models.tf.prediction_tasks.classification import MultiClassClassificationTask
 from merlin.models.utils import schema_utils
 from merlin.schema import Schema, Tags
@@ -62,7 +62,7 @@ class ItemRetrievalTask(MultiClassClassificationTask):
     """
 
     DEFAULT_LOSS = "categorical_crossentropy"
-    DEFAULT_METRICS = topk_metrics_default(top_ks=[10])
+    DEFAULT_METRICS = TopKMetricsAggregator.default_metrics(top_ks=[10])
 
     def __init__(
         self,

--- a/tests/unit/tf/metrics/test_metrics_topk.py
+++ b/tests/unit/tf/metrics/test_metrics_topk.py
@@ -159,7 +159,7 @@ def test_topk_metrics_aggregator(topk_metrics_test_data):
 
     metric_names, metrics, expected_results = zip(*metric_exp_result)
     labels, predictions, label_relevant_counts = topk_metrics_test_data
-    topk_metrics_aggregator = TopKMetricsAggregator(metrics)
+    topk_metrics_aggregator = TopKMetricsAggregator(*metrics)
     topk_metrics_aggregator.label_relevant_counts = label_relevant_counts
     topk_metrics_aggregator.update_state(labels, predictions, None)
 

--- a/tests/unit/tf/metrics/test_metrics_topk.py
+++ b/tests/unit/tf/metrics/test_metrics_topk.py
@@ -20,12 +20,13 @@ import pytest
 import tensorflow as tf
 from sklearn.metrics import ndcg_score as ndcg_score_sklearn
 
-from merlin.models.tf.metrics.ranking import (
+from merlin.models.tf.metrics.topk import (
     AvgPrecisionAt,
     MRRAt,
     NDCGAt,
     PrecisionAt,
     RecallAt,
+    TopKMetricsAggregator,
     average_precision_at,
     dcg_at,
     mrr_at,
@@ -37,24 +38,24 @@ from merlin.models.tf.utils.tf_utils import extract_topk
 
 
 @pytest.fixture
-def ranking_metrics_test_data():
+def topk_metrics_test_data():
     labels = tf.convert_to_tensor([[0, 1, 0, 1, 0], [1, 0, 0, 1, 0], [0, 0, 0, 0, 1]], tf.float32)
     predictions = tf.convert_to_tensor(
         [[10, 9, 8, 7, 6], [1, 4, 3, 2, 5], [10, 9, 8, 7, 6]], tf.float32
     )
-    label_relevant_counts = tf.convert_to_tensor([2, 2, 0], tf.float32)
+    label_relevant_counts = tf.convert_to_tensor([2, 2, 1], tf.float32)
     return labels, predictions, label_relevant_counts
 
 
 @pytest.fixture
-def ranking_metrics_test_data_pre_sorted(ranking_metrics_test_data):
-    labels, predictions, label_relevant_counts = ranking_metrics_test_data
+def topk_metrics_test_data_pre_sorted(topk_metrics_test_data):
+    labels, predictions, _ = topk_metrics_test_data
     predictions, labels, label_relevant_counts = extract_topk(5, predictions, labels)
     return labels, predictions, label_relevant_counts
 
 
-def test_ranking_metrics_not_pre_sorted(ranking_metrics_test_data):
-    labels, predictions, _ = ranking_metrics_test_data
+def test_topk_metrics_pre_sorted(topk_metrics_test_data_pre_sorted):
+    labels, predictions, _ = topk_metrics_test_data_pre_sorted
 
     metric = RecallAt(k=4, pre_sorted=True)
 
@@ -63,16 +64,16 @@ def test_ranking_metrics_not_pre_sorted(ranking_metrics_test_data):
     assert "you must provide label_relevant_counts argument" in str(excinfo.value)
 
 
-def test_recall_at_k(ranking_metrics_test_data_pre_sorted):
-    labels, predictions, label_relevant_counts = ranking_metrics_test_data_pre_sorted
+def test_recall_at_k(topk_metrics_test_data_pre_sorted):
+    labels, predictions, label_relevant_counts = topk_metrics_test_data_pre_sorted
     result = recall_at(labels, predictions, label_relevant_counts, k=4)
 
-    expected_result = [2 / 2, 1 / 2, 0]  # The last example has 0 relevant items
+    expected_result = [2 / 2, 1 / 2, 0 / 1]  # The last example has 0 relevant items
     tf.assert_equal(result, expected_result)
 
 
-def test_precision_at_k(ranking_metrics_test_data_pre_sorted):
-    labels, predictions, label_relevant_counts = ranking_metrics_test_data_pre_sorted
+def test_precision_at_k(topk_metrics_test_data_pre_sorted):
+    labels, predictions, label_relevant_counts = topk_metrics_test_data_pre_sorted
     k = 4
     result = precision_at(labels, predictions, label_relevant_counts, k=k)
 
@@ -80,8 +81,8 @@ def test_precision_at_k(ranking_metrics_test_data_pre_sorted):
     tf.assert_equal(result, expected_result)
 
 
-def test_average_precision_at(ranking_metrics_test_data_pre_sorted):
-    labels, predictions, label_relevant_counts = ranking_metrics_test_data_pre_sorted
+def test_average_precision_at(topk_metrics_test_data_pre_sorted):
+    labels, predictions, label_relevant_counts = topk_metrics_test_data_pre_sorted
     result = average_precision_at(labels, predictions, label_relevant_counts, k=4)
 
     # Averaged precision at the position of relevant items among top-k,
@@ -94,8 +95,8 @@ def dcg_probe(pos_relevant, relevant_score=1):
     return relevant_score / math.log(pos_relevant + 1, 2)
 
 
-def test_dcg_at(ranking_metrics_test_data_pre_sorted):
-    labels, predictions, label_relevant_counts = ranking_metrics_test_data_pre_sorted
+def test_dcg_at(topk_metrics_test_data_pre_sorted):
+    labels, predictions, label_relevant_counts = topk_metrics_test_data_pre_sorted
     result = dcg_at(labels, predictions, label_relevant_counts, k=4)
     expected_result = [
         dcg_probe(2) + dcg_probe(4),
@@ -105,8 +106,8 @@ def test_dcg_at(ranking_metrics_test_data_pre_sorted):
     tf.debugging.assert_near(result, expected_result)
 
 
-def test_ndcg_at(ranking_metrics_test_data_pre_sorted):
-    labels, predictions, label_relevant_counts = ranking_metrics_test_data_pre_sorted
+def test_ndcg_at(topk_metrics_test_data_pre_sorted):
+    labels, predictions, label_relevant_counts = topk_metrics_test_data_pre_sorted
     result = ndcg_at(labels, predictions, label_relevant_counts, k=4)
     expected_result = [
         (dcg_probe(2) + dcg_probe(4)) / (dcg_probe(1) + dcg_probe(2)),
@@ -120,8 +121,8 @@ def test_ndcg_at(ranking_metrics_test_data_pre_sorted):
     tf.debugging.assert_near(tf.cast(result_sklearn, tf.float32), tf.reduce_mean(expected_result))
 
 
-def test_mrr_at(ranking_metrics_test_data_pre_sorted):
-    labels, predictions, label_relevant_counts = ranking_metrics_test_data_pre_sorted
+def test_mrr_at(topk_metrics_test_data_pre_sorted):
+    labels, predictions, label_relevant_counts = topk_metrics_test_data_pre_sorted
     result = mrr_at(labels, predictions, label_relevant_counts, k=4)
     expected_result = [1 / 2, 1 / 4, 0]  # The last example has 0 relevant items
     tf.debugging.assert_near(result, expected_result)
@@ -137,41 +138,58 @@ def test_mrr_at(ranking_metrics_test_data_pre_sorted):
         (NDCGAt(k=4), 0.30499637),
     ],
 )
-def test_ranking_metrics_classes(ranking_metrics_test_data_pre_sorted, metric_exp_result):
-    labels, predictions, label_relevant_counts = ranking_metrics_test_data_pre_sorted
+def test_topk_metrics_classes(topk_metrics_test_data_pre_sorted, metric_exp_result):
+
+    labels, predictions, label_relevant_counts = topk_metrics_test_data_pre_sorted
     metric, expected_result = metric_exp_result
-
-    metric.update_state(labels, predictions, label_relevant_counts)
-
+    metric.label_relevant_counts = label_relevant_counts
+    metric.update_state(labels, predictions)
     result = metric.result()
     tf.debugging.assert_near(result, expected_result)
 
 
+def test_topk_metrics_aggregator(topk_metrics_test_data):
+    metric_exp_result = [
+        ("recall_at_4", RecallAt(k=4), 0.5),
+        ("precision_at_4", PrecisionAt(k=4), 0.25),
+        ("map_at_4", AvgPrecisionAt(k=4), 0.20833333),
+        ("mrr_at_4", MRRAt(k=4), 0.25),
+        ("ndcg_at_4", NDCGAt(k=4), 0.30499637),
+    ]
+
+    metric_names, metrics, expected_results = zip(*metric_exp_result)
+    labels, predictions, label_relevant_counts = topk_metrics_test_data
+    topk_metrics_aggregator = TopKMetricsAggregator(metrics)
+    topk_metrics_aggregator.label_relevant_counts = label_relevant_counts
+    topk_metrics_aggregator.update_state(labels, predictions, None)
+
+    results = topk_metrics_aggregator.result()
+    assert set(results.keys()) == set(metric_names)
+    for metric_name, exp_result in zip(metric_names, expected_results):
+        assert results[metric_name] == exp_result
+
+
 @pytest.mark.parametrize(
     "metric_class",
-    [
-        RecallAt,
-        PrecisionAt,
-        AvgPrecisionAt,
-        MRRAt,
-        NDCGAt,
-    ],
+    [RecallAt, PrecisionAt, AvgPrecisionAt, MRRAt, NDCGAt],
 )
-def test_ranking_metrics_classes_pre_or_not_sorted_matches(ranking_metrics_test_data, metric_class):
-    labels, predictions, label_relevant_counts = ranking_metrics_test_data
-    # Pre-sorting predictions and labels by predictions
+def test_topk_metrics_classes_pre_or_not_sorted_matches(
+    topk_metrics_test_data, topk_metrics_test_data_pre_sorted, metric_class
+):
+    labels, predictions, label_relevant_counts = topk_metrics_test_data
+    # Pre-sorting predictions and labels
     predictions_sorted, labels_sorted, label_relevant_counts_sorted = extract_topk(
         4, predictions, labels
     )
 
     metric1 = metric_class(k=4, pre_sorted=True)
-    metric1.update_state(
-        labels_sorted, predictions_sorted, label_relevant_counts=label_relevant_counts_sorted
-    )
+    metric1.label_relevant_counts = label_relevant_counts_sorted
+    metric1.update_state(labels_sorted, predictions_sorted)
     result1 = metric1.result()
 
     metric2 = metric_class(k=4, pre_sorted=False)
-    metric2.update_state(labels, predictions, label_relevant_counts=label_relevant_counts)
+    metric2.label_relevant_counts = label_relevant_counts
+    metric2.update_state(labels, predictions)
     result2 = metric2.result()
 
     tf.assert_equal(result1, result2)

--- a/tests/unit/tf/models/test_retrieval.py
+++ b/tests/unit/tf/models/test_retrieval.py
@@ -3,7 +3,14 @@ import tensorflow as tf
 
 import merlin.models.tf as mm
 from merlin.io import Dataset
-from merlin.models.tf.metrics.ranking import AvgPrecisionAt, MRRAt, NDCGAt, PrecisionAt, RecallAt
+from merlin.models.tf.metrics.topk import (
+    AvgPrecisionAt,
+    MRRAt,
+    NDCGAt,
+    PrecisionAt,
+    RecallAt,
+    TopKMetricsAggregator,
+)
 from merlin.schema import Tags
 
 
@@ -194,6 +201,43 @@ def test_two_tower_retrieval_model_with_metrics(ecommerce_data: Dataset, run_eag
     #         assert losses.history[metric_name][1] >= losses.history[metric_name][0]
     #     elif metric_name in expected_loss_metrics:
     #         assert losses.history[metric_name][1] <= losses.history[metric_name][0]
+
+    metrics = model.evaluate(
+        ecommerce_data, batch_size=10, item_corpus=ecommerce_data, return_dict=True
+    )
+    assert set(metrics.keys()) == set(expected_metrics_all)
+
+
+@pytest.mark.parametrize("run_eagerly", [True, False])
+def test_two_tower_retrieval_model_with_topk_metrics_aggregator(
+    ecommerce_data: Dataset, run_eagerly
+):
+    ecommerce_data.schema = ecommerce_data.schema.remove_by_tag(Tags.TARGET)
+
+    metrics_agg = TopKMetricsAggregator(
+        [RecallAt(5), MRRAt(5), NDCGAt(5), AvgPrecisionAt(5), PrecisionAt(5)]
+    )
+    model = mm.TwoTowerModel(schema=ecommerce_data.schema, query_tower=mm.MLPBlock([128, 64]))
+    model.compile(optimizer="adam", run_eagerly=run_eagerly, metrics=[metrics_agg])
+
+    # Training
+    num_epochs = 2
+    losses = model.fit(
+        ecommerce_data,
+        batch_size=10,
+        epochs=num_epochs,
+        train_metrics_steps=3,
+        validation_data=ecommerce_data,
+        validation_steps=3,
+    )
+    assert len(losses.epoch) == num_epochs
+
+    # Checking train metrics
+    expected_metrics = ["recall_at_5", "mrr_at_5", "ndcg_at_5", "map_at_5", "precision_at_5"]
+    expected_loss_metrics = ["loss", "regularization_loss"]
+    expected_metrics_all = expected_metrics + expected_loss_metrics
+    expected_metrics_valid = [f"val_{k}" for k in expected_metrics_all]
+    assert set(losses.history.keys()) == set(expected_metrics_all + expected_metrics_valid)
 
     metrics = model.evaluate(
         ecommerce_data, batch_size=10, item_corpus=ecommerce_data, return_dict=True

--- a/tests/unit/tf/models/test_retrieval.py
+++ b/tests/unit/tf/models/test_retrieval.py
@@ -215,7 +215,7 @@ def test_two_tower_retrieval_model_with_topk_metrics_aggregator(
     ecommerce_data.schema = ecommerce_data.schema.remove_by_tag(Tags.TARGET)
 
     metrics_agg = TopKMetricsAggregator(
-        [RecallAt(5), MRRAt(5), NDCGAt(5), AvgPrecisionAt(5), PrecisionAt(5)]
+        RecallAt(5), MRRAt(5), NDCGAt(5), AvgPrecisionAt(5), PrecisionAt(5)
     )
     model = mm.TwoTowerModel(schema=ecommerce_data.schema, query_tower=mm.MLPBlock([128, 64]))
     model.compile(optimizer="adam", run_eagerly=run_eagerly, metrics=[metrics_agg])


### PR DESCRIPTION
### Goals :soccer:
This PR improves metrics computation performance (both during training and inference) by sorting predictions only once before computing Top-k metrics. It is an addition improvement on top of #511
It also renames ranking metrics to top-k metrics which is more general (as RecallAt and PrecisionAt are top-k metrics and not ranking metrics).

### Implementation Details :construction:
- The `TopKMetricsAggregator` metric is introduced to aggregate a list of `TopkMetric` and sort predictions only once before computing the top-k metrics.
- I changed the top-k metrics `update_state(self,y_true,y_pred,sample_weight, label_relevant_counts)` to follow the standard Keras signature, by removing the `label_relevant_counts` arg, which cannot be passed to the standard `model.compiled_metrics.update_state()` method we are now using. To be able to pass that info to `TopkMetric` and to `TopKMetricsAggregator` a property`label_relevant_counts` was created for those classes, so that `model.compute_metrics()` can set it for all metrics before calling `update_state()`

### Testing Details :mag:
- Unit tests were updated to reflect the changes
- I ran a performance test on NGC without and with `TopKMetricsAggregator` 
1. Using `model.compile(..., metrics=[RecallAt(100), RecallAt(300), RecallAt(500), MRRAt(100), MRRAt(300), MRRAt(500), NDCGAt(100), NDCGAt(300), NDCGAt(500)])` 
2. Using  `model.compile(..., metrics=[TopKMetricsAggregator([RecallAt(100), RecallAt(300), ...])]`. 

You can see in the following plot that the training throughtput (average examples per second) increases from 40k to 55k when using `TopKMetricsAggregator`. 

![image](https://user-images.githubusercontent.com/504752/173974178-ea5b9f31-b215-4842-9245-7ef4101e4f34.png)

P.s. This test was performed setting `model.fit(..., train_metrics_steps=1)` which computes metrics for each training step. The throughput of this experiment is improved to 97k (see #511) when we set `train_metrics_steps=100`.