### PR TITLE
Remove `-e` from pip install commands in github workflows

### DIFF
--- a/.github/workflows/datasets.yml
+++ b/.github/workflows/datasets.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[dev]
+          python -m pip install .[dev]
       - name: Build
         run: |
           python setup.py develop

--- a/.github/workflows/docs-sched-rebuild.yaml
+++ b/.github/workflows/docs-sched-rebuild.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[all]
+          python -m pip install .[all]
       - name: Build
         run: |
           python setup.py develop

--- a/.github/workflows/implicit.yml
+++ b/.github/workflows/implicit.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[implicit-dev]
+          python -m pip install .[implicit-dev]
       - name: Build
         run: |
           python setup.py develop

--- a/.github/workflows/lightfm.yml
+++ b/.github/workflows/lightfm.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[lightfm-dev]
+          python -m pip install .[lightfm-dev]
       - name: Build
         run: |
           python setup.py develop

--- a/.github/workflows/pytorch.yml
+++ b/.github/workflows/pytorch.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[pytorch-dev]
+          python -m pip install .[pytorch-dev]
       - name: Build
         run: |
           python setup.py develop

--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install "tensorflow<${{ matrix.tf-max }}"
-          python -m pip install -e .[tensorflow-dev]
+          python -m pip install .[tensorflow-dev]
       - name: Build
         run: |
           python setup.py develop
@@ -107,7 +107,7 @@ jobs:
           pip install "merlin-core@git+https://github.com/NVIDIA-Merlin/core.git"
       - name: Install dependencies
         run: |
-          python -m pip install -e .[tensorflow-dev]
+          python -m pip install .[tensorflow-dev]
       - name: Build
         run: |
           python setup.py develop

--- a/.github/workflows/xgboost.yml
+++ b/.github/workflows/xgboost.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[xgboost-dev]
+          python -m pip install .[xgboost-dev]
       - name: Build
         run: |
           python setup.py develop


### PR DESCRIPTION


<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Restore Github Actions CI workflows to working state.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

The recent release ([64.0.0](https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6400)) of setuptools has changed the way the editable install works in line with PEP 660.

However, the versioneer module in our code (copied from https://github.com/python-versioneer/python-versioneer) has some assumptions about the way the editable install works that breaks with this release.

One option (implemented in this PR) is to remove the editable install. It's not clear to me why we require editable installs in the test environment. If we find out later that it's needed for some reason we can easily revert this change.

Alternatively, we could set the environment variable `SETUPTOOLS_ENABLE_FEATURE=legacy-editable` as a temporary workaround. 

Another option (which we'll probably need to also make changes for to support development workflow) is to patch the `versioneer.py` file with changes suggested in https://github.com/python-versioneer/python-versioneer/issues/314

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

No tests changed. Looking to see if the unit tests here pass in Github Actions workflows.