### PR TITLE
Trying to make model unit-tests faster

### DIFF
--- a/.github/workflows/datasets.yml
+++ b/.github/workflows/datasets.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: '**/**.txt'
+          cache-dependency-path: 'requirements/dev.txt'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/datasets.yml
+++ b/.github/workflows/datasets.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          cache-dependency-path: '**/**.txt'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/datasets.yml
+++ b/.github/workflows/datasets.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/implicit.yml
+++ b/.github/workflows/implicit.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: '**/**.txt'
+          cache-dependency-path: 'requirements/dev.txt'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/implicit.yml
+++ b/.github/workflows/implicit.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          cache-dependency-path: '**/**.txt'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/implicit.yml
+++ b/.github/workflows/implicit.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/lightfm.yml
+++ b/.github/workflows/lightfm.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: '**/**.txt'
+          cache-dependency-path: 'requirements/dev.txt'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/lightfm.yml
+++ b/.github/workflows/lightfm.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          cache-dependency-path: '**/**.txt'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/lightfm.yml
+++ b/.github/workflows/lightfm.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          cache: 'pip'
       - name: Install black Jupyter
         run : |
           pip install black[jupyter]==22.3.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           cache: 'pip'
+          cache-dependency-path: '**/**.txt'
       - name: Install black Jupyter
         run : |
           pip install black[jupyter]==22.3.0

--- a/.github/workflows/pytorch.yml
+++ b/.github/workflows/pytorch.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: '**/**.txt'
+          cache-dependency-path: 'requirements/dev.txt'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/pytorch.yml
+++ b/.github/workflows/pytorch.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          cache-dependency-path: '**/**.txt'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/pytorch.yml
+++ b/.github/workflows/pytorch.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: '**/**.txt'
+          cache-dependency-path: 'requirements/dev.txt'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y
@@ -91,7 +91,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: '**/**.txt'
+          cache-dependency-path: 'requirements/dev.txt'
       - uses: abbbi/github-actions-tune@v1
       - name: Install Ubuntu packages
         run: |

--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y
@@ -88,6 +89,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -25,7 +25,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: 'requirements/dev.txt'
+          cache-dependency-path: |
+            **/setup.cfg
+            requirements/*.txt
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y
@@ -37,7 +39,6 @@ jobs:
           pip install "merlin-core@git+https://github.com/NVIDIA-Merlin/core.git"
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
           python -m pip install "tensorflow<${{ matrix.tf-max }}"
           python -m pip install -e .[tensorflow-dev]
       - name: Build
@@ -91,7 +92,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: 'requirements/dev.txt'
+          cache-dependency-path: |
+            **/setup.cfg
+            requirements/*.txt
       - uses: abbbi/github-actions-tune@v1
       - name: Install Ubuntu packages
         run: |

--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -92,6 +92,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: '**/**.txt'
+      - uses: abbbi/github-actions-tune@v1
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y
@@ -103,7 +104,6 @@ jobs:
           pip install "merlin-core@git+https://github.com/NVIDIA-Merlin/core.git"
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
           python -m pip install -e .[tensorflow-dev]
       - name: Build
         run: |

--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          cache-dependency-path: '**/**.txt'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y
@@ -90,6 +91,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          cache-dependency-path: '**/**.txt'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/xgboost.yml
+++ b/.github/workflows/xgboost.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: '**/**.txt'
+          cache-dependency-path: 'requirements/dev.txt'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/xgboost.yml
+++ b/.github/workflows/xgboost.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          cache-dependency-path: '**/**.txt'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y

--- a/.github/workflows/xgboost.yml
+++ b/.github/workflows/xgboost.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install Ubuntu packages
         run: |
           sudo apt-get update -y

