### PR TITLE
Breaks ties of top-k metrics

### DIFF
--- a/merlin/models/tf/metrics/topk.py
+++ b/merlin/models/tf/metrics/topk.py
@@ -257,7 +257,9 @@ class TopkMetric(Mean, TopkMetricWithLabelRelevantCountsMixin):
 
     def _maybe_sort_top_k(self, y_pred, y_true, label_relevant_counts: tf.Tensor = None):
         if not self.pre_sorted:
-            y_pred, y_true, label_relevant_counts = extract_topk(self.k, y_pred, y_true)
+            y_pred, y_true, label_relevant_counts = extract_topk(
+                self.k, y_pred, y_true, shuffle_ties=True
+            )
         else:
             if label_relevant_counts is None:
                 raise Exception(
@@ -369,10 +371,12 @@ class TopKMetricsAggregator(Metric, TopkMetricWithLabelRelevantCountsMixin):
     def update_state(
         self, y_true: tf.Tensor, y_pred: tf.Tensor, sample_weight: Optional[tf.Tensor] = None
     ):
-        # Extractubg sorted top-k prediction scores and labels only ONCE
+        # Extracting sorted top-k prediction scores and labels only ONCE
         # so that sorting does not need to happen for each individual metric
         # (as the top-k metrics have been set with pre_sorted=True in this constructor
-        y_pred, y_true, label_relevant_counts_from_targets = extract_topk(self.k, y_pred, y_true)
+        y_pred, y_true, label_relevant_counts_from_targets = extract_topk(
+            self.k, y_pred, y_true, shuffle_ties=True
+        )
 
         # If label_relevant_counts is not set by a block (e.g. TopKIndexBlock) that
         # has already extracted the top-k predictions, it is assumed that

--- a/tests/unit/tf/metrics/test_metrics_topk.py
+++ b/tests/unit/tf/metrics/test_metrics_topk.py
@@ -50,7 +50,9 @@ def topk_metrics_test_data():
 @pytest.fixture
 def topk_metrics_test_data_pre_sorted(topk_metrics_test_data):
     labels, predictions, _ = topk_metrics_test_data
-    predictions, labels, label_relevant_counts = extract_topk(5, predictions, labels)
+    predictions, labels, label_relevant_counts = extract_topk(
+        5, predictions, labels, shuffle_ties=True
+    )
     return labels, predictions, label_relevant_counts
 
 
@@ -179,7 +181,7 @@ def test_topk_metrics_classes_pre_or_not_sorted_matches(
     labels, predictions, label_relevant_counts = topk_metrics_test_data
     # Pre-sorting predictions and labels
     predictions_sorted, labels_sorted, label_relevant_counts_sorted = extract_topk(
-        4, predictions, labels
+        4, predictions, labels, shuffle_ties=True
     )
 
     metric1 = metric_class(k=4, pre_sorted=True)

--- a/tests/unit/tf/utils/test_tf_utils.py
+++ b/tests/unit/tf/utils/test_tf_utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import tensorflow as tf
 
 from merlin.models.tf.utils import tf_utils
@@ -36,3 +37,62 @@ class TestTensorInitializer:
         output_2 = reloaded_model(input_tensor).numpy()
 
         np.testing.assert_array_almost_equal(output, output_2)
+
+
+def test_extract_topk():
+    labels = tf.convert_to_tensor(
+        [
+            [0, 1, 0, 1, 0, 0, 1, 0, 0, 0],
+            [1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
+            [0, 1, 0, 0, 1, 0, 0, 0, 1, 0],
+        ],
+        tf.float32,
+    )
+    predictions = tf.convert_to_tensor(
+        [
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            [1, 3, 5, 7, 9, 2, 4, 6, 8, 10],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+        ],
+        tf.float32,
+    )
+
+    predictions_expected = tf.convert_to_tensor(
+        [[10, 9, 8, 7, 6], [10, 9, 8, 7, 6], [1, 1, 1, 1, 1]], tf.float32
+    )
+    labels_expected = tf.convert_to_tensor(
+        [[0, 0, 0, 1, 0], [0, 0, 0, 1, 0], [0, 1, 0, 0, 1]],
+        tf.float32,
+    )
+    label_relevant_counts_expected = tf.convert_to_tensor([3, 2, 3], tf.float32)
+
+    cutoff = 5
+    predictions_sorted, labels_sorted, label_relevant_counts = tf_utils.extract_topk(
+        cutoff, predictions, labels
+    )
+    tf.debugging.assert_equal(label_relevant_counts_expected, label_relevant_counts)
+    tf.debugging.assert_equal(labels_expected, labels_sorted[:, :cutoff])
+    tf.debugging.assert_equal(predictions_expected, predictions_sorted[:, :cutoff])
+
+
+@pytest.mark.parametrize("shuffle_ties", [True, False])
+def test_extract_topk_shuffle_ties(shuffle_ties):
+    labels = tf.convert_to_tensor(
+        [
+            [0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+            [1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0],
+            [0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+        ],
+        tf.float32,
+    )
+    predictions = tf.convert_to_tensor([[10.0] * 20, [5.0] * 20, [6] * 20], tf.float32)
+    label_relevant_counts_expected = tf.convert_to_tensor([5, 4, 4], tf.float32)
+    cutoff = 10
+    predictions_sorted, labels_sorted, label_relevant_counts = tf_utils.extract_topk(
+        cutoff, predictions, labels, shuffle_ties=shuffle_ties
+    )
+    tf.debugging.assert_equal(label_relevant_counts, label_relevant_counts_expected)
+    if shuffle_ties:
+        assert not tf.reduce_all(tf.math.equal(labels_sorted, labels[:, :cutoff]))
+    else:
+        tf.debugging.assert_equal(labels_sorted, labels[:, :cutoff])


### PR DESCRIPTION
Fixes #617
With this fix, we break ties of top-k metrics.
That is done by adding a small random epsilon to the predictions.
That way, we avoid issues when the score of all predictions is equal, like reported in #617

Also added tests and docstrings to `extract_topk()`