### PR TITLE
Negative sampling - Fix boolean checks

### DIFF
--- a/merlin/models/tf/core/prediction.py
+++ b/merlin/models/tf/core/prediction.py
@@ -31,9 +31,9 @@ class PredictionContext(NamedTuple):
         self, targets=None, features=None, mask=None, training=None, testing=None
     ) -> "PredictionContext":
         return PredictionContext(
-            features or self.features,
-            targets or self.targets,
-            mask or self.mask,
+            features if features is not None else self.features,
+            targets if targets is not None else self.targets,
+            mask if mask is not None else self.mask,
             training or self.training,
             testing or self.testing,
         )

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -744,8 +744,8 @@ class Model(BaseModel):
 
         outputs = call_layer(child, inputs, **call_kwargs)
         if isinstance(outputs, Prediction):
-            targets = outputs.targets or context.targets
-            features = outputs.features or context.features
+            targets = outputs.targets if outputs.targets is not None else context.targets
+            features = outputs.features if outputs.features is not None else context.features
             outputs = outputs[0]
             context = context.with_updates(targets=targets, features=features)
 

--- a/tests/unit/tf/data_augmentation/test_negative_sampling.py
+++ b/tests/unit/tf/data_augmentation/test_negative_sampling.py
@@ -97,7 +97,8 @@ class TestAddRandomNegativesToBatch:
             for f in with_negatives.values()
         )
 
-    def test_in_model(self, music_streaming_data: Dataset, tf_random_seed: int):
+    @pytest.mark.parametrize("run_eagerly", [True, False])
+    def test_in_model(self, run_eagerly, music_streaming_data: Dataset, tf_random_seed: int):
         dataset = music_streaming_data
         schema = dataset.schema
 
@@ -137,7 +138,7 @@ class TestAddRandomNegativesToBatch:
         without_negatives = model(features)
         assert without_negatives.shape[0] == batch_size
 
-        testing_utils.model_test(model, dataset)
+        testing_utils.model_test(model, dataset, run_eagerly=run_eagerly)
 
     def test_model_with_dataloader(self, music_streaming_data: Dataset, tf_random_seed: int):
         add_negatives = UniformNegativeSampling(music_streaming_data.schema, 5, seed=tf_random_seed)


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Follow-up to #560 

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

- Fix negative sampling layer when running in eager and graph mode.

Using a tensor in an expression like this `targets or self.targets` results in the following error. Using explicit None checks gets around this.

```                                                                                                                                                                                                                                                                                                                                                                                                                                                                       OperatorNotAllowedInGraphError: using a `tf.Tensor` as a Python `bool` is not allowed: AutoGraph did convert this function.
```

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Enable testing for both eager and graph mode for the model test with uniform negative samping layer 