### PR TITLE
Add signature checks for various models like two-tower & DLRM

### DIFF
--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -755,6 +755,10 @@ class Model(BaseModel):
     ):
         call_kwargs = context.to_call_dict()
 
+        # Prevent features to be part of signature of model-blocks
+        if any(isinstance(sub, ModelBlock) for sub in child.submodules):
+            del call_kwargs["features"]
+
         outputs = call_layer(child, inputs, **call_kwargs)
         if isinstance(outputs, Prediction):
             targets = outputs.targets if outputs.targets is not None else context.targets

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -31,7 +31,16 @@ def test_simple_model(ecommerce_data: Dataset, run_eagerly):
         ml.BinaryClassificationTask("click"),
     )
 
-    testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)
+    loaded_model, _ = testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)
+
+    signatures = getattr(loaded_model, "signatures", {}) or {}
+    default_signature = signatures.get("serving_default")
+
+    model_inputs = set(default_signature.structured_input_signature[1].keys())
+    assert set(ecommerce_data.schema.column_names) == model_inputs
+
+    model_output = list(default_signature.structured_outputs.keys())[0]
+    assert model_output == "click/binary_classification_task"
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -20,7 +20,7 @@ import merlin.models.tf as ml
 from merlin.datasets.synthetic import generate_data
 from merlin.io.dataset import Dataset
 from merlin.models.tf.utils import testing_utils, tf_utils
-from merlin.schema import Schema
+from merlin.schema import Schema, Tags
 
 
 @pytest.mark.parametrize("run_eagerly", [True])
@@ -33,14 +33,8 @@ def test_simple_model(ecommerce_data: Dataset, run_eagerly):
 
     loaded_model, _ = testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)
 
-    signatures = getattr(loaded_model, "signatures", {}) or {}
-    default_signature = signatures.get("serving_default")
-
-    model_inputs = set(default_signature.structured_input_signature[1].keys())
-    assert set(ecommerce_data.schema.column_names) == model_inputs
-
-    model_output = list(default_signature.structured_outputs.keys())[0]
-    assert model_output == "click/binary_classification_task"
+    features = ecommerce_data.schema.remove_by_tag(Tags.TARGET).column_names
+    testing_utils.test_model_signature(loaded_model, features, ["click/binary_classification_task"])
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])

--- a/tests/unit/tf/models/test_ranking.py
+++ b/tests/unit/tf/models/test_ranking.py
@@ -19,6 +19,7 @@ import pytest
 import merlin.models.tf as ml
 from merlin.io import Dataset
 from merlin.models.tf.utils import testing_utils
+from merlin.schema import Tags
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
@@ -52,7 +53,13 @@ def test_dlrm_model(music_streaming_data, run_eagerly):
         prediction_tasks=ml.BinaryClassificationTask("click"),
     )
 
-    testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
+    loaded_model, _ = testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
+
+    features = testing_utils.get_model_inputs(
+        music_streaming_data.schema.remove_by_tag(Tags.TARGET), ["user_genres", "item_genres"]
+    )
+
+    testing_utils.test_model_signature(loaded_model, features, ["click/binary_classification_task"])
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])

--- a/tests/unit/tf/models/test_retrieval.py
+++ b/tests/unit/tf/models/test_retrieval.py
@@ -12,6 +12,7 @@ from merlin.models.tf.metrics.topk import (
     RecallAt,
     TopKMetricsAggregator,
 )
+from merlin.models.tf.utils import testing_utils
 from merlin.schema import Tags
 from tests.common.tf.retrieval import retrieval_tests_common
 
@@ -53,6 +54,16 @@ def test_two_tower_model(music_streaming_data: Dataset, run_eagerly, num_epochs=
     losses = model.fit(music_streaming_data, batch_size=50, epochs=num_epochs)
     assert len(losses.epoch) == num_epochs
     assert all(measure >= 0 for metric in losses.history for measure in losses.history[metric])
+
+    query_features = testing_utils.get_model_inputs(
+        music_streaming_data.schema.select_by_tag(Tags.USER), ["user_genres"]
+    )
+    testing_utils.test_model_signature(model.first.query_block(), query_features, ["output_1"])
+
+    item_features = testing_utils.get_model_inputs(
+        music_streaming_data.schema.select_by_tag(Tags.ITEM), ["item_genres"]
+    )
+    testing_utils.test_model_signature(model.first.item_block(), item_features, ["output_1"])
 
 
 def test_two_tower_model_l2_reg(testing_data: Dataset):


### PR DESCRIPTION
**Fixes:**
- https://github.com/NVIDIA-Merlin/Merlin/issues/468

### Goals :soccer:
Add some signature-def checks to our model-test, to ensure that the model can be served by Merlin-systems.

### Implementation Details :construction:
Checks are based on [this[(https://github.com/NVIDIA-Merlin/systems/blob/main/merlin/systems/dag/ops/tensorflow.py#L66-L87) of `PredictTensorflow` inside `merlin.systems`.

This PR contains a fix where in the `Model` we check if a child contains any `ModelBlock`s and if so we don’t supply the features argument. The features argument will be added automatically inside the `ModelBlock`. This mechanism ensures that the features kwarg is not added to the model-signuture.

