### PR TITLE
Fix CategoricalOneHot with compute_output_shape and check inputs.

### DIFF
--- a/merlin/models/tf/core/transformations.py
+++ b/merlin/models/tf/core/transformations.py
@@ -401,9 +401,11 @@ class ItemsPredictionWeightTying(Block):
 @Block.registry.register_with_multiple_names("categorical_to_onehot")
 @tf.keras.utils.register_keras_serializable(package="merlin_models")
 @requires_schema
-class CategoricalOneHot(Block):
+class CategoricalOneHot(TabularBlock):
     """
-    Transform categorical features (2-D and 3-D tensors) to a one-hot representation.
+    Transform categorical features (2-D and 3-D tensors) to a one-hot representation, only
+    categorical features with "CATEGORICAL" as Tag can be transformed, and other features without
+    this Tag would be discarded
 
     Parameters:
     ----------
@@ -414,22 +416,40 @@ class CategoricalOneHot(Block):
     def __init__(self, schema: Schema = None, **kwargs):
         super().__init__(**kwargs)
         if schema:
-            self.set_schema(schema)
+            self.set_schema(schema.select_by_tag(Tags.CATEGORICAL))
+            # self.schema = schema.select_by_tag(Tags.CATEGORICAL)
         self.cardinalities = schema_utils.categorical_cardinalities(self.schema)
 
     def build(self, input_shapes):
         super(CategoricalOneHot, self).build(input_shapes)
 
     def call(self, inputs: TabularData, **kwargs) -> TabularData:
+        self._check_inputs_type(inputs)
         outputs = {}
         for name, val in self.cardinalities.items():
             outputs[name] = tf.squeeze(tf.one_hot(inputs[name], val))
         return outputs
 
+    def _check_inputs_type(self, inputs):
+        for name, val in self.cardinalities.items():
+            if not isinstance(inputs[name], tf.Tensor):
+                raise ValueError(
+                    f"All `CategoricalOneHot` inputs should be a Tensor. Received {name} with type "
+                    f"of {type(inputs[name])}"
+                )
+
     def compute_output_shape(self, input_shape):
         outputs = {}
-        for key, val in input_shape.items():
-            if len(val) == 3:
+        for key in self.schema.column_names:
+            val = input_shape[key].as_list()
+            rank = len(val)
+            if rank > 2:
+                raise ValueError(
+                    "All `CategoricalOneHot` inputs should have shape `[batch_size]` "
+                    f"or `[batch_size, 1]` or `[batch_size, n]`. Received: input {key} with "
+                    f"shape={val}"
+                )
+            elif rank > 1 and val[-1] != 1:
                 outputs[key] = tf.TensorShape((val[0], val[1], self.cardinalities[key]))
             else:
                 outputs[key] = tf.TensorShape((val[0], self.cardinalities[key]))
@@ -690,7 +710,7 @@ class HashedCross(TabularBlock):
 
         if not (output_mode in ["int", "one_hot"]):
             raise ValueError("output_mode must be 'int' or 'one_hot'")
-        self.schema = schema
+        self.set_schema(schema)
         self.num_bins = num_bins
         self.output_mode = output_mode
         self.sparse = sparse

--- a/merlin/models/tf/core/transformations.py
+++ b/merlin/models/tf/core/transformations.py
@@ -417,7 +417,6 @@ class CategoricalOneHot(TabularBlock):
         super().__init__(**kwargs)
         if schema:
             self.set_schema(schema.select_by_tag(Tags.CATEGORICAL))
-            # self.schema = schema.select_by_tag(Tags.CATEGORICAL)
         self.cardinalities = schema_utils.categorical_cardinalities(self.schema)
 
     def build(self, input_shapes):

--- a/tests/unit/tf/core/test_transformations.py
+++ b/tests/unit/tf/core/test_transformations.py
@@ -93,7 +93,13 @@ def test_categorical_one_hot_encoding():
     )
     inputs["cont1"] = tf.random.uniform((NUM_ROWS, 1), minval=0, maxval=1, dtype=tf.float32)
 
-    outputs = ml.CategoricalOneHot(schema=s)(inputs)
+    input_shape = {}
+    for key in inputs:
+        input_shape[key] = inputs[key].shape
+
+    categorical_one_hot = ml.CategoricalOneHot(schema=s)
+    outputs = categorical_one_hot(inputs)
+    outputs_shape = categorical_one_hot.compute_output_shape(input_shape)
 
     assert list(outputs["cat1"].shape) == [NUM_ROWS, 201]
     assert list(outputs["cat2"].shape) == [NUM_ROWS, 1001]
@@ -101,6 +107,61 @@ def test_categorical_one_hot_encoding():
 
     assert inputs["cat1"][0].numpy() == tf.where(outputs["cat1"][0, :] == 1).numpy()[0]
     assert list(outputs.keys()) == ["cat1", "cat2", "cat3"]
+
+    assert outputs_shape["cat1"] == outputs["cat1"].shape
+    assert outputs_shape["cat2"] == outputs["cat2"].shape
+    assert outputs_shape["cat3"] == outputs["cat3"].shape
+
+
+@pytest.mark.parametrize(
+    "input",
+    [
+        tf.SparseTensor(indices=[[0, 0], [1, 2]], values=[1, 2], dense_shape=[3, 4]),
+        tf.ragged.constant([[9, 8, 7], [], [6, 5], [4]]),
+    ],
+)
+def test_categorical_one_hot_invalid_input(input):
+    test_case = TestCase()
+    s = Schema(
+        [
+            create_categorical_column("cat1", num_items=10, tags=[Tags.CATEGORICAL]),
+        ]
+    )
+    inputs = {}
+    inputs["cat1"] = input
+    categorical_one_hot = ml.CategoricalOneHot(schema=s)
+    with test_case.assertRaisesRegex(ValueError, "inputs should be a Tensor"):
+        categorical_one_hot(inputs)
+
+
+def test_categorical_one_hot_from_config():
+    test_case = TestCase()
+    schema = Schema(
+        [
+            create_categorical_column("cat1", tags=[Tags.CATEGORICAL], num_items=20),
+            create_categorical_column("cat2", tags=[Tags.CATEGORICAL], num_items=20),
+            create_continuous_column("cont1", min_value=0, max_value=1, tags=[Tags.CONTINUOUS]),
+        ]
+    )
+    inputs = {}
+    inputs["cat1"] = tf.constant([1, 2, 3, 2, 1])
+    inputs["cat2"] = tf.constant([101, 101, 103, 102, 102])
+    inputs["cont1"] = tf.random.uniform((5, 1), minval=0, maxval=1, dtype=tf.float32)
+
+    input_shape = {}
+    for key in inputs:
+        input_shape[key] = inputs[key].shape
+
+    categorical_one_hot = ml.CategoricalOneHot(schema=schema)
+    outputs = categorical_one_hot(inputs)
+    output_shape = categorical_one_hot.compute_output_shape(input_shape)
+
+    cloned_categorical_one_hot = ml.CategoricalOneHot.from_config(categorical_one_hot.get_config())
+    cloned_outputs = cloned_categorical_one_hot(inputs)
+    cloned_output_shape = cloned_categorical_one_hot.compute_output_shape(input_shape)
+
+    test_case.assertAllClose(cloned_output_shape, output_shape)
+    test_case.assertAllClose(cloned_outputs, outputs)
 
 
 def test_popularity_logits_correct():


### PR DESCRIPTION
### Goals :soccer:
Fix bugs when using CategoricalOneHot as part of model

### Implementation Details :construction:
1. In compute_outpur_shape: filter out features defined in schema
2. Change the parent class from block to TabularBlock, since if not inheriting from TabularBlock, it may raise type error that schema cannot be deserialized 
3. add _check_inputs_type, raise error if input is SparseTensor or RaggedTensor.
4. Debug of compute_output_shape, for inputs that are not scalars, original compute_output_shape may get incorrect results

### Testing Details :mag:
Add tests for invalid inputs and from_config()
