### PR TITLE
Removing use of synthetic data in traditional models notebook test.

### DIFF
--- a/tests/unit/tf/examples/test_07_train_traditional_models.py
+++ b/tests/unit/tf/examples/test_07_train_traditional_models.py
@@ -13,23 +13,6 @@ pytest.importorskip("implicit")
     execute=False,
 )
 def test_func(tb):
-    tb.inject(
-        """
-        from unittest.mock import patch
-        from merlin.datasets.synthetic import generate_data
-        mock_train, mock_valid = generate_data(
-            input="movielens-100k",
-            num_rows=1000,
-            set_sizes=(0.8, 0.2)
-        )
-        p1 = patch(
-            "merlin.datasets.entertainment.get_movielens",
-            return_value=[mock_train, mock_valid]
-        )
-        p1.start()
-        """
-    )
-    tb.cells.pop(34)
     tb.execute()
     xgboost_metrics = tb.ref("metrics")
     implicit_metrics = tb.ref("implicit_metrics")


### PR DESCRIPTION
The synthetic data has some issues with it's train/test split functionality.

<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Follow-up to #629

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Unblock PRs by fixing flaky/failing test.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

The notebook being tested here uses implicit and lightfm. These models have some requirements for the way the data is split into train/test.

- Implicit requires that the test user-item matrix is not larger than the training user-item matrix. This is not guaranteed by the synthetic data. (if the largest user or item id ends in the test data)
- LightFM requries that no interactions are shared between train/test when evaluating. This is not guaranteed by the synthetic data. (in fact it's very likely to happen).

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Removing the use of synthetic data in the unit test for traditional models. We can bring this back if we change the way this works in the synthetic module that generates this.