### PR TITLE
Add new block EmbeddingTable

### DIFF
--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -81,6 +81,7 @@ from merlin.models.tf.inputs.embedding import (
     ContinuousEmbedding,
     EmbeddingFeatures,
     EmbeddingOptions,
+    EmbeddingTable,
     FeatureConfig,
     SequenceEmbeddingFeatures,
     TableConfig,

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -288,7 +288,7 @@ class EmbeddingTable(EmbeddingTableBase):
 
     def get_config(self):
         config = super().get_config()
-        config["table"] = tf.keras.utils.serialize_keras_object(self.table)
+        config["table"] = tf.keras.layers.serialize(self.table)
         config["combiner"] = self.combiner
 
         return config

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -59,19 +59,11 @@ EMBEDDING_FEATURES_PARAMS_DOCSTRING = """
 """
 
 
-# table = EmbeddingTable(100, col)
-
-# table = EmbeddingTable(100)
-# table.add_feature(col)
-# {"user-id": ..., "item-id": ...}
-
-
 class EmbeddingTableBase(Block):
     def __init__(self, dim: int, col_schema: ColumnSchema, trainable=True, **kwargs):
         super(EmbeddingTableBase, self).__init__(trainable=trainable, **kwargs)
         self.dim = dim
 
-        # Do validation of col_schema
         if not col_schema.int_domain:
             raise ValueError("`col_schema` needs to have a int-domain")
 

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -222,7 +222,7 @@ class EmbeddingTable(EmbeddingTableBase):
         if not col_schema:
             if not name:
                 raise ValueError("`name` is required when not using a ColumnSchema")
-            col_schema = create_categorical_column(name, num_items)
+            col_schema = create_categorical_column(name, num_items - 1)
 
         return cls(dim, col_schema, name=name, **kwargs)
 

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -221,12 +221,11 @@ class EmbeddingTable(EmbeddingTableBase):
                 raise ValueError("`name` is required when not using a ColumnSchema")
             col_schema = create_categorical_column(name, num_items - 1)
 
-        var = tf.Variable(embeddings, trainable=trainable)
         return cls(
             dim,
             col_schema,
             name=name,
-            weights=[var],
+            weights=[tf.Variable(embeddings, trainable=trainable)],
             trainable=trainable,
             **kwargs,
         )

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -202,6 +202,7 @@ class EmbeddingTable(EmbeddingTableBase):
         data: Union[Dataset, DataFrameType],
         trainable=True,
         name=None,
+        col_schema=None,
         **kwargs,
     ):
         """Create From pre-trained embeddings from a Dataset or DataFrame.
@@ -218,7 +219,6 @@ class EmbeddingTable(EmbeddingTableBase):
         initializer = TensorInitializer.from_dataset(data)
         num_items, dim = tuple(initializer._weights.shape)
 
-        col_schema = kwargs.get("col_schema", None)
         if not col_schema:
             if not name:
                 raise ValueError("`name` is required when not using a ColumnSchema")

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -27,7 +27,7 @@ import merlin.io
 from merlin.core.dispatch import DataFrameType
 from merlin.io import Dataset
 from merlin.models.tf.blocks.core.base import Block, BlockType
-from merlin.models.tf.blocks.core.combinators import ParallelBlock, SequentialBlock
+from merlin.models.tf.blocks.core.combinators import SequentialBlock
 from merlin.models.tf.blocks.core.tabular import (
     TABULAR_MODULE_PARAMS_DOCSTRING,
     Filter,

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -224,7 +224,14 @@ class EmbeddingTable(EmbeddingTableBase):
                 raise ValueError("`name` is required when not using a ColumnSchema")
             col_schema = create_categorical_column(name, num_items - 1)
 
-        return cls(dim, col_schema, name=name, embeddings_initializer=initializer, **kwargs)
+        return cls(
+            dim,
+            col_schema,
+            name=name,
+            embeddings_initializer=initializer,
+            trainable=trainable,
+            **kwargs,
+        )
 
     def build(self, input_shapes):
         """Creates state between layer instantiation and layer call.

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -224,7 +224,7 @@ class EmbeddingTable(EmbeddingTableBase):
                 raise ValueError("`name` is required when not using a ColumnSchema")
             col_schema = create_categorical_column(name, num_items - 1)
 
