### PR TITLE
XGBoost - Use DaskDeviceQuantileDMatrix with GPU Training

### DIFF
--- a/merlin/models/xgb/__init__.py
+++ b/merlin/models/xgb/__init__.py
@@ -76,6 +76,8 @@ class XGBoost:
     def fit(
         self,
         train: Dataset,
+        *,
+        use_quantile=True,
         **train_kwargs,
     ) -> xgb.Booster:
         """Trains the XGBoost Model.
@@ -90,6 +92,11 @@ class XGBoost:
             The training dataset to use to fit the model.
             We will use the column(s) tagged with merlin.schema.Tags.TARGET that match the
             objective as the label(s).
+        use_quantile : bool
+            This param is only relevant when using GPU.  (with
+            tree_method="gpu_hist"). If set to False, will use a
+            `DaskDMatrix`, instead of the default
+            `DaskDeviceQuantileDMatrix`, which is preferred for GPU training.
         **train_kwargs
             Additional keyword arguments passed to the xgboost.train function
 
@@ -109,7 +116,7 @@ class XGBoost:
         )
 
         dmatrix_cls = xgb.dask.DaskDMatrix
-        if self.params.get("tree_method") == "gpu_hist":
+        if self.params.get("tree_method") == "gpu_hist" and use_quantile:
             # `DaskDeviceQuantileDMatrix` is a data type specialized
             # for the `gpu_hist` tree method that reduces memory overhead.
             # When training on GPU pipeline, it's preferred over `DaskDMatrix`.

--- a/tests/unit/xgb/test_xgboost.py
+++ b/tests/unit/xgb/test_xgboost.py
@@ -13,8 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import pytest
+from unittest.mock import patch
 
+import pytest
+import xgboost
+
+from merlin.core.dispatch import HAS_GPU
 from merlin.io import Dataset
 from merlin.models.xgb import XGBoost
 
@@ -101,3 +105,24 @@ class TestXGBoost:
         model.fit(social_data)
         model.predict(social_data)
         model.evaluate(social_data)
+
+
+@pytest.mark.skipif(not HAS_GPU, reason="No GPU available")
+@patch("xgboost.dask.train", side_effect=xgboost.dask.train)
+def test_gpu_hist(mock_train, dask_client, music_streaming_data: Dataset):
+    schema = music_streaming_data.schema
+    model = XGBoost(schema, objective="reg:logistic", tree_method="gpu_hist")
+    model.fit(music_streaming_data)
+    model.predict(music_streaming_data)
+    metrics = model.evaluate(music_streaming_data)
+    assert "rmse" in metrics
+
+    assert mock_train.called
+    assert mock_train.call_count == 1
+
+    train_call = mock_train.call_args_list[0]
+    client, params, dtrain = train_call.args
+    assert dask_client == client
+    assert params["tree_method"] == "gpu_hist"
+    assert params["objective"] == "reg:logistic"
+    assert isinstance(dtrain, xgboost.dask.DaskDeviceQuantileDMatrix)


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Fixes #525 

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Use more efficient datatype for training with GPU + XGBoost by default.

The DeviceQuantileDMatrix is recommended when using GPU to reduce memory usage and improve speed of training.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

When `tree_method="gpu_hist"` is used. Automatically switch the datatype used for training from `DaskDMatrix` to `DaskDeviceQuantileDMatrix`.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Test added for the default behaviour with gpu_hist - that the data used for training is of type `DaskDeviceQuantileDMatrix`. And checking that the optional argument added to the fit method `use_quantile=False` can be used to disable this.