### PR TITLE
XGBoost -  Train/eval with features from schema passed in to the constructor

### DIFF
--- a/merlin/models/xgb/__init__.py
+++ b/merlin/models/xgb/__init__.py
@@ -230,6 +230,8 @@ def get_targets(schema: Schema, target_tag: Tags) -> List[str]:
 
 
 def get_features(schema: Schema):
+    """Find feature columns from schema. Returns all non-list column names from the schema
+    that are not tagged as targets."""
     all_target_columns = schema.select_by_tag(Tags.TARGET).column_names
 
     # Ignore list-like columns from schema

--- a/merlin/models/xgb/__init__.py
+++ b/merlin/models/xgb/__init__.py
@@ -243,6 +243,8 @@ def get_features(schema: Schema):
         warnings.warn(f"Ignoring list columns as inputs to XGBoost model: {list_column_names}.")
 
     feature_columns = schema.excluding_by_name(list_column_names + all_target_columns).column_names
+    if len(feature_columns) == 0:
+        raise ValueError("No feature columns found in schema.")
 
     return feature_columns
 

--- a/tests/unit/xgb/test_xgboost.py
+++ b/tests/unit/xgb/test_xgboost.py
@@ -135,3 +135,11 @@ def test_gpu_hist_dmatrix(
     assert params["tree_method"] == "gpu_hist"
     assert params["objective"] == "reg:logistic"
     assert isinstance(dtrain, expected_dtrain_cls)
+
+
+def test_sub_schema(dask_client, music_streaming_data: Dataset):
+    schema = music_streaming_data.schema
+    sub_schema = schema.select_by_name(["session_id", "country", "play_percentage"])
+    model = XGBoost(sub_schema, objective="reg:logistic")
+    model.fit(music_streaming_data)
+    assert model.booster.num_features() == 2

--- a/tests/unit/xgb/test_xgboost.py
+++ b/tests/unit/xgb/test_xgboost.py
@@ -137,9 +137,28 @@ def test_gpu_hist_dmatrix(
     assert isinstance(dtrain, expected_dtrain_cls)
 
 
-def test_sub_schema(dask_client, music_streaming_data: Dataset):
-    schema = music_streaming_data.schema
-    sub_schema = schema.select_by_name(["session_id", "country", "play_percentage"])
-    model = XGBoost(sub_schema, objective="reg:logistic")
-    model.fit(music_streaming_data)
-    assert model.booster.num_features() == 2
+@pytest.mark.usefixtures("dask_client")
+class TestSchema:
+    def test_fit_with_sub_schema(self, music_streaming_data: Dataset):
+        schema = music_streaming_data.schema
+        sub_schema = schema.select_by_name(["session_id", "country", "play_percentage"])
+        model = XGBoost(sub_schema, objective="reg:logistic")
+        model.fit(music_streaming_data)
+        assert model.booster.num_features() == 2
+
+    def test_no_features(self, music_streaming_data: Dataset):
+        schema = music_streaming_data.schema
+        sub_schema = schema.select_by_name(["unknown_feature", "play_percentage"])
+        with pytest.raises(ValueError) as excinfo:
+            XGBoost(sub_schema, objective="reg:logistic")
+        assert "No feature columns found" in str(excinfo.value)
+
+    def test_fit_with_missing_features(self, music_streaming_data: Dataset):
+        schema = music_streaming_data.schema
+        sub_schema = schema.select_by_name(["session_id", "play_percentage"])
+        model = XGBoost(sub_schema, objective="reg:logistic")
+        df = music_streaming_data.to_ddf().compute()
+        new_dataset = Dataset(df[["click", "play_percentage"]])
+        with pytest.raises(KeyError) as excinfo:
+            model.fit(new_dataset)
+        assert "session_id" in str(excinfo)


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Fixes #527

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Update the XGBoost class to match expectations from the other models in Merlin Models. The model constructed should be a function of the arguments passed into the constructor.

This only makes a difference if the schema of the dataset passed into the `fit` method is different from that passed to the `__init__`.

Supports train/eval with features from schema passed in to the constructor, instead of those passed into the `fit` method.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

Figure out the feature column names in the `__init__` method instead of inside the `fit` method.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Adds a test for a sub_schema being used for constructing the class.