### PR TITLE
Keep Dataloader lazy when using map operations

### DIFF
--- a/merlin/models/loader/backend.py
+++ b/merlin/models/loader/backend.py
@@ -492,7 +492,7 @@ class DataLoader:
                     c = (c, batch_lists)
 
                 batches[n].append(c)
-        return [self._handle_tensors(*batch) for batch in batches]
+        return (self._handle_tensors(*batch) for batch in batches)
 
     def _get_segment_lengths(self, num_samples):
         """


### PR DESCRIPTION
This preserves the iterator nature of BatchedDataset when using a map operation.

<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Improve consistency of dataloader operation when adding map operations.

The BatchedDataset can be iterated through lazily after being constructed. However, if a map is applied, it runs on the whole dataset before returning the first batch,

#### Example

Create example merlin Dataset

```python
import numpy as np
import pandas as pd

dataset_size = 10_000
data_df = pd.DataFrame({"feature": np.random.randint(100, size=dataset_size)})

from merlin.io import Dataset
from merlin.schema import Schema, ColumnSchema, Tags

schema = Schema([ColumnSchema("feature", tags=[Tags.CATEGORICAL])])
dataset = Dataset(data_df, schema=schema)
```

Timing getting the first batch from the dataset with and without the `.map`

```python
import time
import timeit
from merlin.models.tf.dataset import BatchedDataset

# -----------------------------------------------------------------------------
# < 0.1 seconds - without .map

batched_dataset = BatchedDataset(dataset, batch_size=10)
timeit.timeit(lambda: next(batched_dataset), number=1)

# -----------------------------------------------------------------------------
# ~ 100 seconds - with a .map 

batched_dataset = BatchedDataset(dataset, batch_size=10)

def identity(x, y):
    time.sleep(0.1)
    return (x, y)

batched_dataset = batched_dataset.map(identity)
timeit.timeit(lambda: next(batched_dataset), number=1)
```

With this PR, both versions in the above example return in less than or approx. 0.1 seconds (in the case of the time.sleep)

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

Replacing the list comprehension in the Dataloader `make_tensors` method return a generator instead.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Turned the above example into a unit test.