### PR TITLE
Make blocks part of Model and not of SequentialBlock

### DIFF
--- a/merlin/models/config/schema.py
+++ b/merlin/models/config/schema.py
@@ -21,7 +21,6 @@ from merlin.schema import ColumnSchema, Schema, Tags
 
 class SchemaMixin:
     REQUIRES_SCHEMA = False
-    # _has_custom__call__ = True
 
     def set_schema(self, schema=None):
         self.check_schema(schema=schema)
@@ -53,10 +52,10 @@ class SchemaMixin:
         if self.REQUIRES_SCHEMA and not getattr(self, "_schema", None) and not schema:
             raise ValueError(f"{self.__class__.__name__} requires a schema.")
 
-    # def __call__(self, *args, **kwargs):
-    #     self.check_schema()
-    #
-    #     return super().__call__(*args, **kwargs)
+    def __call__(self, *args, **kwargs):
+        self.check_schema()
+
+        return super().__call__(*args, **kwargs)
 
     def _maybe_set_schema(self, input, schema):
         if input and getattr(input, "set_schema", None):

--- a/merlin/models/config/schema.py
+++ b/merlin/models/config/schema.py
@@ -21,6 +21,7 @@ from merlin.schema import ColumnSchema, Schema, Tags
 
 class SchemaMixin:
     REQUIRES_SCHEMA = False
+    # _has_custom__call__ = True
 
     def set_schema(self, schema=None):
         self.check_schema(schema=schema)
@@ -52,10 +53,10 @@ class SchemaMixin:
         if self.REQUIRES_SCHEMA and not getattr(self, "_schema", None) and not schema:
             raise ValueError(f"{self.__class__.__name__} requires a schema.")
 
-    def __call__(self, *args, **kwargs):
-        self.check_schema()
-
-        return super().__call__(*args, **kwargs)
+    # def __call__(self, *args, **kwargs):
+    #     self.check_schema()
+    #
+    #     return super().__call__(*args, **kwargs)
 
     def _maybe_set_schema(self, input, schema):
         if input and getattr(input, "set_schema", None):

--- a/merlin/models/tf/blocks/core/base.py
+++ b/merlin/models/tf/blocks/core/base.py
@@ -152,8 +152,6 @@ class ContextMixin:
         return self._context
 
     def _set_context(self, context: ModelContext):
-        if hasattr(self, "_context"):
-            context._merge(self._context)
         self._context: ModelContext = context
 
 

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -237,7 +237,7 @@ class EmbeddingTable(EmbeddingTableBase):
         self.table._maybe_build(inputs)
         return super(EmbeddingTable, self)._maybe_build(inputs)
 
