### PR TITLE
XGBoost - Use DaskDMatrix for evals data to ensure metrics in logs match result of evaluate

### DIFF
--- a/merlin/models/xgb/__init__.py
+++ b/merlin/models/xgb/__init__.py
@@ -171,7 +171,10 @@ class XGBoost:
                 self.target_columns,
                 self.qid_column,
             )
-            d_eval = dmatrix_cls(self.dask_client, X, label=y, qid=qid)
+            # using the quantile DMatrix as part of evals results in a
+            # discrepancy between metrics reported in logs and result
+            # of evaluate
+            d_eval = xgb.dask.DaskDMatrix(self.dask_client, X, label=y, qid=qid)
             watchlist.append((d_eval, name))
 
         train_res = xgb.dask.train(

--- a/tests/unit/xgb/test_xgboost.py
+++ b/tests/unit/xgb/test_xgboost.py
@@ -121,14 +121,13 @@ class TestXGBoost:
     ],
 )
 @patch("xgboost.dask.train", side_effect=xgboost.dask.train)
-def test_gpu_hist_dmatrix(
-    mock_train, fit_kwargs, expected_dtrain_cls, dask_client, music_streaming_data: Dataset
-):
-    schema = music_streaming_data.schema
+def test_gpu_hist_dmatrix(mock_train, fit_kwargs, expected_dtrain_cls, dask_client):
+    train, valid = generate_data("music-streaming", num_rows=100, set_sizes=(0.5, 0.5))
+    schema = train.schema
     model = XGBoost(schema, objective="reg:logistic", tree_method="gpu_hist")
-    model.fit(music_streaming_data, **fit_kwargs)
-    model.predict(music_streaming_data)
-    metrics = model.evaluate(music_streaming_data)
+    model.fit(train, evals=[(valid, "valid")], **fit_kwargs)
+    model.predict(valid)
+    metrics = model.evaluate(valid)
     assert "rmse" in metrics
 
     assert mock_train.called
@@ -136,9 +135,12 @@ def test_gpu_hist_dmatrix(
 
     train_call = mock_train.call_args_list[0]
     client, params, dtrain = train_call.args
+    evals = train_call.kwargs["evals"]
     assert dask_client == client
     assert params["tree_method"] == "gpu_hist"
     assert params["objective"] == "reg:logistic"
+    # check that we don't use quantile dmatrix for non-training eval data
+    assert not isinstance(evals[0][0], xgboost.dask.DaskDeviceQuantileDMatrix)
     assert isinstance(dtrain, expected_dtrain_cls)
 
 


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->


### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Ensure metrics in logs match the result of the `.evaluate` method.

Example in this gist of the metrics difference:
https://gist.github.com/oliverholworthy/db8dfca6e08d29fa6481f5f9d66c8049

Issue reported by @rnyak 

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

When using the DaskDeviceQuantileDMatrix in the `evals` passed to the train function, there is a difference between the metrics reported in the logs printed to the screen and the metric you will get from the call to `model.evaluate`.

We can resolve this by always using the DaskDMatrix for evals data (Thanks to @radekosmulski for this suggestion). The downside of this might be if you have a sufficiently large dataset you want to pass to evals that requires the efficiency of the DeviceQuantileDMatrix when running on the GPU. 

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Added a test to ensure that dmatrix passed to evals is not the device quantile version.