-        return cls(dim, col_schema, name=name, **kwargs)
+        return cls(dim, col_schema, name=name, embeddings_initializer=initializer, **kwargs)
 
     def build(self, input_shapes):
         """Creates state between layer instantiation and layer call.

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -307,6 +307,7 @@ class TensorInitializer(tf.keras.initializers.Initializer):
     def __call__(self, shape: tf.TensorShape, dtype: tf.DType = None, **kwargs) -> tf.Tensor:
         """Returns a tensor object initialized with the tensor
         set in the constructor.
+
         Parameters
         ----------
         shape : tf.TensorShape
@@ -314,6 +315,7 @@ class TensorInitializer(tf.keras.initializers.Initializer):
         dtype : tf.DType, optional
             Optional dtype of the tensor. Only numeric or boolean dtypes are
         supported, by default None
+
         Returns
         -------
         tf.Tensor

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -231,6 +231,10 @@ def df_to_tensor(gdf, dtype=None):
         # matrix which means we had to transpose
         # for the bug above, so untranspose
         x = tf.transpose(x)
+
+    if dtype:
+        return tf.cast(x, dtype)
+
     return x
 
 
@@ -299,7 +303,7 @@ class TensorInitializer(tf.keras.initializers.Initializer):
     """
 
     def __init__(self, weights: Union[tf.Tensor, Any], **kwargs):
-        self._weights = tf.convert_to_tensor(weights)
+        self._weights = tf.constant(weights)
 
     def __call__(self, shape: tf.TensorShape, dtype: tf.DType = None, **kwargs) -> tf.Tensor:
         """Returns a tensor object initialized with the tensor

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -325,7 +325,7 @@ class TensorInitializer(tf.keras.initializers.Initializer):
         return weights
 
     @classmethod
-    def from_dataset(cls, data: Union[Dataset, DataFrameType], **kwargs) -> TensorInitializer:
+    def from_dataset(cls, data: Union[Dataset, DataFrameType], **kwargs) -> "TensorInitializer":
         if hasattr(data, "to_ddf"):
             data = data.to_ddf().compute()
         embeddings = tf_utils.df_to_tensor(data)

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -325,7 +325,7 @@ class TensorInitializer(tf.keras.initializers.Initializer):
         return weights
 
     @classmethod
-    def from_dataset(cls, data: Union[Dataset, DataFrameType], **kwargs):
+    def from_dataset(cls, data: Union[Dataset, DataFrameType], **kwargs) -> TensorInitializer:
         if hasattr(data, "to_ddf"):
             data = data.to_ddf().compute()
         embeddings = tf_utils.df_to_tensor(data)

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -296,19 +296,17 @@ def get_candidate_probs(
     return candidate_probs
 
 
-@tf.keras.utils.register_keras_serializable(package="merlin.models")
 class TensorInitializer(tf.keras.initializers.Initializer):
     """Initializer that returns a tensor (e.g. pre-trained
     embeddings) set in the constructor
     """
 
     def __init__(self, weights: Union[tf.Tensor, Any], **kwargs):
-        self._weights = tf.constant(weights)
+        self._weights = tf.convert_to_tensor(weights)
 
     def __call__(self, shape: tf.TensorShape, dtype: tf.DType = None, **kwargs) -> tf.Tensor:
         """Returns a tensor object initialized with the tensor
         set in the constructor.
-
         Parameters
         ----------
         shape : tf.TensorShape
@@ -316,7 +314,6 @@ class TensorInitializer(tf.keras.initializers.Initializer):
         dtype : tf.DType, optional
             Optional dtype of the tensor. Only numeric or boolean dtypes are
         supported, by default None
-
         Returns
         -------
         tf.Tensor
@@ -330,7 +327,7 @@ class TensorInitializer(tf.keras.initializers.Initializer):
         return weights
 
     @classmethod
-    def from_dataset(cls, data: Union[Dataset, DataFrameType], **kwargs) -> "TensorInitializer":
+    def from_dataset(cls, data: Union[Dataset, DataFrameType], **kwargs):
         if hasattr(data, "to_ddf"):
             data = data.to_ddf().compute()
         embeddings = tf_utils.df_to_tensor(data)
@@ -338,7 +335,7 @@ class TensorInitializer(tf.keras.initializers.Initializer):
         return cls(weights=embeddings, **kwargs)
 
     def get_config(self):  # To support serialization
-        return {"weights": self._weights.numpy()}
+        return {"weights": self._weights}
 
 
 def call_layer(layer: tf.keras.layers.Layer, inputs, *args, **kwargs):

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -292,6 +292,7 @@ def get_candidate_probs(
     return candidate_probs
 
 
+@tf.keras.utils.register_keras_serializable(package="merlin.models")
 class TensorInitializer(tf.keras.initializers.Initializer):
     """Initializer that returns a tensor (e.g. pre-trained
     embeddings) set in the constructor

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -334,7 +334,7 @@ class TensorInitializer(tf.keras.initializers.Initializer):
         return cls(weights=embeddings, **kwargs)
 
     def get_config(self):  # To support serialization
-        return {"weights": self._weights}
+        return {"weights": self._weights.numpy()}
 
 
 def call_layer(layer: tf.keras.layers.Layer, inputs, *args, **kwargs):

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -156,8 +156,8 @@ class TestEmbeddingTable:
         np.testing.assert_array_almost_equal(embeddings_before_fit, embeddings_after_fit)
 
     def test_pretrained_embedding_table(self, music_streaming_data: Dataset):
-        vocab_size = 16
-        embedding_dim = 10
+        vocab_size = music_streaming_data.schema.column_schemas["item_id"].int_domain.max + 1
+        embedding_dim = 32
         weights = np.random.rand(vocab_size, embedding_dim)
         pre_trained_weights_df = pd.DataFrame(weights)
 
@@ -165,12 +165,12 @@ class TestEmbeddingTable:
             pre_trained_weights_df, name="item_id", trainable=False
         )
 
