### PR TITLE
Update setup.cfg to fix the import error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 # package_dir =
 # = src
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.8
 
 [options.packages.find]
 # where = src


### PR DESCRIPTION


<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->



### Goals :soccer:
- For python < 3.8 The merlin import fails on this line on [dataset.py:338](https://github.com/NVIDIA-Merlin/models/blob/53c17e1ce68abc7752ddcd96b68fa24181266dc6/merlin/models/tf/dataset.py#L338) with this error: `Invalid Syntax` 
Pylance reports this error: `Unpack operation not allowed in tuples prior to Python 3.8`
![image](https://user-images.githubusercontent.com/4503796/182804608-7f561749-6cae-4aba-8c8d-2a77bcc17dde.png)


### Implementation Details :construction:
Just changing the `python_requires` to be  `>=3.8`

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
Tested that it works with >=3.8 (I tested with 3.9)
