### PR TITLE
Fixing bug in saving of two-tower model in TF<2.9

### DIFF
--- a/merlin/models/config/schema.py
+++ b/merlin/models/config/schema.py
@@ -52,10 +52,10 @@ class SchemaMixin:
         if self.REQUIRES_SCHEMA and not getattr(self, "_schema", None) and not schema:
             raise ValueError(f"{self.__class__.__name__} requires a schema.")
 
-    # def __call__(self, *args, **kwargs):
-    #     self.check_schema()
-    #
-    #     return super().__call__(*args, **kwargs)
+    def __call__(self, *args, **kwargs):
+        self.check_schema()
+
+        return super().__call__(*args, **kwargs)
 
     def _maybe_set_schema(self, input, schema):
         if input and getattr(input, "set_schema", None):

--- a/merlin/models/config/schema.py
+++ b/merlin/models/config/schema.py
@@ -52,10 +52,10 @@ class SchemaMixin:
         if self.REQUIRES_SCHEMA and not getattr(self, "_schema", None) and not schema:
             raise ValueError(f"{self.__class__.__name__} requires a schema.")
 
-    def __call__(self, *args, **kwargs):
-        self.check_schema()
-
-        return super().__call__(*args, **kwargs)
+    # def __call__(self, *args, **kwargs):
+    #     self.check_schema()
+    #
+    #     return super().__call__(*args, **kwargs)
 
     def _maybe_set_schema(self, input, schema):
         if input and getattr(input, "set_schema", None):


### PR DESCRIPTION
Fixes #570

### Implementation Details :construction:
The error message is:

```
>       metrics = model.evaluate(
            ecommerce_data, batch_size=10, item_corpus=ecommerce_data, return_dict=True
        )

tests/unit/tf/models/test_retrieval.py:244:

merlin/models/tf/models/base.py:878: in evaluate                                                                                                                                                                           
    self.pre_eval_topk = TopKIndexBlock.from_block(
merlin/models/tf/core/index.py:208: in from_block
    return super().from_block(block=block, data=data, id_column=id_column, k=k, **kwargs)  
merlin/models/tf/core/index.py:81: in from_block                                                                                                                                                                            
    embedding_df = cls.get_candidates_dataset(block, data, id_column)
merlin/models/tf/core/index.py:112: in get_candidates_dataset
    model_encode = TFModelEncode(model=block, output_concat_func=np.concatenate)
merlin/models/tf/utils/batch_utils.py:80: in __init__                                                                                                                                                                       
    model.save(save_path)

[...]

>         raise e.ag_error_metadata.to_exception(e)
E         TypeError: in user code:
E
E             File "/usr/local/lib/python3.8/dist-packages/keras/saving/saving_utils.py", line 138, in _wrapped_model  *
E                 outputs = model(*args, **kwargs)
E             File "/workspace/dev/merlin/models/merlin/models/config/schema.py", line 58, in __call__  *
E                 return super().__call__(*args, **kwargs)
E
E             TypeError: tf__call() takes 2 positional arguments but 3 were given
```

The issue is that the model object. In this case the item_block of a two tower model thinks it accepts 2 arguments when actually it only wants one. 

We can check this with the helper function  `model_call_inputs` and a breakpoint in the `RetrievalModel.evaluate` method.  which reports that the item_block has 2 arguments. (The error "_2 positional arguments but 3 were given_" is not 1 vs 2 because of the additional `self` argument.)


This PR introduces a fix for this by overwriting the mechanism that Keras uses to infer the signature-defs of the model. It turns out that Keras is interpreting kwargs (like features & targets) as required args. This PR fixes this.