-        assert embedding_table.input_dim == 16
+        assert embedding_table.input_dim == vocab_size
 
         inputs = tf.constant([1])
         output = embedding_table(inputs)
 
-        assert list(output.shape) == [1, 10]
+        assert list(output.shape) == [1, embedding_dim]
         np.testing.assert_array_almost_equal(weights, embedding_table.table.embeddings)
 
         model = mm.Model(

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -15,6 +15,7 @@
 #
 
 import numpy as np
+import pandas as pd
 import pytest
 import tensorflow as tf
 from tensorflow.keras.initializers import RandomUniform
@@ -22,9 +23,8 @@ from tensorflow.keras.initializers import RandomUniform
 import merlin.models.tf as mm
 from merlin.io import Dataset
 from merlin.models.tf.utils import testing_utils
-from merlin.schema import ColumnSchema, Tags
-
 from merlin.models.tf.utils.testing_utils import model_test
+from merlin.schema import ColumnSchema, Tags
 
 
 def test_embedding_features(tf_cat_features):
@@ -135,7 +135,20 @@ class TestEmbeddingTable:
         pass
 
     def test_pretrained_embedding_table(self):
-        pass
+        vocab_size = 16
+        embedding_dim = 10
+        weights = np.random.rand(vocab_size, embedding_dim)
+        pre_trained_weights_df = pd.DataFrame(weights)
+
+        embedding_table = mm.EmbeddingTable.from_pretrained(pre_trained_weights_df, name="item_id")
+
+        assert embedding_table.input_dim == 16
+
+        inputs = tf.constant([1])
+        output = embedding_table(inputs)
+
+        assert list(output.shape) == [1, 10]
+        np.testing.assert_array_almost_equal(weights, embedding_table.table.embeddings)
 
 
 def test_embedding_features_yoochoose(testing_data: Dataset):

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -127,7 +127,7 @@ class TestEmbeddingTable:
         model = mm.Model(
             tf.keras.layers.Lambda(lambda features: features["item_id"]),
             embedding_layer,
-            mm.BinaryClassificationTask("click")
+            mm.BinaryClassificationTask("click"),
         )
         model_test(model, music_streaming_data)
 


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Relates to https://github.com/NVIDIA-Merlin/Merlin/issues/404

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Support flexible embedding table use. Including pre-trained embeddings and different embedding layer implementations.


### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

Adds new block called `EmbeddingTable` which wraps the keras Embedding layer.
  
This block is constructed from a dim (output dimension for the embeddings)  and a column schema (which specifies the input dimension. 

Can be called with:
- sparse or ragged tensors with a `combiner` (e.g. mean)
- dense or ragged tensors without a combiner
 
### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
