### PR TITLE
Wrap Features in Class for compatibility with ItemRetrievalScorer

### DIFF
--- a/merlin/models/tf/core/prediction.py
+++ b/merlin/models/tf/core/prediction.py
@@ -20,8 +20,16 @@ import tensorflow as tf
 TensorLike = Union[tf.Tensor, tf.SparseTensor, tf.RaggedTensor]
 
 
+class Features:
+    def __init__(self, values: Dict[str, TensorLike]):
+        self.values = values
+
+    def __getitem__(self, key: str) -> TensorLike:
+        return self.values[key]
+
+
 class PredictionContext(NamedTuple):
-    features: Dict[str, TensorLike]
+    features: Features
     targets: Optional[Union[tf.Tensor, Dict[str, tf.Tensor]]] = None
     mask: tf.Tensor = (None,)
     training: bool = False

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -13,7 +13,7 @@ from tensorflow.keras.utils import unpack_x_y_sample_weight
 import merlin.io
 from merlin.models.tf.core.base import Block, ModelContext, PredictionOutput, is_input_block
 from merlin.models.tf.core.combinators import SequentialBlock
-from merlin.models.tf.core.prediction import Prediction, PredictionContext
+from merlin.models.tf.core.prediction import Features, Prediction, PredictionContext
 from merlin.models.tf.core.tabular import TabularBlock
 from merlin.models.tf.core.transformations import AsDenseFeatures, AsRaggedFeatures
 from merlin.models.tf.dataset import BatchedDataset
@@ -730,7 +730,9 @@ class Model(BaseModel):
     def _create_context(
         self, inputs, targets=None, training=False, testing=False
     ) -> PredictionContext:
-        context = PredictionContext(inputs, targets=targets, training=training, testing=testing)
+        context = PredictionContext(
+            Features(inputs), targets=targets, training=training, testing=testing
+        )
 
         return context
 


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Follow up to #554 

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

In #554 ,among other things, we changed the way features are stored and passed around to layers that need the context of the inputs. e.g. the `ItemRetrievalScorer`.

After #554 tests using the `RetrievalModel.evaluate` method started breaking with tensorflow version 2.8.0. (The tests pass with the newer release 2.9.1.)

The error message is:

```
>       metrics = model.evaluate(
            ecommerce_data, batch_size=10, item_corpus=ecommerce_data, return_dict=True
        )

tests/unit/tf/models/test_retrieval.py:244:

merlin/models/tf/models/base.py:878: in evaluate                                                                                                                                                                           
    self.pre_eval_topk = TopKIndexBlock.from_block(
merlin/models/tf/core/index.py:208: in from_block
    return super().from_block(block=block, data=data, id_column=id_column, k=k, **kwargs)  
merlin/models/tf/core/index.py:81: in from_block                                                                                                                                                                            
    embedding_df = cls.get_candidates_dataset(block, data, id_column)
merlin/models/tf/core/index.py:112: in get_candidates_dataset
    model_encode = TFModelEncode(model=block, output_concat_func=np.concatenate)
merlin/models/tf/utils/batch_utils.py:80: in __init__                                                                                                                                                                       
    model.save(save_path)

[...]

>         raise e.ag_error_metadata.to_exception(e)
E         TypeError: in user code:
E
E             File "/usr/local/lib/python3.8/dist-packages/keras/saving/saving_utils.py", line 138, in _wrapped_model  *
E                 outputs = model(*args, **kwargs)
E             File "/workspace/dev/merlin/models/merlin/models/config/schema.py", line 58, in __call__  *
E                 return super().__call__(*args, **kwargs)
E
E             TypeError: tf__call() takes 2 positional arguments but 3 were given
```

The issue is that the model object. In this case the item_block of a two tower model thinks it accepts 2 arguments when actually it only wants one. 

We can check this with the helper function  `model_call_inputs` and a breakpoint in the `RetrievalModel.evaluate` method.  which reports that the item_block has 2 arguments. (The error "_2 positional arguments but 3 were given_" is not 1 vs 2 because of the additional `self` argument.)

```python
from keras.saving.saving_utils import model_call_inputs

len(model_call_inputs(item_block)[0])  # => 2
```

By wrapping the features in a class, somehow this results in the model helper correctly returning 1 instead of 2.

```python
class Features:
    def __init__(self, values: Dict[str, TensorLike]):
        self.values = values

    def __getitem__(self, key: str) -> TensorLike:
        return self.values[key]
```

This is not necessary in tensorflow 2.9.0 and 2.9.1.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Tested on 2.8.0 and 2.9.0 locally

PR #573 extends our testing matrix to check both these versions