### PR TITLE
Fix test failing at random

### DIFF
--- a/tests/unit/tf/examples/test_07_train_traditional_models.py
+++ b/tests/unit/tf/examples/test_07_train_traditional_models.py
@@ -13,7 +13,7 @@ pytest.importorskip("implicit")
     execute=False,
 )
 def test_func(tb):
-    tb.execute()
+    tb.execute_cell(list(range(34)))
     xgboost_metrics = tb.ref("metrics")
     implicit_metrics = tb.ref("implicit_metrics")
 


### PR DESCRIPTION
This fixes a test that was intermittently failing:
```
nbclient.exceptions.CellExecutionError: An error occurred while executing the following cell:

E           ------------------

E           lightfm_preds = lightfm.predict(valid)

E           ------------------

E

E           �[0;31m---------------------------------------------------------------------------�[0m

E           �[0;31mValueError�[0m                                Traceback (most recent call last)

E           Input �[0;32mIn [17]�[0m, in �[0;36m<cell line: 1>�[0;34m()�[0m

E           �[0;32m----> 1�[0m lightfm_preds �[38;5;241m=�[39m �[43mlightfm�[49m�[38;5;241;43m.�[39;49m�[43mpredict�[49m�[43m(�[49m�[43mvalid�[49m�[43m)�[49m

E

E           File �[0;32m~/workspace/merlin_models/models/merlin/models/lightfm/init.py:103�[0m, in �[0;36mLightFM.predict�[0;34m(self, dataset, k)�[0m

E           �[1;32m     94�[0m �[38;5;124;03m"""Generate predictions from the dataset�[39;00m

E           �[1;32m     95�[0m

E           �[1;32m     96�[0m �[38;5;124;03mParameters�[39;00m

E           �[0;32m   (...)�[0m

E           �[1;32m    100�[0m �[38;5;124;03m    The number of recommendations to generate for each user�[39;00m

E           �[1;32m    101�[0m �[38;5;124;03m"""�[39;00m

E           �[1;32m    102�[0m data �[38;5;241m=�[39m dataset_to_coo(dataset)

E           �[0;32m--> 103�[0m �[38;5;28;01mreturn�[39;00m �[38;5;28;43mself�[39;49m�[38;5;241;43m.�[39;49m�[43mlightfm_model�[49m�[38;5;241;43m.�[39;49m�[43mpredict�[49m�[43m(�[49m�[43mdata�[49m�[38;5;241;43m.�[39;49m�[43mrow�[49m�[43m,�[49m�[43m �[49m�[43mdata�[49m�[38;5;241;43m.�[39;49m�[43mcol�[49m�[43m)�[49m

E

E           File �[0;32m/usr/local/lib/python3.8/dist-packages/lightfm/lightfm.py:817�[0m, in �[0;36mLightFM.predict�[0;34m(self, user_ids, item_ids, item_features, user_features, num_threads)�[0m

E           �[1;32m    814�[0m n_users �[38;5;241m=�[39m user_ids�[38;5;241m.�[39mmax() �[38;5;241m+�[39m �[38;5;241m1�[39m

E           �[1;32m    815�[0m n_items �[38;5;241m=�[39m item_ids�[38;5;241m.�[39mmax() �[38;5;241m+�[39m �[38;5;241m1�[39m

E           �[0;32m--> 817�[0m (user_features, item_features) �[38;5;241m=�[39m �[38;5;28;43mself�[39;49m�[38;5;241;43m.�[39;49m�[43m_construct_feature_matrices�[49m�[43m(�[49m

E           �[1;32m    818�[0m �[43m    �[49m�[43mn_users�[49m�[43m,�[49m�[43m �[49m�[43mn_items�[49m�[43m,�[49m�[43m �[49m�[43muser_features�[49m�[43m,�[49m�[43m �[49m�[43mitem_features�[49m

E           �[1;32m    819�[0m �[43m�[49m�[43m)�[49m

E           �[1;32m    821�[0m lightfm_data �[38;5;241m=�[39m �[38;5;28mself�[39m�[38;5;241m.�[39m_get_lightfm_data()

E           �[1;32m    823�[0m predictions �[38;5;241m=�[39m np�[38;5;241m.�[39mempty(�[38;5;28mlen�[39m(user_ids), dtype�[38;5;241m=�[39mnp�[38;5;241m.�[39mfloat32)

E

E           File �[0;32m/usr/local/lib/python3.8/dist-packages/lightfm/lightfm.py:335�[0m, in �[0;36mLightFM._construct_feature_matrices�[0;34m(self, n_users, n_items, user_features, item_features)�[0m

E           �[1;32m    333�[0m �[38;5;28;01mif�[39;00m �[38;5;28mself�[39m�[38;5;241m.�[39mitem_embeddings �[38;5;129;01mis�[39;00m �[38;5;129;01mnot�[39;00m �[38;5;28;01mNone�[39;00m:

E           �[1;32m    334�[0m     �[38;5;28;01mif�[39;00m �[38;5;129;01mnot�[39;00m �[38;5;28mself�[39m�[38;5;241m.�[39mitem_embeddings�[38;5;241m.�[39mshape[�[38;5;241m0�[39m] �[38;5;241m>�[39m�[38;5;241m=�[39m item_features�[38;5;241m.�[39mshape[�[38;5;241m1�[39m]:

E           �[0;32m--> 335�[0m         �[38;5;28;01mraise�[39;00m �[38;5;167;01mValueError�[39;00m(

E           �[1;32m    336�[0m             �[38;5;124m"�[39m�[38;5;124mThe item feature matrix specifies more �[39m�[38;5;124m"�[39m

E           �[1;32m    337�[0m             �[38;5;124m"�[39m�[38;5;124mfeatures than there are estimated �[39m�[38;5;124m"�[39m

E           �[1;32m    338�[0m             �[38;5;124m"�[39m�[38;5;124mfeature embeddings: �[39m�[38;5;132;01m{}�[39;00m�[38;5;124m vs �[39m�[38;5;132;01m{}�[39;00m�[38;5;124m.�[39m�[38;5;124m"�[39m�[38;5;241m.�[39mformat(

E           �[1;32m    339�[0m                 �[38;5;28mself�[39m�[38;5;241m.�[39mitem_embeddings�[38;5;241m.�[39mshape[�[38;5;241m0�[39m], item_features�[38;5;241m.�[39mshape[�[38;5;241m1�[39m]

E           �[1;32m    340�[0m             )

E           �[1;32m    341�[0m         )

E           �[1;32m    343�[0m user_features �[38;5;241m=�[39m �[38;5;28mself�[39m�[38;5;241m.�[39m_to_cython_dtype(user_features)

E           �[1;32m    344�[0m item_features �[38;5;241m=�[39m �[38;5;28mself�[39m�[38;5;241m.�[39m_to_cython_dtype(item_features)

E

E           �[0;31mValueError�[0m: The item feature matrix specifies more features than there are estimated feature embeddings: 292 vs 327.

E           ValueError: The item feature matrix specifies more features than there are estimated feature embeddings: 292 vs 327.
```