### PR TITLE
Enable predict in XGBoost without targets in provided dataset

### DIFF
--- a/merlin/models/xgb/__init__.py
+++ b/merlin/models/xgb/__init__.py
@@ -61,8 +61,10 @@ class XGBoost:
         self.params = {**params, "objective": objective}
 
         target_tag = get_target_tag(objective)
+        if isinstance(target_columns, str):
+            target_columns = [target_columns]
         self.target_columns = target_columns or get_targets(schema, target_tag)
-        self.feature_columns = get_features(schema)
+        self.feature_columns = get_features(schema, self.target_columns)
 
         if objective.startswith("rank") and qid_column is None:
             qid_column = schema.select_by_tag(Tags.USER_ID).column_names[0]
@@ -211,9 +213,7 @@ class XGBoost:
         if self.booster is None:
             raise ValueError("The fit method must be called before predict.")
 
-        X, _, qid = dataset_to_xy(
-            dataset, self.feature_columns, self.target_columns, self.qid_column
-        )
+        X, _, qid = dataset_to_xy(dataset, self.feature_columns, [], self.qid_column)
         data = xgb.dask.DaskDMatrix(self.dask_client, X, qid=qid)
         preds = xgb.dask.predict(self.dask_client, self.booster, data, **predict_kwargs).compute()
 
@@ -250,10 +250,10 @@ def get_targets(schema: Schema, target_tag: Tags) -> List[str]:
     )
 
 
-def get_features(schema: Schema):
+def get_features(schema: Schema, target_columns: List[str]):
     """Find feature columns from schema. Returns all non-list column names from the schema
     that are not tagged as targets."""
-    all_target_columns = schema.select_by_tag(Tags.TARGET).column_names
+    all_target_columns = schema.select_by_tag(Tags.TARGET).column_names + target_columns
 
     # Ignore list-like columns from schema
     list_column_names = [
@@ -263,7 +263,9 @@ def get_features(schema: Schema):
     if list_column_names:
         warnings.warn(f"Ignoring list columns as inputs to XGBoost model: {list_column_names}.")
 
-    feature_columns = schema.excluding_by_name(list_column_names + all_target_columns).column_names
+    feature_columns = schema.excluding_by_name(
+        set(list_column_names + all_target_columns)
+    ).column_names
     if len(feature_columns) == 0:
         raise ValueError("No feature columns found in schema.")
 
@@ -273,7 +275,7 @@ def get_features(schema: Schema):
 def dataset_to_xy(
     dataset: Dataset,
     feature_columns: List[str],
-    target_columns: Union[str, list],
+    target_columns: List[str],
     qid_column: Optional[str],
 ):
     """Convert Merlin Dataset to XGBoost DMatrix"""


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Fixes #599 

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Enable predictions on datasets without target columns in the XGBoost API

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

Passes empty target_columns when constructing dataset used in `predict` method

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Adds a tests adapted from #599 to check that we can call predict without target columns present in dataset