### PR TITLE
Update stacking in `DLRMBlock` to use correct axis for the dot product.

### DIFF
--- a/merlin/models/tf/blocks/dlrm.py
+++ b/merlin/models/tf/blocks/dlrm.py
@@ -17,6 +17,7 @@
 from typing import Optional
 
 from merlin.models.tf.blocks.interaction import DotProductInteraction
+from merlin.models.tf.core.aggregation import StackFeatures
 from merlin.models.tf.core.base import Block, Debug
 from merlin.models.tf.core.combinators import Filter, ParallelBlock, SequentialBlock
 from merlin.models.tf.inputs.continuous import ContinuousFeatures
@@ -134,4 +135,4 @@ def DLRMBlock(
 
 
 def DotProductInteractionBlock():
-    return SequentialBlock(DotProductInteraction(), pre_aggregation="stack")
+    return SequentialBlock(StackFeatures(axis=1), DotProductInteraction())

--- a/tests/unit/tf/blocks/test_dlrm.py
+++ b/tests/unit/tf/blocks/test_dlrm.py
@@ -22,26 +22,31 @@ from merlin.schema import Tags
 
 
 def test_dlrm_block(testing_data: Dataset):
+    schema = testing_data.schema
     dlrm = ml.DLRMBlock(
-        testing_data.schema,
+        schema,
         embedding_dim=64,
         bottom_block=ml.MLPBlock([64]),
         top_block=ml.DenseResidualBlock(),
     )
     outputs = dlrm(ml.sample_batch(testing_data, batch_size=100, include_targets=False))
-
-    assert list(outputs.shape) == [100, 2080]
+    num_features = len(schema.select_by_tag(Tags.CATEGORICAL)) + 1
+    dot_product_dim = (num_features - 1) * num_features // 2
+    assert list(outputs.shape) == [100, dot_product_dim + 64]
 
 
 def test_dlrm_block_no_top_block(testing_data: Dataset):
+    schema = testing_data.schema
     dlrm = ml.DLRMBlock(
-        testing_data.schema,
+        schema,
         embedding_dim=64,
         bottom_block=ml.MLPBlock([64]),
     )
     outputs = dlrm(ml.sample_batch(testing_data, batch_size=100, include_targets=False))
+    num_features = len(schema.select_by_tag(Tags.CATEGORICAL)) + 1
+    dot_product_dim = (num_features - 1) * num_features // 2
 
-    assert list(outputs.shape) == [100, 2016]
+    assert list(outputs.shape) == [100, dot_product_dim]
 
 
 def test_dlrm_block_no_continuous_features(testing_data: Dataset):


### PR DESCRIPTION


<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Correct the implementation of the dot product component of the DLRM Layer.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

While adding a test in #619
Noticed that the output dimension didn't feel right.

The stacking aggregation is using axis -1 (the default in `StackFeatures`).

Which results in the `DotProductInteraction` receiving inputs with shape `(batch_size, embedding_dim, num_features)` instead of the expected shape `(batch_size, num_features, embedding_dim)`.

This changes the axis to 1 so that the embedding dim comes last.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Updated existing tests for the expected output shape of the DLRMBlock. 