### PR TITLE
Enable serialization of TensorInitializer

### DIFF
--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -330,7 +330,7 @@ class TensorInitializer(tf.keras.initializers.Initializer):
         return weights
 
     @classmethod
-    def from_dataset(cls, data: Union[Dataset, DataFrameType], **kwargs):
+    def from_dataset(cls, data: Union[Dataset, DataFrameType], **kwargs) -> "TensorInitializer":
         if hasattr(data, "to_ddf"):
             data = data.to_ddf().compute()
         embeddings = tf_utils.df_to_tensor(data)

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -338,7 +338,7 @@ class TensorInitializer(tf.keras.initializers.Initializer):
         return cls(weights=embeddings, **kwargs)
 
     def get_config(self):  # To support serialization
-        return {"weights": self._weights}
+        return {"weights": self._weights.numpy()}
 
 
 def call_layer(layer: tf.keras.layers.Layer, inputs, *args, **kwargs):

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -296,6 +296,7 @@ def get_candidate_probs(
     return candidate_probs
 
 
+@tf.keras.utils.register_keras_serializable(package="merlin.models")
 class TensorInitializer(tf.keras.initializers.Initializer):
     """Initializer that returns a tensor (e.g. pre-trained
     embeddings) set in the constructor

--- a/tests/unit/tf/utils/test_tf_utils.py
+++ b/tests/unit/tf/utils/test_tf_utils.py
@@ -1,0 +1,38 @@
+import numpy as np
+import tensorflow as tf
+
+from merlin.models.tf.utils import tf_utils
+
+
+class TestTensorInitializer:
+    def test_serialize(self):
+        shape = (10, 1)
+        initializer = tf_utils.TensorInitializer(np.random.rand(*shape).astype(np.float32))
+        variable = tf.keras.backend.variable(initializer(shape))
+        output = tf.keras.backend.get_value(variable)
+
+        config = tf.keras.initializers.serialize(initializer)
+        reloaded_initializer = tf.keras.initializers.deserialize(config)
+
+        variable = tf.keras.backend.variable(reloaded_initializer(shape))
+        output_2 = tf.keras.backend.get_value(variable)
+
+        np.testing.assert_array_almost_equal(output, output_2)
+
+    def test_model_load(self, tmpdir):
+        shape = (10, 1)
+        initializer = tf_utils.TensorInitializer(np.random.rand(*shape))
+
+        inputs = tf.keras.Input((10,))
+        outputs = tf.keras.layers.Dense(1, kernel_initializer=initializer)(inputs)
+        model = tf.keras.models.Model(inputs, outputs)
+
+        input_tensor = tf.constant(np.random.rand(1, 10))
+
+        output = model(input_tensor).numpy()
+
+        model.save(tmpdir)
+        reloaded_model = tf.keras.models.load_model(tmpdir)
+        output_2 = reloaded_model(input_tensor).numpy()
+
+        np.testing.assert_array_almost_equal(output, output_2)


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Allow `TensorInitializer` to be saved and reloaded when used in a model.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

The `TensorInitializer` currently fails to re-load without providing `custom_objects`. And fails to save to disk when saving a model.

- Adding serializable decorator to allow loading without specifying custom_objects
- Returning numpy representation of tensor when constructing config

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Adding a test for serializing and deserializing the initializer. And with a saved model. 