### PR TITLE
Enable `TabularData` to be used with `EmbeddingTable`

### DIFF
--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -190,6 +190,7 @@ class EmbeddingTable(EmbeddingTableBase):
                 **table_kwargs,
             )
         self.combiner = combiner
+        self.supports_masking = True
 
     @classmethod
     def from_pretrained(

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -299,7 +299,12 @@ class EmbeddingTable(EmbeddingTableBase):
 
         return out
 
-    def compute_output_shape(self, input_shape):
+    def compute_output_shape(
+        self, input_shape: Union[tf.TensorShape, Dict[str, tf.TensorShape]]
+    ) -> tf.Tensor:
+        if isinstance(input_shape, dict):
+            input_shape = input_shape[self.col_schema.name]
+
         first_dims = input_shape
         if (self.combiner is not None) or (input_shape.rank > 1 and input_shape[-1] == 1):
             first_dims = input_shape[:-1]

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -247,7 +247,7 @@ class EmbeddingTable(EmbeddingTableBase):
         #    self.combiner.build(self.table.compute_output_shape(input_shapes))
         return super(EmbeddingTable, self).build(input_shapes)
 
-    def call(self, inputs, **kwargs):
+    def call(self, inputs: Union[tf.Tensor, TabularData], **kwargs) -> tf.Tensor:
         """
         Parameters
         ----------

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -99,6 +99,18 @@ class TestEmbeddingTable:
         output = copied_layer(inputs)
         assert list(output.shape) == expected_output_shape
 
+    def test_layer_simple(self):
+        col_schema = self.sample_column_schema
+        dim = np.random.randint(1, high=32)
+        testing_utils.layer_test(
+            mm.EmbeddingTable,
+            kwargs={"dim": dim, "col_schema": col_schema},
+            input_data=tf.constant([[1], [2], [3]], dtype=tf.int32),
+            expected_output_shape=tf.TensorShape([None, dim]),
+            expected_output_dtype=tf.float32,
+            supports_masking=True,
+        )
+
     @pytest.mark.parametrize(
         ["input_shape", "expected_output_shape", "kwargs"],
         [

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -74,6 +74,7 @@ class TestEmbeddingTable:
             (16, {}, tf.ragged.constant([[1, 2, 3], [4, 5]]), [2, None, 16]),
             (16, {"combiner": "mean"}, tf.ragged.constant([[1, 2, 3], [4, 5]]), [2, 16]),
             (16, {"combiner": "mean"}, tf.sparse.from_dense(tf.constant([[1, 2, 3]])), [1, 16]),
+            (12, {}, {"item_id": tf.constant([[1]])}, [1, 12]),
         ],
     )
     def test_layer(self, dim, kwargs, inputs, expected_output_shape):
@@ -85,6 +86,8 @@ class TestEmbeddingTable:
 
         if "combiner" in kwargs:
             assert isinstance(output, tf.Tensor)
+        elif isinstance(inputs, dict):
+            assert type(inputs[column_schema.name]) is type(output)
         else:
             assert type(inputs) is type(output)
 

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -99,6 +99,22 @@ class TestEmbeddingTable:
         output = copied_layer(inputs)
         assert list(output.shape) == expected_output_shape
 
+    @pytest.mark.parametrize(
+        ["input_shape", "expected_output_shape", "kwargs"],
+        [
+            (tf.TensorShape([1, 1]), tf.TensorShape([1, 10]), {}),
+            (tf.TensorShape([1, 3]), tf.TensorShape([1, 3, 10]), {}),
+            (tf.TensorShape([2, None]), tf.TensorShape([2, None, 10]), {}),
+            (tf.TensorShape([2, None]), tf.TensorShape([2, 10]), {"combiner": "mean"}),
+            ({"item_id": tf.TensorShape([1, 1])}, tf.TensorShape([1, 10]), {}),
+        ],
+    )
+    def test_compute_output_shape(self, input_shape, expected_output_shape, kwargs):
+        column_schema = self.sample_column_schema
+        layer = mm.EmbeddingTable(10, column_schema, **kwargs)
+        output_shape = layer.compute_output_shape(input_shape)
+        assert list(output_shape) == list(expected_output_shape)
+
     def test_dense_with_combiner(self):
         dim = 16
         column_schema = self.sample_column_schema


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Relates to https://github.com/NVIDIA-Merlin/Merlin/issues/479

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

The `EmbeddingTable` layer has partial support for TabularData inputs and masking. (It was written with the intent to support both. This PR is a follow-up to add further implementation for these features.

- Enable `EmbeddingTable` layer to be used with TabularData inputs (`Dict[str, Tensor]`).
- Enable `EmbeddingTable` layer to be used with masking

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

- Trying to use `EmbeddingTable` in contexts where a dict of tensors is passed currently throws an exception from the `compute_output_shape` method. Extending support for this input format.
- Setting `supports_masking = True` in the constructor of `EmbeddingTable` to 

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Added tests for `compute_output_shape` with different inputs.