### PR TITLE
Adding schema's to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,7 +16,12 @@ recursive-include tests *.parquet
 recursive-include tests *.pbtxt
 recursive-include tests *.py
 
-recursive-include merlin/models *.parquet *.json *.py *.typed
+recursive-include merlin *.json
+recursive-include merlin *.parquet
+recursive-include merlin *.pbtxt
+recursive-include merlin *.py
+
+recursive-include merlin/models *.typed
 
 
 # Ignore notebooks & examples


### PR DESCRIPTION
### Goals :soccer:
This PR fixes a small bug in `MANIFEST.IN` where the schema’s of the various datasets are not made part of the package. 
