### PR TITLE
XGBoost - Add evals argument to fit to support eval on datasets other than training

### DIFF
--- a/merlin/models/xgb/__init__.py
+++ b/merlin/models/xgb/__init__.py
@@ -142,6 +142,7 @@ class XGBoost:
             assert isinstance(dataset, Dataset)
             X, y, qid = dataset_to_xy(
                 dataset,
+                self.feature_columns,
                 self.target_columns,
                 self.qid_column,
             )

--- a/tests/unit/xgb/test_xgboost.py
+++ b/tests/unit/xgb/test_xgboost.py
@@ -19,6 +19,7 @@ import pytest
 import xgboost
 
 from merlin.core.dispatch import HAS_GPU
+from merlin.datasets.synthetic import generate_data
 from merlin.io import Dataset
 from merlin.models.xgb import XGBoost
 
@@ -164,9 +165,29 @@ class TestSchema:
         assert "session_id" in str(excinfo)
 
 
-@patch("xgboost.dask.train", side_effect=xgboost.dask.train)
-def test_custom_evals(mock_train, dask_client, music_streaming_data: Dataset):
-    schema = music_streaming_data.schema
-    model = XGBoost(schema, objective="reg:logistic")
-    model.fit(music_streaming_data, evals=[(music_streaming_data, "example")])
-    assert set(model.evals_result.keys()) == {"example"}
+class TestEvals:
+    def test_multiple(self, dask_client):
+        train, valid_a, valid_b = generate_data(
+            "music-streaming", num_rows=100, set_sizes=(0.6, 0.2, 0.2)
+        )
+        model = XGBoost(train.schema, objective="reg:logistic")
+        model.fit(train, evals=[(valid_a, "a"), (valid_b, "b")])
+        assert set(model.evals_result.keys()) == {"a", "b"}
+
+    def test_default(self, dask_client):
+        train = generate_data("music-streaming", num_rows=100)
+        model = XGBoost(train.schema, objective="reg:logistic")
+        model.fit(train)
+        assert set(model.evals_result.keys()) == {"train"}
+
+    def test_train_and_valid(self, dask_client):
+        train, valid = generate_data("music-streaming", num_rows=100, set_sizes=(0.5, 0.5))
+        model = XGBoost(train.schema, objective="reg:logistic")
+        model.fit(train, evals=[(valid, "valid"), (train, "train")])
+        assert set(model.evals_result.keys()) == {"valid", "train"}
+
+    def test_invalid_data(self, dask_client):
+        train, _ = generate_data("music-streaming", num_rows=100, set_sizes=(0.5, 0.5))
+        model = XGBoost(train.schema, objective="reg:logistic")
+        with pytest.raises(AssertionError):
+            model.fit(train, evals=[([], "valid")])

--- a/tests/unit/xgb/test_xgboost.py
+++ b/tests/unit/xgb/test_xgboost.py
@@ -162,3 +162,11 @@ class TestSchema:
         with pytest.raises(KeyError) as excinfo:
             model.fit(new_dataset)
         assert "session_id" in str(excinfo)
+
+
+@patch("xgboost.dask.train", side_effect=xgboost.dask.train)
+def test_custom_evals(mock_train, dask_client, music_streaming_data: Dataset):
+    schema = music_streaming_data.schema
+    model = XGBoost(schema, objective="reg:logistic")
+    model.fit(music_streaming_data, evals=[(music_streaming_data, "example")])
+    assert set(model.evals_result.keys()) == {"example"}


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Fixes #526 

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

A common pattern when using XGBoost is to pass a different dataset (e.g. validation data) to be monitored when training. We would like to support this functionality by allowing users of the XGBoost class to specify these datasets

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

- Adding new parameter evals to the fit method which accepts a list of tuples similar to the evals expected by the xgboost train function. The difference is that we expcect a Merlin Dataset instead of a DMatrix here.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Test added for custom eval. We check the evals result returned by the training.