--- a/merlin/models/tf/dataset.py
+++ b/merlin/models/tf/dataset.py
@@ -554,8 +554,13 @@ def sample_batch(
 
     from merlin.models.tf.core.transformations import AsDenseFeatures, AsRaggedFeatures
 
-    batched_dataset = BatchedDataset(data, batch_size=batch_size, shuffle=shuffle)
-    inputs, targets = next(iter(batched_dataset))
+    if not isinstance(data, BatchedDataset):
+        data = BatchedDataset(data, batch_size=batch_size, shuffle=shuffle)
+
+    batch = next(iter(data))
+    # batch could be of type Prediction, so we can't unpack directly
+    inputs, targets = batch[0], batch[1]
+
     if to_ragged:
         inputs = AsRaggedFeatures()(inputs)
     elif to_dense:

--- a/merlin/models/tf/utils/testing_utils.py
+++ b/merlin/models/tf/utils/testing_utils.py
@@ -25,7 +25,7 @@ from keras.utils import tf_inspect
 from tensorflow.python.framework.test_util import disable_cudnn_autotune
 
 import merlin.io
-from merlin.models.tf.dataset import BatchedDataset
+from merlin.models.tf.dataset import BatchedDataset, sample_batch
 from merlin.models.tf.models.base import Model
 from merlin.schema import Schema
 
@@ -80,6 +80,7 @@ def model_test(
     run_eagerly: bool = True,
     optimizer="adam",
     epochs: int = 1,
+    reload_model: bool = False,
     **kwargs,
 ) -> Tuple[Model, Any]:
     """Generic model test. It will compile & fit the model and make sure it can be re-trained."""
@@ -87,25 +88,28 @@ def model_test(
     model.compile(run_eagerly=run_eagerly, optimizer=optimizer, **kwargs)
     losses = model.fit(dataset, batch_size=50, epochs=epochs, steps_per_epoch=1)
 
-    assert len(losses.epoch) == epochs
+    batch = sample_batch(dataset, batch_size=50)
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        model.save(tmpdir)
-        loaded_model = tf.keras.models.load_model(tmpdir)
+    if reload_model:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            model.save(tmpdir)
+            loaded_model = tf.keras.models.load_model(tmpdir)
 
-    assert isinstance(loaded_model, type(model))
+        assert isinstance(loaded_model, type(model))
 
-    np.array_equal(
-        model.predict(dataset, batch_size=50, steps=1),
-        loaded_model.predict(dataset, batch_size=50, steps=1),
-    )
+        np.array_equal(
+            model.predict(batch[0]),
+            loaded_model.predict(batch[0]),
+        )
 
-    loaded_model.compile(run_eagerly=run_eagerly, optimizer=optimizer, **kwargs)
-    losses = loaded_model.fit(dataset, batch_size=50, epochs=epochs, steps_per_epoch=1)
+        loaded_model.compile(run_eagerly=run_eagerly, optimizer=optimizer, **kwargs)
+        loaded_model.train_step(batch)
 
-    assert len(losses.epoch) == epochs
+        return loaded_model, losses
 
-    return loaded_model, losses
+    assert isinstance(model.from_config(model.get_config()), type(model))
+
+    return model, losses
 
 
 def get_model_inputs(schema: Schema, list_cols: Optional[Sequence[str]] = None):

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -108,9 +108,10 @@ def test_train_metrics_steps(
     num_rows, batch_size, train_metrics_steps, expected_steps, expected_metrics_steps
 ):
     dataset = generate_data("e-commerce", num_rows=num_rows)
+    dataset.schema = dataset.schema.select_by_name(["user_id", "click"])
     model = ml.Model(
         ml.InputBlock(dataset.schema),
-        ml.MLPBlock([4]),
+        ml.MLPBlock([2]),
         ml.BinaryClassificationTask("click"),
     )
     model.compile(

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -99,8 +99,8 @@ class MetricsLogger(tf.keras.callbacks.Callback):
     ["num_rows", "batch_size", "train_metrics_steps", "expected_steps", "expected_metrics_steps"],
     [
         (1, 1, 1, 1, 1),
-        # (60, 10, 2, 6, 3),
-        # (60, 10, 3, 6, 2),
+        (60, 10, 2, 6, 3),
+        (60, 10, 3, 6, 2),
         (120, 10, 4, 12, 3),
     ],
 )
@@ -108,10 +108,9 @@ def test_train_metrics_steps(
     num_rows, batch_size, train_metrics_steps, expected_steps, expected_metrics_steps
 ):
     dataset = generate_data("e-commerce", num_rows=num_rows)
-    dataset.schema = dataset.schema.select_by_name(["user_id", "click"])
     model = ml.Model(
         ml.InputBlock(dataset.schema),
-        ml.MLPBlock([2]),
+        ml.MLPBlock([64]),
         ml.BinaryClassificationTask("click"),
     )
     model.compile(

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -27,7 +27,7 @@ from merlin.schema import Schema, Tags
 def test_simple_model(ecommerce_data: Dataset, run_eagerly):
     model = ml.Model(
         ml.InputBlock(ecommerce_data.schema),
-        ml.MLPBlock([64]),
+        ml.MLPBlock([4]),
         ml.BinaryClassificationTask("click"),
     )
 
@@ -39,16 +39,16 @@ def test_simple_model(ecommerce_data: Dataset, run_eagerly):
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_model_from_block(ecommerce_data: Dataset, run_eagerly):
-    embedding_options = ml.EmbeddingOptions(embedding_dim_default=32)
+    embedding_options = ml.EmbeddingOptions(embedding_dim_default=2)
     model = ml.Model.from_block(
-        ml.MLPBlock([64]),
+        ml.MLPBlock([4]),
         ecommerce_data.schema,
         prediction_tasks=ml.BinaryClassificationTask("click"),
         embedding_options=embedding_options,
     )
 
     assert all(
-        [f.table.dim == 32 for f in list(model.blocks[0]["categorical"].feature_config.values())]
+        [f.table.dim == 2 for f in list(model.blocks[0]["categorical"].feature_config.values())]
     )
 
     testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)
@@ -56,7 +56,7 @@ def test_model_from_block(ecommerce_data: Dataset, run_eagerly):
 
 def test_block_from_model_with_input(ecommerce_data: Dataset):
     inputs = ml.InputBlock(ecommerce_data.schema)
-    block = inputs.connect(ml.MLPBlock([64]))
+    block = inputs.connect(ml.MLPBlock([2]))
 
     with pytest.raises(ValueError) as excinfo:
         ml.Model.from_block(
@@ -110,7 +110,7 @@ def test_train_metrics_steps(
     dataset = generate_data("e-commerce", num_rows=num_rows)
     model = ml.Model(
         ml.InputBlock(dataset.schema),
-        ml.MLPBlock([64]),
+        ml.MLPBlock([4]),
         ml.BinaryClassificationTask("click"),
     )
     model.compile(
@@ -140,7 +140,7 @@ def test_train_metrics_steps(
 def test_model_pre_post(ecommerce_data: Dataset, run_eagerly):
     model = ml.Model(
         ml.InputBlock(ecommerce_data.schema),
-        ml.MLPBlock([64]),
+        ml.MLPBlock([4]),
         ml.BinaryClassificationTask("click"),
         post=ml.NoOp(),
     )
@@ -162,7 +162,7 @@ def test_sub_class_model(ecommerce_data: Dataset):
             super(SubClassedModel, self).__init__()
             if "input_block" not in kwargs:
                 self.input_block = ml.InputBlock(schema)
-                self.mlp = ml.MLPBlock([64, 32])
+                self.mlp = ml.MLPBlock([4])
                 self.prediction = ml.BinaryClassificationTask(target)
             else:
                 self.input_block = kwargs["input_block"]

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -23,7 +23,7 @@ from merlin.models.tf.utils import testing_utils, tf_utils
 from merlin.schema import Schema, Tags
 
 
-@pytest.mark.parametrize("run_eagerly", [True])
+@pytest.mark.parametrize("run_eagerly", [False])
 def test_simple_model(ecommerce_data: Dataset, run_eagerly):
     model = ml.Model(
         ml.InputBlock(ecommerce_data.schema),

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -99,8 +99,8 @@ class MetricsLogger(tf.keras.callbacks.Callback):
     ["num_rows", "batch_size", "train_metrics_steps", "expected_steps", "expected_metrics_steps"],
     [
         (1, 1, 1, 1, 1),
-        (60, 10, 2, 6, 3),
-        (60, 10, 3, 6, 2),
+        # (60, 10, 2, 6, 3),
+        # (60, 10, 3, 6, 2),
         (120, 10, 4, 12, 3),
     ],
 )

--- a/tests/unit/tf/models/test_benchmark.py
+++ b/tests/unit/tf/models/test_benchmark.py
@@ -24,8 +24,8 @@ from merlin.models.tf.utils import testing_utils
 def test_ncf_model(ecommerce_data, run_eagerly):
     model = ml.benchmark.NCFModel(
         ecommerce_data.schema,
-        embedding_dim=64,
-        mlp_block=ml.MLPBlock([64]),
+        embedding_dim=2,
+        mlp_block=ml.MLPBlock([2]),
         prediction_tasks=ml.BinaryClassificationTask("click"),
     )
 

--- a/tests/unit/tf/models/test_benchmark.py
+++ b/tests/unit/tf/models/test_benchmark.py
@@ -22,6 +22,7 @@ from merlin.models.tf.utils import testing_utils
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_ncf_model(ecommerce_data, run_eagerly):
+    ecommerce_data.schema = ecommerce_data.schema.select_by_name(["user_id", "item_id", "click"])
     model = ml.benchmark.NCFModel(
         ecommerce_data.schema,
         embedding_dim=2,

--- a/tests/unit/tf/models/test_ranking.py
+++ b/tests/unit/tf/models/test_ranking.py
@@ -24,7 +24,7 @@ from merlin.schema import Tags
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_simple_model(ecommerce_data: Dataset, run_eagerly):
-    body = ml.InputBlock(ecommerce_data.schema).connect(ml.MLPBlock([64]))
+    body = ml.InputBlock(ecommerce_data.schema).connect(ml.MLPBlock([4]))
     model = ml.Model(body, ml.BinaryClassificationTask("click"))
     model.compile(optimizer="adam", run_eagerly=run_eagerly)
 
@@ -35,7 +35,7 @@ def test_simple_model(ecommerce_data: Dataset, run_eagerly):
 def test_mf_model_single_binary_task(ecommerce_data, run_eagerly):
     model = ml.MatrixFactorizationModel(
         ecommerce_data.schema,
-        dim=64,
+        dim=4,
         aggregation="cosine",
         prediction_tasks=ml.BinaryClassificationTask("click"),
     )
@@ -47,9 +47,9 @@ def test_mf_model_single_binary_task(ecommerce_data, run_eagerly):
 def test_dlrm_model(music_streaming_data, run_eagerly):
     model = ml.DLRMModel(
         music_streaming_data.schema,
-        embedding_dim=64,
-        bottom_block=ml.MLPBlock([64]),
-        top_block=ml.MLPBlock([32]),
+        embedding_dim=4,
+        bottom_block=ml.MLPBlock([4]),
+        top_block=ml.MLPBlock([4]),
         prediction_tasks=ml.BinaryClassificationTask("click"),
     )
 
@@ -66,8 +66,8 @@ def test_dlrm_model(music_streaming_data, run_eagerly):
 def test_dlrm_model_without_continuous_features(ecommerce_data, run_eagerly):
     model = ml.DLRMModel(
         ecommerce_data.schema,
-        embedding_dim=64,
-        top_block=ml.MLPBlock([32]),
+        embedding_dim=4,
+        top_block=ml.MLPBlock([4]),
         prediction_tasks=ml.BinaryClassificationTask("click"),
     )
 
@@ -80,11 +80,11 @@ def test_dcn_model(ecommerce_data, stacked, run_eagerly):
     model = ml.DCNModel(
         ecommerce_data.schema,
         depth=3,
-        deep_block=ml.MLPBlock([64]),
+        deep_block=ml.MLPBlock([4]),
         stacked=stacked,
         embedding_options=ml.EmbeddingOptions(
             embedding_dims=None,
-            embedding_dim_default=64,
+            embedding_dim_default=4,
             infer_embedding_sizes=True,
             infer_embedding_sizes_multiplier=2.0,
         ),
@@ -98,23 +98,23 @@ def test_dcn_model(ecommerce_data, stacked, run_eagerly):
 def test_dlrm_model_multi_task(music_streaming_data, run_eagerly):
     dlrm_body = ml.DLRMBlock(
         music_streaming_data.schema,
-        embedding_dim=64,
-        bottom_block=ml.MLPBlock([64]),
-        top_block=ml.MLPBlock([32]),
+        embedding_dim=2,
+        bottom_block=ml.MLPBlock([2]),
+        top_block=ml.MLPBlock([2]),
     )
 
-    tasks_blocks = dict(click=ml.MLPBlock([16]), play_percentage=ml.MLPBlock([20]))
+    tasks_blocks = dict(click=ml.MLPBlock([2]), play_percentage=ml.MLPBlock([2]))
 
     prediction_tasks = ml.PredictionTasks(music_streaming_data.schema, task_blocks=tasks_blocks)
 
-    model = ml.Model(dlrm_body, ml.MLPBlock([64]), prediction_tasks)
+    model = ml.Model(dlrm_body, ml.MLPBlock([2]), prediction_tasks)
 
     testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
 
 
 @pytest.mark.parametrize("prediction_task", [ml.BinaryClassificationTask, ml.RegressionTask])
 def test_serialization_model(ecommerce_data: Dataset, prediction_task):
-    body = ml.InputBlock(ecommerce_data.schema).connect(ml.MLPBlock([64]))
+    body = ml.InputBlock(ecommerce_data.schema).connect(ml.MLPBlock([4]))
     model = ml.Model(body, prediction_task("click"))
 
     testing_utils.model_test(model, ecommerce_data)

--- a/tests/unit/tf/models/test_ranking.py
+++ b/tests/unit/tf/models/test_ranking.py
@@ -36,9 +36,11 @@ def test_mf_model_single_binary_task(ecommerce_data, run_eagerly):
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_dlrm_model(music_streaming_data, run_eagerly):
-    schema = music_streaming_data.schema.select_by_name(["item_id", "user_age", "click"])
+    music_streaming_data.schema = music_streaming_data.schema.select_by_name(
+        ["item_id", "user_age", "click"]
+    )
     model = ml.DLRMModel(
-        schema,
+        music_streaming_data.schema,
         embedding_dim=2,
         bottom_block=ml.MLPBlock([2]),
         prediction_tasks=ml.BinaryClassificationTask("click"),
@@ -47,17 +49,20 @@ def test_dlrm_model(music_streaming_data, run_eagerly):
     loaded_model, _ = testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
 
     features = testing_utils.get_model_inputs(
-        music_streaming_data.schema.remove_by_tag(Tags.TARGET), ["user_genres", "item_genres"]
+        music_streaming_data.schema.remove_by_tag(Tags.TARGET)
     )
     testing_utils.test_model_signature(loaded_model, features, ["click/binary_classification_task"])
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_dlrm_model_without_continuous_features(ecommerce_data, run_eagerly):
+    ecommerce_data.schema = ecommerce_data.schema.select_by_name(
+        ["user_categories", "item_category", "click"]
+    )
     model = ml.DLRMModel(
         ecommerce_data.schema,
-        embedding_dim=4,
-        top_block=ml.MLPBlock([4]),
+        embedding_dim=2,
+        top_block=ml.MLPBlock([2]),
         prediction_tasks=ml.BinaryClassificationTask("click"),
     )
 
@@ -66,9 +71,12 @@ def test_dlrm_model_without_continuous_features(ecommerce_data, run_eagerly):
 
 @pytest.mark.parametrize("stacked", [True, False])
 @pytest.mark.parametrize("run_eagerly", [True, False])
-def test_dcn_model(ecommerce_data, stacked, run_eagerly):
+def test_dcn_model(music_streaming_data, stacked, run_eagerly):
+    music_streaming_data.schema = music_streaming_data.schema.select_by_name(
+        ["item_id", "user_age", "click"]
+    )
     model = ml.DCNModel(
-        ecommerce_data.schema,
+        music_streaming_data.schema,
         depth=1,
         deep_block=ml.MLPBlock([2]),
         stacked=stacked,
@@ -76,28 +84,30 @@ def test_dcn_model(ecommerce_data, stacked, run_eagerly):
             embedding_dims=None,
             embedding_dim_default=2,
             infer_embedding_sizes=True,
-            infer_embedding_sizes_multiplier=2.0,
+            infer_embedding_sizes_multiplier=0.2,
         ),
         prediction_tasks=ml.BinaryClassificationTask("click"),
     )
 
-    testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)
+    testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_dlrm_model_multi_task(music_streaming_data, run_eagerly):
-    dlrm_body = ml.DLRMBlock(
-        music_streaming_data.schema,
-        embedding_dim=2,
-        bottom_block=ml.MLPBlock([2]),
-        top_block=ml.MLPBlock([2]),
+    music_streaming_data.schema = music_streaming_data.schema.select_by_name(
+        ["item_id", "user_age", "click", "play_percentage"]
     )
-
     tasks_blocks = dict(click=ml.MLPBlock([2]), play_percentage=ml.MLPBlock([2]))
-
-    prediction_tasks = ml.PredictionTasks(music_streaming_data.schema, task_blocks=tasks_blocks)
-
-    model = ml.Model(dlrm_body, ml.MLPBlock([2]), prediction_tasks)
+    model = ml.Model(
+        ml.DLRMBlock(
+            music_streaming_data.schema,
+            embedding_dim=2,
+            bottom_block=ml.MLPBlock([2]),
+            top_block=ml.MLPBlock([2]),
+        ),
+        ml.MLPBlock([2]),
+        ml.PredictionTasks(music_streaming_data.schema, task_blocks=tasks_blocks),
+    )
 
     testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
 

--- a/tests/unit/tf/models/test_retrieval.py
+++ b/tests/unit/tf/models/test_retrieval.py
@@ -18,14 +18,14 @@ from tests.common.tf.retrieval import retrieval_tests_common
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
-def test_matrix_factorization_model(music_streaming_data: Dataset, run_eagerly, num_epochs=2):
-    music_streaming_data.schema = music_streaming_data.schema.remove_by_tag(Tags.TARGET)
+def test_matrix_factorization_model(music_streaming_data: Dataset, run_eagerly):
+    music_streaming_data.schema = music_streaming_data.schema.select_by_name(["user_id", "item_id"])
 
     model = mm.MatrixFactorizationModel(music_streaming_data.schema, dim=4)
     model.compile(optimizer="adam", run_eagerly=run_eagerly)
 
-    losses = model.fit(music_streaming_data, batch_size=50, epochs=num_epochs)
-    assert len(losses.epoch) == num_epochs
+    losses = model.fit(music_streaming_data, batch_size=50, epochs=1, steps_per_epoch=1)
+    assert len(losses.epoch) == 1
     assert all(measure >= 0 for metric in losses.history for measure in losses.history[metric])
 
 
@@ -46,12 +46,14 @@ def test_matrix_factorization_model_l2_reg(testing_data: Dataset):
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_two_tower_model(music_streaming_data: Dataset, run_eagerly, num_epochs=2):
-    music_streaming_data.schema = music_streaming_data.schema.remove_by_tag(Tags.TARGET)
+    music_streaming_data.schema = music_streaming_data.schema.select_by_name(
+        ["item_id", "user_genres"]
+    )
 
-    model = mm.TwoTowerModel(music_streaming_data.schema, query_tower=mm.MLPBlock([4]))
+    model = mm.TwoTowerModel(music_streaming_data.schema, query_tower=mm.MLPBlock([2]))
     model.compile(optimizer="adam", run_eagerly=run_eagerly)
 
-    losses = model.fit(music_streaming_data, batch_size=50, epochs=num_epochs)
+    losses = model.fit(music_streaming_data, batch_size=50, epochs=num_epochs, steps_per_epoch=1)
     assert len(losses.epoch) == num_epochs
     assert all(measure >= 0 for metric in losses.history for measure in losses.history[metric])
 
@@ -61,23 +63,22 @@ def test_two_tower_model(music_streaming_data: Dataset, run_eagerly, num_epochs=
     testing_utils.test_model_signature(model.first.query_block(), query_features, ["output_1"])
 
     item_features = testing_utils.get_model_inputs(
-        music_streaming_data.schema.select_by_tag(Tags.ITEM), ["item_genres"]
+        music_streaming_data.schema.select_by_tag(Tags.ITEM),
     )
     testing_utils.test_model_signature(model.first.item_block(), item_features, ["output_1"])
 
 
 def test_two_tower_model_l2_reg(testing_data: Dataset):
-
     model = mm.TwoTowerModel(
         testing_data.schema,
-        query_tower=mm.MLPBlock([4]),
+        query_tower=mm.MLPBlock([2]),
         embedding_options=mm.EmbeddingOptions(
             embedding_dim_default=2,
             embeddings_l2_reg=0.1,
         ),
     )
 
-    _ = model(mm.sample_batch(testing_data, batch_size=100, include_targets=False))
+    _ = model(mm.sample_batch(testing_data, batch_size=10, include_targets=False))
 
     l2_emb_losses = model.losses
 
@@ -97,17 +98,15 @@ def test_two_tower_model_with_custom_options(
     run_eagerly,
     logits_pop_logq_correction,
     loss,
-    num_epochs=2,
 ):
-
     from tensorflow.keras import regularizers
 
     from merlin.models.tf.core.transformations import PopularityLogitsCorrection
     from merlin.models.utils import schema_utils
 
     data = ecommerce_data
+    data.schema = data.schema.select_by_name(["user_categories", "item_id"])
 
-    data.schema = data.schema.remove_by_tag(Tags.TARGET)
     metrics = [
         tf.keras.metrics.AUC(from_logits=True, name="auc"),
         mm.RecallAt(5),
@@ -159,11 +158,11 @@ def test_two_tower_model_with_custom_options(
 
     model.compile(optimizer="adam", run_eagerly=run_eagerly, loss=loss, metrics=metrics)
 
-    losses = model.fit(data, batch_size=50, epochs=num_epochs)
-    assert len(losses.epoch) == num_epochs
+    losses = model.fit(data, batch_size=50, epochs=1, steps_per_epoch=1)
+    assert len(losses.epoch) == 1
     assert all(measure >= 0 for metric in losses.history for measure in losses.history[metric])
 
-    metrics = model.evaluate(data, batch_size=10, item_corpus=data, return_dict=True)
+    metrics = model.evaluate(data, batch_size=10, item_corpus=data, return_dict=True, steps=1)
     assert set(metrics.keys()) == set(
         [
             "loss",
@@ -182,23 +181,23 @@ def test_two_tower_model_with_custom_options(
     "loss", ["categorical_crossentropy", "bpr", "bpr-max", "binary_crossentropy"]
 )
 def test_two_tower_retrieval_model_with_metrics(ecommerce_data: Dataset, run_eagerly, loss):
-    ecommerce_data.schema = ecommerce_data.schema.remove_by_tag(Tags.TARGET)
+    ecommerce_data.schema = ecommerce_data.schema.select_by_name(["user_categories", "item_id"])
 
     metrics = [RecallAt(5), MRRAt(5), NDCGAt(5), AvgPrecisionAt(5), PrecisionAt(5)]
     model = mm.TwoTowerModel(schema=ecommerce_data.schema, query_tower=mm.MLPBlock([4]))
     model.compile(optimizer="adam", run_eagerly=run_eagerly, metrics=metrics, loss=loss)
 
     # Training
-    num_epochs = 2
     losses = model.fit(
         ecommerce_data,
         batch_size=10,
-        epochs=num_epochs,
+        epochs=1,
+        steps_per_epoch=1,
         train_metrics_steps=3,
         validation_data=ecommerce_data,
         validation_steps=3,
     )
-    assert len(losses.epoch) == num_epochs
+    assert len(losses.epoch) == 1
 
     # Checking train metrics
     expected_metrics = ["recall_at_5", "mrr_at_5", "ndcg_at_5", "map_at_5", "precision_at_5"]
@@ -216,7 +215,7 @@ def test_two_tower_retrieval_model_with_metrics(ecommerce_data: Dataset, run_eag
     #         assert losses.history[metric_name][1] <= losses.history[metric_name][0]
 
     metrics = model.evaluate(
-        ecommerce_data, batch_size=10, item_corpus=ecommerce_data, return_dict=True
+        ecommerce_data, batch_size=10, item_corpus=ecommerce_data, return_dict=True, steps=1
     )
     assert set(metrics.keys()) == set(expected_metrics_all)
 
@@ -225,7 +224,7 @@ def test_two_tower_retrieval_model_with_metrics(ecommerce_data: Dataset, run_eag
 def test_two_tower_retrieval_model_with_topk_metrics_aggregator(
     ecommerce_data: Dataset, run_eagerly
 ):
-    ecommerce_data.schema = ecommerce_data.schema.remove_by_tag(Tags.TARGET)
+    ecommerce_data.schema = ecommerce_data.schema.select_by_name(["user_categories", "item_id"])
 
     metrics_agg = TopKMetricsAggregator(
         RecallAt(5), MRRAt(5), NDCGAt(5), AvgPrecisionAt(5), PrecisionAt(5)
@@ -234,16 +233,16 @@ def test_two_tower_retrieval_model_with_topk_metrics_aggregator(
     model.compile(optimizer="adam", run_eagerly=run_eagerly, metrics=[metrics_agg])
 
     # Training
-    num_epochs = 2
     losses = model.fit(
         ecommerce_data,
         batch_size=10,
-        epochs=num_epochs,
+        epochs=1,
+        steps_per_epoch=1,
         train_metrics_steps=3,
         validation_data=ecommerce_data,
         validation_steps=3,
     )
-    assert len(losses.epoch) == num_epochs
+    assert len(losses.epoch) == 1
 
     # Checking train metrics
     expected_metrics = ["recall_at_5", "mrr_at_5", "ndcg_at_5", "map_at_5", "precision_at_5"]
@@ -253,7 +252,7 @@ def test_two_tower_retrieval_model_with_topk_metrics_aggregator(
     assert set(losses.history.keys()) == set(expected_metrics_all + expected_metrics_valid)
 
     metrics = model.evaluate(
-        ecommerce_data, batch_size=10, item_corpus=ecommerce_data, return_dict=True
+        ecommerce_data, batch_size=10, item_corpus=ecommerce_data, return_dict=True, steps=1
     )
     assert set(metrics.keys()) == set(expected_metrics_all)
 

--- a/tests/unit/tf/utils/test_batch.py
+++ b/tests/unit/tf/utils/test_batch.py
@@ -7,12 +7,14 @@ from merlin.io import Dataset
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_model_encode(ecommerce_data: Dataset, run_eagerly):
-    body = ml.InputBlock(ecommerce_data.schema).connect(ml.MLPBlock([64]))
-    prediction_task = ml.PredictionTasks(ecommerce_data.schema)
-    model = ml.Model(body, prediction_task)
+    model = ml.Model(
+        ml.InputBlock(ecommerce_data.schema),
+        ml.MLPBlock([2]),
+        ml.PredictionTasks(ecommerce_data.schema),
+    )
 
     model.compile(run_eagerly=run_eagerly, optimizer="adam")
-    model.fit(ecommerce_data, batch_size=50, epochs=1)
+    model.fit(ecommerce_data, batch_size=50, epochs=1, steps_per_epoch=1)
     data = model.batch_predict(ecommerce_data, batch_size=10)
     ddf = data.compute(scheduler="synchronous")
 
@@ -21,10 +23,9 @@ def test_model_encode(ecommerce_data: Dataset, run_eagerly):
 
 
 def test_two_tower_embedding_extraction(ecommerce_data: Dataset):
-    two_tower = ml.TwoTowerBlock(ecommerce_data.schema, query_tower=ml.MLPBlock([64, 128]))
-
     model = ml.RetrievalModel(
-        two_tower, ml.ItemRetrievalTask(ecommerce_data.schema, target_name="click")
+        ml.TwoTowerBlock(ecommerce_data.schema, query_tower=ml.MLPBlock([2])),
+        ml.ItemRetrievalTask(ecommerce_data.schema, target_name="click"),
     )
     model.compile(run_eagerly=True, optimizer="adam")
     model.fit(ecommerce_data, batch_size=50, epochs=1)
@@ -32,21 +33,20 @@ def test_two_tower_embedding_extraction(ecommerce_data: Dataset):
     item_embs = model.item_embeddings(ecommerce_data, 10)
     item_embs_ddf = item_embs.compute(scheduler="synchronous")
 
-    assert len(list(item_embs_ddf.columns)) == 5 + 128
+    assert len(list(item_embs_ddf.columns)) == 5 + 2
 
     user_embs = model.query_embeddings(ecommerce_data, 10)
     user_embs_ddf = user_embs.compute(scheduler="synchronous")
 
-    assert len(list(user_embs_ddf.columns)) == 13 + 128
+    assert len(list(user_embs_ddf.columns)) == 13 + 2
 
 
 def test_two_tower_extracted_embeddings_are_equal(ecommerce_data: Dataset):
     import numpy as np
 
-    two_tower = ml.TwoTowerBlock(ecommerce_data.schema, query_tower=ml.MLPBlock([64, 128]))
-
     model = ml.RetrievalModel(
-        two_tower, ml.ItemRetrievalTask(ecommerce_data.schema, target_name="click")
+        ml.TwoTowerBlock(ecommerce_data.schema, query_tower=ml.MLPBlock([2])),
+        ml.ItemRetrievalTask(ecommerce_data.schema, target_name="click"),
     )
     model.compile(run_eagerly=True, optimizer="adam")
     model.fit(ecommerce_data, batch_size=50, epochs=1)


### PR DESCRIPTION
### Goals :soccer:
Our unit-test has become slow (typically over 20 min). This PR tries to speed things up and get things well under 10 minutes. 

### Implementation Details :construction:
- Caching of pip-installs
- Reducing model + schema sizes in all tests
- Reducing number of epochs + steps.
