### PR TITLE
EmbeddingFeatures - Move embedding table creation from build to __init__

### DIFF
--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -36,6 +36,20 @@ def test_embedding_features(tf_cat_features):
     assert all([emb.shape[-1] == dim for emb in embeddings.values()])
 
 
+def test_embedding_features_tables():
+    feature_config = {
+        "cat_a": mm.FeatureConfig(mm.TableConfig(100, 32, name="cat_a", initializer=None)),
+        "cat_b": mm.FeatureConfig(mm.TableConfig(64, 16, name="cat_b", initializer=None)),
+    }
+    embeddings = mm.EmbeddingFeatures(feature_config)
+
+    assert embeddings.embedding_tables["cat_a"].input_dim == 100
+    assert embeddings.embedding_tables["cat_a"].output_dim == 32
+
+    assert embeddings.embedding_tables["cat_b"].input_dim == 64
+    assert embeddings.embedding_tables["cat_b"].output_dim == 16
+
+
 def test_embedding_features_yoochoose(testing_data: Dataset):
     schema = testing_data.schema.select_by_tag(Tags.CATEGORICAL)
 


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Fixes #530

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Allow inspection of embedding tables before `fit` called on model.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

Moving the embedding table construction from the `build` method to the `__init__` in EmbeddingFeatures.

The keras Embedding layer defers the construction of weights until the `build` method is called. So it's safe to construct these Embedding layers when we create the EmbeddingFeatures

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Adds a test for EmbeddingFeatures to check that we can inspect the embedding tables without calling the layer first. (without the build method being called)