-    def call(self, inputs):
+    def call(self, inputs, **kwargs):
         """
         Parameters
         ----------

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -646,18 +646,20 @@ class Model(BaseModel):
         super(Model, self).__init__(**kwargs)
         context = context or ModelContext()
         if len(blocks) == 1 and isinstance(blocks[0], SequentialBlock):
-            self.block = blocks[0]
-        else:
-            self.block = SequentialBlock(blocks, context=context, block_name="blocks")
-        if not getattr(self.block, "_context", None):
-            self.block._set_context(context)
+            blocks = blocks[0].layers
+
+        self.blocks = blocks
+        for block in self.submodules:
+            if hasattr(block, "_set_context"):
+                block._set_context(context)
+
         self.pre = pre
         self.post = post
         self.context = context
         self._is_fitting = False
 
         input_block_schemas = [
-            block.schema for block in self.block.submodules if getattr(block, "is_input", False)
+            block.schema for block in self.submodules if getattr(block, "is_input", False)
         ]
         self.schema = sum(input_block_schemas, Schema())
 
@@ -669,7 +671,8 @@ class Model(BaseModel):
         if self.pre:
             outputs = call_layer(self.pre, outputs, **kwargs)
 
-        outputs = call_layer(self.block, outputs, **kwargs)
+        for block in self.blocks:
+            outputs = call_layer(block, outputs, **kwargs)
 
         if self.post:
             inputs = call_layer(self.post, outputs, **kwargs)
@@ -678,11 +681,11 @@ class Model(BaseModel):
 
     @property
     def first(self):
-        return self.block.layers[0]
+        return self.blocks[0]
 
     @property
     def last(self):
-        return self.block.layers[-1]
+        return self.blocks[-1]
 
     @classmethod
     def from_block(
@@ -724,14 +727,29 @@ class Model(BaseModel):
 
     @classmethod
     def from_config(cls, config, custom_objects=None):
-        block = tf.keras.utils.deserialize_keras_object(config.pop("block"))
-        config = maybe_deserialize_keras_objects(config, ["pre", "post"])
+        pre = config.pop("pre", None)
+        post = config.pop("post", None)
+        context = config.pop("context", None)
+        layers = [
+            tf.keras.layers.deserialize(conf, custom_objects=custom_objects)
+            for conf in config.values()
+        ]
 
-        return cls(block, **config)
+        if pre is not None:
+            pre = tf.keras.layers.deserialize(pre, custom_objects=custom_objects)
+
+        if post is not None:
+            post = tf.keras.layers.deserialize(post, custom_objects=custom_objects)
+
+        if context is not None:
+            context = tf.keras.layers.deserialize(context, custom_objects=custom_objects)
+
+        return cls(*layers, context=context, pre=pre, post=post)
 
     def get_config(self):
-        config = {"block": tf.keras.utils.serialize_keras_object(self.block)}
-        config = maybe_deserialize_keras_objects(config, ["pre", "post"])
+        config = maybe_deserialize_keras_objects({}, ["pre", "post", "context"])
+        for i, layer in enumerate(self.blocks):
+            config[i] = tf.keras.utils.serialize_keras_object(layer)
 
         return config
 
@@ -825,7 +843,7 @@ class RetrievalModel(Model):
 
     @property
     def retrieval_block(self) -> RetrievalBlock:
-        return next(b for b in self.block if isinstance(b, RetrievalBlock))
+        return next(b for b in self.blocks if isinstance(b, RetrievalBlock))
 
     def query_embeddings(
         self,

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -15,8 +15,8 @@ from merlin.models.config.schema import FeatureCollection
 from merlin.models.tf.blocks.core.base import Block, ModelContext, PredictionOutput, is_input_block
 from merlin.models.tf.blocks.core.combinators import SequentialBlock
 from merlin.models.tf.blocks.core.context import FeatureContext
-from merlin.models.tf.blocks.core.transformations import AsDenseFeatures
 from merlin.models.tf.blocks.core.tabular import TabularBlock
+from merlin.models.tf.blocks.core.transformations import AsDenseFeatures
 from merlin.models.tf.dataset import BatchedDataset
 from merlin.models.tf.inputs.base import InputBlock
 from merlin.models.tf.losses.base import loss_registry
@@ -677,7 +677,8 @@ class Model(BaseModel):
         last_layer = None
 
         if self.pre is not None:
-            input_shape = self.pre.build(input_shape)
+            self.pre.build(input_shape)
+            input_shape = self.pre.compute_output_shape(input_shape)
 
         for layer in self.blocks:
             try:
@@ -694,7 +695,7 @@ class Model(BaseModel):
             last_layer = layer
 
         if self.post is not None:
-            input_shape = self.post.build(input_shape)
+            self.post.build(input_shape)
 
         self.built = True
 

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -765,7 +765,6 @@ class Model(BaseModel):
     def from_config(cls, config, custom_objects=None):
         pre = config.pop("pre", None)
         post = config.pop("post", None)
-        # context = config.pop("context", None)
         layers = [
             tf.keras.layers.deserialize(conf, custom_objects=custom_objects)
             for conf in config.values()
@@ -776,9 +775,6 @@ class Model(BaseModel):
 
         if post is not None:
             post = tf.keras.layers.deserialize(post, custom_objects=custom_objects)
-
-        # if context is not None:
-        #     context = tf.keras.layers.deserialize(context, custom_objects=custom_objects)
 
         return cls(*layers, pre=pre, post=post)
 

--- a/merlin/models/tf/utils/batch_utils.py
+++ b/merlin/models/tf/utils/batch_utils.py
@@ -82,11 +82,11 @@ class TFModelEncode(ModelEncode):
         model_load_func = block_load_func if block_load_func else tf.keras.models.load_model
         if not output_names:
             try:
-                output_names = model.block.last.task_names
+                output_names = model.last.task_names
             except AttributeError:
                 pass
         if not output_concat_func:
-            if len(output_names) == 1:  # type: ignore
+            if output_names and len(output_names) == 1:  # type: ignore
                 output_concat_func = np.concatenate
             else:
                 output_concat_func = get_lib().concat  # type: ignore

--- a/merlin/models/tf/utils/batch_utils.py
+++ b/merlin/models/tf/utils/batch_utils.py
@@ -64,6 +64,8 @@ class ModelEncode:
 
 
 class TFModelEncode(ModelEncode):
+    """Batch-prediction for a model."""
+
     def __init__(
         self,
         model: tp.Union[Model, tf.keras.Model],
@@ -111,8 +113,10 @@ class TFModelEncode(ModelEncode):
 
 
 class ItemEmbeddings(TFModelEncode):
+    """Extract item-embeddings from model"""
+
     def __init__(self, model: Model, batch_size: int = 512, save_path: tp.Optional[str] = None):
-        item_block = model.block.first.item_block()
+        item_block = model.first.item_block()
         schema = item_block.schema
 
         super().__init__(
@@ -125,13 +129,15 @@ class ItemEmbeddings(TFModelEncode):
 
 
 class QueryEmbeddings(TFModelEncode):
+    """Extract query-embeddings from model"""
+
     def __init__(
         self,
         model: RetrievalModel,
         batch_size: int = 512,
         save_path: tp.Optional[str] = None,
     ):
-        query_block = model.block.first.query_block()
+        query_block = model.first.query_block()
         schema = query_block.schema
 
         super().__init__(

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -349,8 +349,11 @@ def call_layer(layer: tf.keras.layers.Layer, inputs, *args, **kwargs):
     filtered_kwargs = filter_kwargs(kwargs, layer, cascade_kwargs_if_possible=True)
 
     if not has_custom_call:
-        filtered_kwargs = filter_kwargs(
-            filtered_kwargs, layer.call, cascade_kwargs_if_possible=True
-        )
+        if isinstance(layer, tf.keras.layers.Lambda):
+            filtered_kwargs = filter_kwargs(kwargs, layer.function, cascade_kwargs_if_possible=True)
+        else:
+            filtered_kwargs = filter_kwargs(
+                filtered_kwargs, layer.call, cascade_kwargs_if_possible=True
+            )
 
     return layer(inputs, *args, **filtered_kwargs)

--- a/tests/unit/tf/blocks/core/test_base.py
+++ b/tests/unit/tf/blocks/core/test_base.py
@@ -36,8 +36,12 @@ class DummyFeaturesBlock(ml.Block):
         items = list(feature_context.features.select_by_tag(Tags.ITEM_ID).values.values())[0]
         emb_table = self.context.get_embedding(Tags.ITEM_ID)
         item_embeddings = tf.gather(emb_table, tf.cast(items, tf.int32))
-        if tf.rank(item_embeddings) == 3:
-            item_embeddings = tf.squeeze(item_embeddings)
+        rank = tf.rank(item_embeddings)
+        if isinstance(rank, tf.Tensor):
+            item_embeddings = tf.cond(tf.equal(rank, 3), lambda: tf.squeeze(item_embeddings), lambda: item_embeddings)
+        else:
+            if rank == 3:
+                item_embeddings = tf.squeeze(item_embeddings)
 
         return inputs * item_embeddings
 
@@ -60,4 +64,4 @@ def test_block_context_model(ecommerce_data: Dataset, run_eagerly: bool):
 
     copy_model, _ = testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)
 
-    assert copy_model.context == copy_model.block.layers[0].context
+    assert copy_model.context == copy_model.blocks[0].context

--- a/tests/unit/tf/blocks/core/test_base.py
+++ b/tests/unit/tf/blocks/core/test_base.py
@@ -38,7 +38,9 @@ class DummyFeaturesBlock(ml.Block):
         item_embeddings = tf.gather(emb_table, tf.cast(items, tf.int32))
         rank = tf.rank(item_embeddings)
         if isinstance(rank, tf.Tensor):
-            item_embeddings = tf.cond(tf.equal(rank, 3), lambda: tf.squeeze(item_embeddings), lambda: item_embeddings)
+            item_embeddings = tf.cond(
+                tf.equal(rank, 3), lambda: tf.squeeze(item_embeddings), lambda: item_embeddings
+            )
         else:
             if rank == 3:
                 item_embeddings = tf.squeeze(item_embeddings)

--- a/tests/unit/tf/blocks/core/test_transformations.py
+++ b/tests/unit/tf/blocks/core/test_transformations.py
@@ -275,5 +275,5 @@ def test_items_weight_tying_with_different_domain_name():
     model = ml.Model(input_block, ml.MLPBlock([64]), weight_tying_block, task)
 
     _ = model(inputs)
-    weight_tying_embeddings = model.block[2].context.get_embedding("joint_item_id")
+    weight_tying_embeddings = model.blocks[2].context.get_embedding("joint_item_id")
     assert weight_tying_embeddings.shape == (101, 64)

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -45,7 +45,7 @@ def test_model_from_block(ecommerce_data: Dataset, run_eagerly):
     )
 
     assert all(
-        [f.table.dim == 32 for f in list(model.block.inputs["categorical"].feature_config.values())]
+        [f.table.dim == 32 for f in list(model.blocks[0]["categorical"].feature_config.values())]
     )
 
     testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)

--- a/tests/unit/tf/utils/test_batch.py
+++ b/tests/unit/tf/utils/test_batch.py
@@ -17,7 +17,7 @@ def test_model_encode(ecommerce_data: Dataset, run_eagerly):
     ddf = data.compute(scheduler="synchronous")
 
     assert len(list(ddf.columns)) == 27
-    assert all([task in list(ddf.columns) for task in model.block.last.task_names])
+    assert all([task in list(ddf.columns) for task in model.last.task_names])
 
 
 def test_two_tower_embedding_extraction(ecommerce_data: Dataset):


### PR DESCRIPTION
### Goals :soccer:
Currently the blocks that are being passed into `Model` will be wrapped into a `SequentialBlock`. This leads to nesting and makes it hard to enable certain functionality down the line that’s contained to the model. 

### Implementation Details :construction:
This PR makes `blocks` part of the `Model`, and the model class will take care of calling those blocks sequentially.

### Testing Details :mag:
All tests are passing
