### PR TITLE
Fix lightfm evaluate code

### DIFF
--- a/merlin/models/lightfm/__init__.py
+++ b/merlin/models/lightfm/__init__.py
@@ -86,9 +86,9 @@ class LightFM:
             self.lightfm_model, test, self.train_data, k=k, num_threads=self.num_threads
         ).mean()
         auc = lightfm.evaluation.auc_score(
-            self.lightfm_model, test, self.train_data, k=k, num_threads=self.num_threads
+            self.lightfm_model, test, self.train_data, num_threads=self.num_threads
         ).mean()
-        return {f"precisions@{k}": precision, f"auc@{k}": auc}
+        return {f"precisions@{k}": precision, "auc": auc}
 
     def predict(self, dataset: Dataset, k=10):
         """Generate predictions from the dataset

--- a/tests/unit/lightfm/test_lightfm.py
+++ b/tests/unit/lightfm/test_lightfm.py
@@ -13,14 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from merlin.io import Dataset
+import numpy as np
+
+from merlin.datasets.synthetic import generate_data
 from merlin.models.lightfm import LightFM
 from merlin.schema import Tags
 
 
-def test_warp(music_streaming_data: Dataset):
-    music_streaming_data.schema = music_streaming_data.schema.remove_by_tag(Tags.TARGET)
-    model = LightFM(learning_rate=0.05, loss="warp", epochs=10)
-    model.fit(music_streaming_data)
+def test_warp():
+    np.random.seed(0)
+    train, valid = generate_data("music-streaming", 100, (0.95, 0.05))
+    train.schema = train.schema.remove_by_tag(Tags.TARGET)
+    valid.schema = valid.schema.remove_by_tag(Tags.TARGET)
 
-    model.predict(music_streaming_data)
+    model = LightFM(learning_rate=0.05, loss="warp", epochs=10)
+    model.fit(train)
+
+    model.predict(train)
+
+    metrics = model.evaluate(valid, k=10)
+    assert metrics["auc"] > 0.01


### PR DESCRIPTION
the lightfm evaluate code was passing a 'k' parameter to auc_score -
which is the one metrics in lightfm that doesn't take a 'k' parameter.
Fix and add the evaluate code to the unittests to catch this kind of bug