### PR TITLE
Supports task-specific sample weights, weighed_metrics and fixes InputBlockV2

### DIFF
--- a/merlin/models/tf/blocks/retrieval/base.py
+++ b/merlin/models/tf/blocks/retrieval/base.py
@@ -288,7 +288,7 @@ class ItemRetrievalScorer(Block):
         if self.sampled_softmax_mode or isinstance(targets, tf.Tensor):
             positive_item_ids = targets
         else:
-            positive_item_ids = tf.squeeze(features[self.item_id_feature_name], 1)
+            positive_item_ids = tf.squeeze(features[self.item_id_feature_name])
 
         neg_items_ids = None
         if training or testing:
@@ -303,10 +303,14 @@ class ItemRetrievalScorer(Block):
                 )
 
             batch_items_embeddings = predictions[self.item_name]
-            batch_items_metadata = {
-                feat_name: tf.squeeze(features[feat_name], 1)
-                for feat_name in self._required_features
-            }
+
+            if self.sampled_softmax_mode:
+                batch_items_metadata = {self.item_id_feature_name: positive_item_ids}
+            else:
+                batch_items_metadata = {
+                    feat_name: tf.squeeze(features[feat_name])
+                    for feat_name in self._required_features
+                }
 
             positive_scores = tf.reduce_sum(
                 tf.multiply(predictions[self.query_name], predictions[self.item_name]),
@@ -350,7 +354,7 @@ class ItemRetrievalScorer(Block):
                 if isinstance(targets, tf.Tensor):
                     positive_item_ids = targets
                 else:
-                    positive_item_ids = tf.squeeze(features[self.item_id_feature_name], 1)
+                    positive_item_ids = tf.squeeze(features[self.item_id_feature_name])
 
                 if len(neg_items_ids_list) == 1:
                     neg_items_ids = neg_items_ids_list[0]

--- a/merlin/models/tf/blocks/retrieval/base.py
+++ b/merlin/models/tf/blocks/retrieval/base.py
@@ -288,7 +288,7 @@ class ItemRetrievalScorer(Block):
         if self.sampled_softmax_mode or isinstance(targets, tf.Tensor):
             positive_item_ids = targets
         else:
-            positive_item_ids = features[self.item_id_feature_name]
+            positive_item_ids = tf.squeeze(features[self.item_id_feature_name])
 
         neg_items_ids = None
         if training or testing:
@@ -349,7 +349,7 @@ class ItemRetrievalScorer(Block):
                 if isinstance(targets, tf.Tensor):
                     positive_item_ids = targets
                 else:
-                    positive_item_ids = features[self.item_id_feature_name]
+                    positive_item_ids = tf.squeeze(features[self.item_id_feature_name])
 
                 if len(neg_items_ids_list) == 1:
                     neg_items_ids = neg_items_ids_list[0]

--- a/merlin/models/tf/blocks/retrieval/base.py
+++ b/merlin/models/tf/blocks/retrieval/base.py
@@ -288,7 +288,7 @@ class ItemRetrievalScorer(Block):
         if self.sampled_softmax_mode or isinstance(targets, tf.Tensor):
             positive_item_ids = targets
         else:
-            positive_item_ids = tf.squeeze(features[self.item_id_feature_name])
+            positive_item_ids = tf.squeeze(features[self.item_id_feature_name], 1)
 
         neg_items_ids = None
         if training or testing:
@@ -304,7 +304,8 @@ class ItemRetrievalScorer(Block):
 
             batch_items_embeddings = predictions[self.item_name]
             batch_items_metadata = {
-                feat_name: features[feat_name] for feat_name in self._required_features
+                feat_name: tf.squeeze(features[feat_name], 1)
+                for feat_name in self._required_features
             }
 
             positive_scores = tf.reduce_sum(
@@ -349,7 +350,7 @@ class ItemRetrievalScorer(Block):
                 if isinstance(targets, tf.Tensor):
                     positive_item_ids = targets
                 else:
-                    positive_item_ids = tf.squeeze(features[self.item_id_feature_name])
+                    positive_item_ids = tf.squeeze(features[self.item_id_feature_name], 1)
 
                 if len(neg_items_ids_list) == 1:
                     neg_items_ids = neg_items_ids_list[0]

--- a/merlin/models/tf/core/base.py
+++ b/merlin/models/tf/core/base.py
@@ -48,6 +48,7 @@ class PredictionOutput(NamedTuple):
     label_relevant_counts: Optional[tf.Tensor] = None
     valid_negatives_mask: Optional[tf.Tensor] = None
     negative_item_ids: Optional[tf.Tensor] = None
+    sample_weight: Optional[tf.Tensor] = None
 
     def copy_with_updates(
         self,
@@ -57,6 +58,7 @@ class PredictionOutput(NamedTuple):
         label_relevant_counts: Optional[tf.Tensor] = None,
         valid_negatives_mask: Optional[tf.Tensor] = None,
         negative_item_ids: Optional[tf.Tensor] = None,
+        sample_weight: Optional[tf.Tensor] = None,
     ):
         """Creates a new instance of PredictionOutput
         allowing to override the attributes for the copy
@@ -78,6 +80,7 @@ class PredictionOutput(NamedTuple):
             negative_item_ids=(
                 self.negative_item_ids if negative_item_ids is None else negative_item_ids
             ),
+            sample_weight=(self.sample_weight if sample_weight is None else sample_weight),
         )
         return output
 

--- a/merlin/models/tf/core/prediction.py
+++ b/merlin/models/tf/core/prediction.py
@@ -55,6 +55,7 @@ class PredictionContext(NamedTuple):
 class Prediction(NamedTuple):
     outputs: Dict[str, TensorLike]
     targets: Optional[Union[tf.Tensor, Dict[str, tf.Tensor]]] = None
+    sample_weight: Optional[tf.Tensor] = None
     features: Optional[Dict[str, TensorLike]] = None
 
     @property

--- a/merlin/models/tf/core/transformations.py
+++ b/merlin/models/tf/core/transformations.py
@@ -36,11 +36,7 @@ from merlin.schema import Schema, Tags
 @Block.registry.register("as-ragged")
 @tf.keras.utils.register_keras_serializable(package="merlin.models")
 class AsRaggedFeatures(TabularBlock):
-    """Convert all list-inputs to ragged-tensors.
-
-    By default, the dataloader will represent list-columns as a tuple of values & row-lengths.
-
-    """
+    """Convert all list (multi-hot/sequential) features to tf.RaggedTensor"""
 
     def call(self, inputs: TabularData, **kwargs) -> TabularData:
         outputs = {}
@@ -52,8 +48,19 @@ class AsRaggedFeatures(TabularBlock):
 
         return outputs
 
-    def compute_output_shape(self, input_shape):
-        return input_shape
+    def compute_output_shape(self, input_shapes):
+        output_shapes = {}
+        for k, v in input_shapes.items():
+            # If it is a list/sparse feature (in tuple representation), uses the offset as shape
+            if isinstance(v, tuple) and isinstance(v[1], tf.TensorShape):
+                output_shapes[k] = tf.TensorShape([v[1][0], None])
+            else:
+                output_shapes[k] = v
+
+        return output_shapes
+
+    def compute_call_output_shape(self, input_shapes):
+        return self.compute_output_shape(input_shapes)
 
 
 @Block.registry.register("as-sparse")

--- a/merlin/models/tf/inputs/base.py
+++ b/merlin/models/tf/inputs/base.py
@@ -22,10 +22,11 @@ from merlin.models.tf.core.base import Block, BlockType
 from merlin.models.tf.core.combinators import (
     Filter,
     ParallelBlock,
+    SequentialBlock,
     TabularAggregationType,
     TabularBlock,
 )
-from merlin.models.tf.core.transformations import AsDenseFeatures
+from merlin.models.tf.core.transformations import AsDenseFeatures, AsRaggedFeatures
 from merlin.models.tf.inputs.continuous import ContinuousFeatures
 from merlin.models.tf.inputs.embedding import (
     ContinuousEmbedding,
@@ -267,9 +268,12 @@ def InputBlockV2(
     else:
         continuous = TabularBlock(schema=con_schema, pre=con_filter)
 
-    return ParallelBlock(
-        dict(continuous=continuous, embeddings=embeddings),
-        pre=pre,
-        post=post,
-        aggregation=aggregation,
+    return SequentialBlock(
+        AsRaggedFeatures(),
+        ParallelBlock(
+            dict(continuous=continuous, embeddings=embeddings),
+            pre=pre,
+            post=post,
+            aggregation=aggregation,
+        ),
     )

--- a/merlin/models/tf/inputs/base.py
+++ b/merlin/models/tf/inputs/base.py
@@ -219,7 +219,7 @@ def InputBlockV2(
     continuous_column_selector: Union[Tags, Schema] = Tags.CONTINUOUS,
     pre: Optional[BlockType] = None,
     post: Optional[BlockType] = None,
-    aggregation: Optional[TabularAggregationType] = None,
+    aggregation: Optional[TabularAggregationType] = "concat",
 ) -> ParallelBlock:
     """The entry block of the model to process input features from a schema.
     This is the 2nd version of InputBlock, which is more flexible for accepting
@@ -245,7 +245,7 @@ def InputBlockV2(
     post : Optional[BlockType], optional
         Transformation block to apply after the embeddings lookup, by default None
     aggregation : Optional[TabularAggregationType], optional
-        Transformation block to apply for aggregating the inputs, by default None
+        Transformation block to apply for aggregating the inputs, by default "concat"
 
     Returns
     -------

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -240,7 +240,8 @@ class EmbeddingTable(EmbeddingTableBase):
         return super(EmbeddingTable, self)._maybe_build(inputs)
 
     def build(self, input_shapes):
-        self.table.build(input_shapes)
+        if not self.table.built:
+            self.table.build(input_shapes)
         # if isinstance(self.combiner, tf.keras.layers.Layer):
         #    self.combiner.build(self.table.compute_output_shape(input_shapes))
         return super(EmbeddingTable, self).build(input_shapes)
@@ -276,9 +277,9 @@ class EmbeddingTable(EmbeddingTableBase):
                     f"Received: {type(inputs)}. Column name: {self.col_schema.name}"
                 )
             if isinstance(inputs, tf.RaggedTensor):
-                sparse_inputs = inputs.to_sparse()
+                inputs = inputs.to_sparse()
             out = tf.nn.safe_embedding_lookup_sparse(
-                self.table.embeddings, sparse_inputs, None, combiner=self.combiner
+                self.table.embeddings, inputs, None, combiner=self.combiner
             )
         else:
             if not isinstance(inputs, (tf.RaggedTensor, tf.Tensor)):

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -329,7 +329,10 @@ class BaseModel(tf.keras.Model):
 
         num_v1_blocks = len(self.prediction_tasks)
 
-        if isinstance(metrics, (list, tuple)):
+        if isinstance(metrics, dict):
+            out = metrics
+
+        elif isinstance(metrics, (list, tuple)):
             if num_v1_blocks > 0:
                 if num_v1_blocks == 1:
                     out[self.prediction_tasks[0].task_name] = metrics
@@ -343,7 +346,7 @@ class BaseModel(tf.keras.Model):
                     for i, block in enumerate(self.prediction_blocks):
                         out[block.full_name] = metrics[i]
 
-        if not metrics:
+        elif metrics is None:
             for task_name, task in self.prediction_tasks_by_name().items():
                 out[task_name] = [m() if inspect.isclass(m) else m for m in task.DEFAULT_METRICS]
 
@@ -357,7 +360,10 @@ class BaseModel(tf.keras.Model):
 
         num_v1_blocks = len(self.prediction_tasks)
 
-        if isinstance(weighted_metrics, (list, tuple)):
+        if isinstance(weighted_metrics, dict):
+            out = weighted_metrics
+
+        elif isinstance(weighted_metrics, (list, tuple)):
             if num_v1_blocks > 0:
                 if num_v1_blocks == 1:
                     out[self.prediction_tasks[0].task_name] = weighted_metrics

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -16,7 +16,7 @@ from merlin.models.tf.core.base import Block, ModelContext, PredictionOutput, is
 from merlin.models.tf.core.combinators import SequentialBlock
 from merlin.models.tf.core.prediction import Prediction, PredictionContext
 from merlin.models.tf.core.tabular import TabularBlock
-from merlin.models.tf.core.transformations import AsDenseFeatures, AsRaggedFeatures
+from merlin.models.tf.core.transformations import AsRaggedFeatures
 from merlin.models.tf.dataset import BatchedDataset
 from merlin.models.tf.inputs.base import InputBlock
 from merlin.models.tf.losses.base import loss_registry
@@ -877,7 +877,7 @@ class Model(BaseModel):
 
     def call(self, inputs, targets=None, training=False, testing=False, output_context=False):
         context = self._create_context(
-            AsDenseFeatures()(inputs),  # TODO: Change this to ragged
+            AsRaggedFeatures()(inputs),
             targets=targets,
             training=training,
             testing=testing,

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -299,10 +299,6 @@ class BaseModel(tf.keras.Model):
                 "`prediction_tasks` is deprecated and will be removed in a future version.",
             )
 
-        _loss = {}
-        if isinstance(loss, (tf.keras.losses.Loss, str)) and len(self.prediction_tasks) == 1:
-            _loss = {task.task_name: loss for task in self.prediction_tasks}
-
         if num_v1_blocks > 0:
             self.output_names = [task.task_name for task in self.prediction_tasks]
         else:
@@ -877,10 +873,7 @@ class Model(BaseModel):
 
     def call(self, inputs, targets=None, training=False, testing=False, output_context=False):
         context = self._create_context(
-            AsRaggedFeatures()(inputs),
-            targets=targets,
-            training=training,
-            testing=testing,
+            AsRaggedFeatures()(inputs), targets=targets, training=training, testing=testing,
         )
 
         outputs = inputs

--- a/merlin/models/tf/prediction_tasks/multi.py
+++ b/merlin/models/tf/prediction_tasks/multi.py
@@ -17,6 +17,7 @@ from typing import Dict, Optional, Union
 
 from tensorflow.keras.layers import Layer
 
+from merlin.models.tf.core.base import Block
 from merlin.models.tf.prediction_tasks.base import ParallelPredictionBlock
 from merlin.schema import Schema
 
@@ -25,13 +26,32 @@ def PredictionTasks(
     schema: Schema,
     task_blocks: Optional[Union[Layer, Dict[str, Layer]]] = None,
     task_weight_dict: Optional[Dict[str, float]] = None,
+    task_pre_dict: Optional[Dict[str, Block]] = None,
     bias_block: Optional[Layer] = None,
     **kwargs,
 ) -> ParallelPredictionBlock:
+    """Creates Multi-task prediction Blocks from schema
+
+    Parameters
+    ----------
+    schema : Schema
+        The `Schema` with the input features
+    task_blocks : Optional[Union[Layer, Dict[str, Layer]]], optional
+        Task blocks to be used for prediction, by default None
+    task_weight_dict : Optional[Dict[str, float]], optional
+        Dict where keys are target feature names and values are weights for each task,
+        by default None
+    task_pre_dict: Optional[Dict[str, Block]], optional
+        Dict where keys are target feature names and values are Blocks to be used as pre
+        for those tasks
+    bias_block : Optional[Layer], optional
+        Bias block to be used for prediction, by default None
+    """
     return ParallelPredictionBlock.from_schema(
         schema,
         task_blocks=task_blocks,
         task_weight_dict=task_weight_dict,
+        task_pre_dict=task_pre_dict,
         bias_block=bias_block,
         **kwargs,
     )

--- a/tests/unit/tf/core/test_index.py
+++ b/tests/unit/tf/core/test_index.py
@@ -90,7 +90,7 @@ def test_topk_recommender_outputs(ecommerce_data: Dataset, batch_size=100):
         samplers=[mm.InBatchSampler()],
     )
 
-    model.compile("adam", metrics=[mm.RecallAt(10)])
+    model.compile("adam", metrics=[mm.RecallAt(10)], run_eagerly=False)
     model.fit(ecommerce_data, batch_size=batch_size, epochs=3)
     eval_metrics = model.evaluate(
         ecommerce_data, item_corpus=ecommerce_data, batch_size=batch_size, return_dict=True

--- a/tests/unit/tf/data_augmentation/test_negative_sampling.py
+++ b/tests/unit/tf/data_augmentation/test_negative_sampling.py
@@ -206,15 +206,16 @@ class TestAddRandomNegativesToBatch:
         testing_utils.model_test(model, dataset, run_eagerly=run_eagerly)
 
     def test_model_with_dataloader(self, music_streaming_data: Dataset, tf_random_seed: int):
-        add_negatives = UniformNegativeSampling(music_streaming_data.schema, 5, seed=tf_random_seed)
+        add_negatives = UniformNegativeSampling(
+            music_streaming_data.schema, 5, seed=tf_random_seed, return_tuple=True
+        )
 
         batch_size, n_per_positive = 10, 5
         dataset = BatchedDataset(music_streaming_data, batch_size=batch_size)
         dataset = dataset.map(add_negatives)
 
         batch_output = next(iter(dataset))
-        features = batch_output.outputs
-        targets = batch_output.targets
+        features, targets = batch_output
 
         expected_batch_size = batch_size + batch_size * n_per_positive
 

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -70,7 +70,7 @@ class TestEmbeddingTable:
     @pytest.mark.parametrize(
         ["dim", "kwargs", "inputs", "expected_output_shape"],
         [
-            (32, {}, tf.constant([1]), [1, 32]),
+            (32, {}, tf.constant([[1]]), [1, 32]),
             (16, {}, tf.ragged.constant([[1, 2, 3], [4, 5]]), [2, None, 16]),
             (16, {"combiner": "mean"}, tf.ragged.constant([[1, 2, 3], [4, 5]]), [2, 16]),
             (16, {"combiner": "mean"}, tf.sparse.from_dense(tf.constant([[1, 2, 3]])), [1, 16]),
@@ -168,7 +168,7 @@ class TestEmbeddingTable:
 
         assert embedding_table.input_dim == vocab_size
 
-        inputs = tf.constant([1])
+        inputs = tf.constant([[1]])
         output = embedding_table(inputs)
 
         assert list(output.shape) == [1, embedding_dim]

--- a/tests/unit/tf/inputs/test_tabular.py
+++ b/tests/unit/tf/inputs/test_tabular.py
@@ -96,6 +96,7 @@ def test_tabular_seq_features_ragged_embeddings(sequence_testing_data: Dataset):
     tab_module = ml.InputBlockV2(
         sequence_testing_data.schema,
         embeddings=ml.Embeddings(sequence_testing_data.schema, sequence_combiner=None),
+        aggregation=None,
     )
 
     batch = ml.sample_batch(
@@ -122,6 +123,7 @@ def test_tabular_seq_features_ragged_emb_combiner(sequence_testing_data: Dataset
         sequence_testing_data.schema,
         embeddings=ml.Embeddings(sequence_testing_data.schema, sequence_combiner=seq_combiner),
         continuous_column_selector=con2d,
+        aggregation=None,
     )
 
     batch = ml.sample_batch(
@@ -158,6 +160,7 @@ def test_tabular_seq_features_ragged_custom_emb_combiner(sequence_testing_data: 
                 schema, "_weights"
             ),
         ),
+        aggregation=None,
     )
 
     outputs_weighted_avg = input_block_weighed_avg(batch, features=batch)
@@ -167,6 +170,7 @@ def test_tabular_seq_features_ragged_custom_emb_combiner(sequence_testing_data: 
         embeddings=ml.Embeddings(
             schema, sequence_combiner=tf.keras.layers.Lambda(lambda x: tf.reduce_mean(x, axis=1))
         ),
+        aggregation=None,
     )
 
     outputs_simple_avg = input_block_simple_avg(batch, features=batch)
@@ -200,6 +204,7 @@ def test_tabular_seq_features_avg_embeddings_with_mapvalues(sequence_testing_dat
                 lambda x: tf.math.reduce_mean(x, axis=1) if isinstance(x, tf.RaggedTensor) else x
             )
         ),
+        aggregation=None,
     )
 
     output = input_block(batch)
@@ -211,7 +216,8 @@ def test_tabular_seq_features_avg_embeddings_with_mapvalues(sequence_testing_dat
     assert all(tf.rank(val) == 2 for name, val in output.items() if name in cat_schema.column_names)
 
 
-def test_embedding_tables_from_schema_infer_dims(sequence_testing_data: Dataset):
+@pytest.mark.parametrize("aggregation", [None, "concat"])
+def test_embedding_tables_from_schema_infer_dims(sequence_testing_data: Dataset, aggregation: str):
     cat_schema = sequence_testing_data.schema.select_by_tag(Tags.CATEGORICAL)
     embeddings_block = ml.Embeddings(
         cat_schema,
@@ -221,7 +227,7 @@ def test_embedding_tables_from_schema_infer_dims(sequence_testing_data: Dataset)
         infer_embeddings_ensure_dim_multiple_of_8=True,
         embeddings_initializer="truncated_normal",
     )
-    input_block = ml.InputBlockV2(cat_schema, embeddings=embeddings_block)
+    input_block = ml.InputBlockV2(cat_schema, embeddings=embeddings_block, aggregation=aggregation)
 
     batch = ml.sample_batch(
         sequence_testing_data, batch_size=100, include_targets=False, to_ragged=True
@@ -229,10 +235,13 @@ def test_embedding_tables_from_schema_infer_dims(sequence_testing_data: Dataset)
 
     outputs = input_block(batch)
 
-    assert {k: v.shape[-1] for k, v in outputs.items()} == {
-        "test_user_id": 21,
-        "item_id_seq": 15,
-        # Inferred dims from cardinality
-        "categories": 16,
-        "user_country": 8,
-    }
+    if aggregation == "concat":
+        assert outputs.shape[-1] == 60
+    elif aggregation is None:
+        assert {k: v.shape[-1] for k, v in outputs.items()} == {
+            "test_user_id": 21,
+            "item_id_seq": 15,
+            # Inferred dims from cardinality
+            "categories": 16,
+            "user_country": 8,
+        }

--- a/tests/unit/tf/prediction_tasks/test_multi_task.py
+++ b/tests/unit/tf/prediction_tasks/test_multi_task.py
@@ -50,7 +50,14 @@ def test_mmoe_head(music_streaming_data: Dataset):
     prediction_tasks = ml.PredictionTasks(music_streaming_data.schema)
     mmoe = ml.MMOEBlock(prediction_tasks, expert_block=ml.MLPBlock([64]), num_experts=4)
     model = ml.Model(inputs, ml.MLPBlock([64]), mmoe, prediction_tasks)
-    model.compile(optimizer="adam", run_eagerly=True)
+
+    loss_weights = {
+        "click/binary_classification_task": 1.0,
+        "like/binary_classification_task": 2.0,
+        "play_percentage/regression_task": 3.0,
+    }
+
+    model.compile(optimizer="adam", run_eagerly=True, loss_weights=loss_weights)
 
     metrics = model.train_step(ml.sample_batch(music_streaming_data, batch_size=50))
 


### PR DESCRIPTION
### Context
Currently, if `sample_weight` is provided it is used for computing the loss and metrics for all prediction tasks.
Although, for Multi-Task Learning, it is sometimes necessary to use different `sample_loss` for different prediction tasks.

For example, when training a ranking model that predicts both a click or a purchase we have two separate binary classification tasks. Those the two task losses are summed automatically, with weights optionally defined in `model.compile(loss_weights=)`.

But you might want to have different sample weights for those different tasks. For example, in this use case, `purchase==1`  is only possible if `clicked==1`. So the model gets better results if the loss for purchase target is computed only for clicked examples, to make the purchase target less sparser, like proposed in the [PLE paper](https://dl.acm.org/doi/10.1145/3383313.3412236) about Multi-Task Learning. That can be implemented by giving `sample_weight=0` for purchase task when `clicked==0`, which is what we allow with this PR.

### Goals :soccer:
- [x] Enable support for task-specific sample weights
- [x] Enable support for task-specific weighted metrics
- [x] Adds examples on how to set `loss_weights`, `sample_weights` and `weighted_metrics` in `model.compile()`
- [x] Fixes bugs of `InputBlockV2` and `EmbeddingTable` in graph mode

### Implementation Details :construction:
- In this PR we make it possible to set task-specific `sample_weights` and also to manipulate any information in `PredictionOutput`, like `predictions`, `targets`, `masks`.
- The `sample_weight` can be provided by mapping the dataloader to return a triple (features, targets, sample_weight), or for task-specific `sample_weight` they can be set by means of a `pre` block for the `PredictionTask`
- The `sample_weight` is used to compute the loss and also the `weighted_metrics`. The  `metrics` are not affect by `sample_weight`

### Testing Details :mag:
The new test `test_mmoe_head_task_specific_sample_weight` demonstrates how it is possible to create a custom block that sets a task-specific `sample_weight` based on a feature available in `features` or `targets`.
I also included tests to demonstrate how `loss_weights` can be used to set task-specific weights for the final loss.
