### PR TITLE
Enable static weights to be used with `EmbeddingTable.from_pretrained`

### DIFF
--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -180,6 +180,7 @@ class EmbeddingTable(EmbeddingTableBase):
                 embeddings_constraint=embeddings_constraint,
                 mask_zero=mask_zero,
                 input_length=input_length,
+                trainable=trainable,
             )
             self.table = tf.keras.layers.Embedding(
                 input_dim=self.input_dim,

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -163,7 +163,6 @@ class EmbeddingTable(EmbeddingTableBase):
         dtype=None,
         dynamic=False,
         table=None,
-        weights=None,
         **kwargs,
     ):
         """Create an EmbeddingTable."""
@@ -180,7 +179,6 @@ class EmbeddingTable(EmbeddingTableBase):
                 activity_regularizer=activity_regularizer,
                 embeddings_constraint=embeddings_constraint,
                 mask_zero=mask_zero,
-                weights=weights,
                 input_length=input_length,
             )
             self.table = tf.keras.layers.Embedding(
@@ -226,7 +224,7 @@ class EmbeddingTable(EmbeddingTableBase):
             dim,
             col_schema,
             name=name,
-            weights=[tf.Variable(embeddings, trainable=trainable)],
+            embeddings_initializer=tf.keras.initializers.constant(embeddings),
             trainable=trainable,
             **kwargs,
         )

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -166,14 +166,6 @@ class TestEmbeddingTable:
             pre_trained_weights_df, name="item_id", trainable=trainable
         )
 
-        assert embedding_table.input_dim == vocab_size
-
-        inputs = tf.constant([[1]])
-        output = embedding_table(inputs)
-
-        assert list(output.shape) == [1, embedding_dim]
-        np.testing.assert_array_almost_equal(weights, embedding_table.table.embeddings)
-
         model = mm.Model(
             tf.keras.layers.Lambda(lambda inputs: inputs["item_id"]),
             embedding_table,


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Relates to https://github.com/NVIDIA-Merlin/Merlin/issues/479

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Enable static weights to be used with the `EmbeddingTable.from_pretrained` method

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

The current implementation initializes the embedings using the `weights` parameter.

However, this only works if the layer is called first before the model is compiled/fit.

Switching to use the `embeddings_initializer` parameter instead which works as expected with trainable False.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Removing part of the test for the from_pretrained method to capture the behaviour of the embeddings correctly.