### PR TITLE
Extend `EmbeddingTable` and `Embeddings` with support for shared embeddings

### DIFF
--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -62,7 +62,7 @@ EMBEDDING_FEATURES_PARAMS_DOCSTRING = """
 
 
 class EmbeddingTableBase(Block):
-    def __init__(self, dim: int, col_schema: ColumnSchema, trainable=True, **kwargs):
+    def __init__(self, dim: int, col_schema: ColumnSchema, *, trainable=True, **kwargs):
         super(EmbeddingTableBase, self).__init__(trainable=trainable, **kwargs)
         self.dim = dim
 
@@ -184,6 +184,7 @@ class EmbeddingTable(EmbeddingTableBase):
         self,
         dim: int,
         col_schema: ColumnSchema,
+        *,
         embeddings_initializer="uniform",
         embeddings_regularizer=None,
         activity_regularizer=None,

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -342,9 +342,10 @@ class EmbeddingTable(EmbeddingTableBase):
         if isinstance(input_shape, dict):
             output_shapes = {}
             for feature_name in self.feature_names:
-                output_shapes[feature_name] = self._compute_output_shape_table(
-                    input_shape[feature_name]
-                )
+                if feature_name in input_shape:
+                    output_shapes[feature_name] = self._compute_output_shape_table(
+                        input_shape[feature_name]
+                    )
         else:
             output_shapes = self._compute_output_shape_table(input_shape)
 

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -483,7 +483,13 @@ def Embeddings(
 
     for col in schema:
         table_kwargs = _forward_kwargs_to_table(col, table_cls, kwargs)
-        tables[col.name] = table_cls(_get_dim(col, dim, infer_dim_fn), col, **table_kwargs)
+        table_name = col.int_domain.name or col.name
+        if table_name in tables:
+            tables[table_name].add_feature(col)
+        else:
+            tables[table_name] = table_cls(
+                _get_dim(col, dim, infer_dim_fn), col, name=table_name, **table_kwargs
+            )
 
     return ParallelBlock(
         tables, pre=pre, post=post, aggregation=aggregation, name=block_name, schema=schema

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -87,6 +87,10 @@ class EmbeddingTableBase(Block):
     def input_dim(self):
         return self.col_schema.int_domain.max + 1
 
+    @property
+    def table_name(self):
+        return self.col_schema.int_domain.name or self.col_schema.name
+
     def add_feature(self, col_schema: ColumnSchema) -> None:
         if not col_schema.int_domain:
             raise ValueError("`col_schema` needs to have an int-domain")
@@ -214,7 +218,7 @@ class EmbeddingTable(EmbeddingTableBase):
             self.table = tf.keras.layers.Embedding(
                 input_dim=self.input_dim,
                 output_dim=self.dim,
-                name=self.col_schema.name,
+                name=self.table_name,
                 **table_kwargs,
             )
         self.sequence_combiner = sequence_combiner

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -260,7 +260,9 @@ class EmbeddingTable(EmbeddingTableBase):
         -------
         A tensor corresponding to the embeddings for inputs
         """
+        return_dict = False
         if isinstance(inputs, dict):
+            return_dict = True
             inputs = inputs[self.col_schema.name]
 
         if isinstance(inputs, tuple) and len(inputs) == 2:
@@ -294,6 +296,9 @@ class EmbeddingTable(EmbeddingTableBase):
             # Instead of casting the variable as in most layers, cast the output, as
             # this is mathematically equivalent but is faster.
             out = tf.cast(out, self._dtype_policy.compute_dtype)
+
+        if return_dict:
+            out = {self.col_schema.name: out}
 
         return out
 

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -71,6 +71,8 @@ class EmbeddingTableBase(Block):
 
         self.col_schema = col_schema
 
+        self.feature_names = [col_schema.name]
+
     @classmethod
     def from_pretrained(
         cls,
@@ -84,6 +86,28 @@ class EmbeddingTableBase(Block):
     @property
     def input_dim(self):
         return self.col_schema.int_domain.max + 1
+
+    def add_feature(self, col_schema: ColumnSchema) -> None:
+        if not col_schema.int_domain:
+            raise ValueError("`col_schema` needs to have an int-domain")
+
+        if (
+            col_schema.int_domain.name
+            and self.col_schema.int_domain.name
+            and col_schema.int_domain.name != self.col_schema.int_domain.name
+        ):
+            raise ValueError(
+                "`col_schema` int-domain name does not match table domain name. "
+                f"{col_schema.int_domain.name} != {self.col_schema.int_domain.name} "
+            )
+
+        if col_schema.int_domain.max != self.col_schema.int_domain.max:
+            raise ValueError(
+                "`col_schema.int_domain.max` does not match existing input dim."
+                f"{col_schema.int_domain.max} != {self.col_schema.int_domain.max} "
+            )
+
+        self.feature_names += col_schema.name
 
     def get_config(self):
         config = super().get_config()

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -247,8 +247,6 @@ class EmbeddingTable(EmbeddingTableBase):
     def build(self, input_shapes):
         if not self.table.built:
             self.table.build(input_shapes)
-        # if isinstance(self.combiner, tf.keras.layers.Layer):
-        #    self.combiner.build(self.table.compute_output_shape(input_shapes))
         return super(EmbeddingTable, self).build(input_shapes)
 
     def call(self, inputs: Union[tf.Tensor, TabularData], **kwargs) -> tf.Tensor:
@@ -271,12 +269,6 @@ class EmbeddingTable(EmbeddingTableBase):
         # Eliminating the last dim==1 of dense tensors before embedding lookup
         if isinstance(inputs, tf.Tensor):
             inputs = tf.squeeze(inputs, axis=-1)
-
-        """
-        dtype = backend.dtype(inputs)
-        if dtype != "int32" and dtype != "int64":
-            inputs = tf.cast(inputs, "int32")
-        """
 
         if isinstance(inputs, (tf.RaggedTensor, tf.SparseTensor)):
             if self.sequence_combiner and isinstance(self.sequence_combiner, str):

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -288,9 +288,9 @@ class EmbeddingTable(EmbeddingTableBase):
         """
         if isinstance(inputs, dict):
             out = {}
-            for col_name in [self.col_schema.name]:
-                if col_name in inputs:
-                    out[col_name] = self._call_table(inputs[col_name], **kwargs)
+            for feature_name in self.feature_names:
+                if feature_name in inputs:
+                    out[feature_name] = self._call_table(inputs[feature_name], **kwargs)
         else:
             out = self._call_table(inputs, **kwargs)
 
@@ -336,8 +336,10 @@ class EmbeddingTable(EmbeddingTableBase):
     ) -> Union[tf.TensorShape, Dict[str, tf.TensorShape]]:
         if isinstance(input_shape, dict):
             output_shapes = {}
-            for col_name in [self.col_schema.name]:
-                output_shapes[col_name] = self._compute_output_shape_table(input_shape[col_name])
+            for feature_name in self.feature_names:
+                output_shapes[feature_name] = self._compute_output_shape_table(
+                    input_shape[feature_name]
+                )
         else:
             output_shapes = self._compute_output_shape_table(input_shape)
 

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -132,17 +132,17 @@ class EmbeddingTableBase(Block):
         config = super().get_config()
         config["dim"] = self.dim
 
-        schema = schema_to_tensorflow_metadata_json(Schema([self.col_schema]))
+        schema = schema_to_tensorflow_metadata_json(self.schema)
         config["schema"] = schema
 
         return config
 
     @classmethod
     def from_config(cls, config):
+        dim = config.pop("dim")
         schema = tensorflow_metadata_json_to_schema(config.pop("schema"))
-        col_schema = schema.first
 
-        return cls(col_schema=col_schema, **config)
+        return cls(dim, *schema, **config)
 
 
 CombinerType = Union[str, tf.keras.layers.Layer]

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -472,10 +472,13 @@ def Embeddings(
 
 def _forward_kwargs_to_table(col, table_cls, kwargs):
     arg_spec = inspect.getfullargspec(table_cls.__init__)
-    table_kwargs = dict(zip(arg_spec.args[-len(arg_spec.defaults) :], arg_spec.defaults))
+    supported_kwargs = arg_spec.kwonlyargs
+    if arg_spec.defaults:
+        supported_kwargs += arg_spec.args[-len(arg_spec.defaults) :]
 
+    table_kwargs = {}
     for key, val in kwargs.items():
-        if key in table_kwargs:
+        if key in supported_kwargs:
             if isinstance(val, dict):
                 if col.name in val:
                     table_kwargs[key] = val[col.name]

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -249,16 +249,18 @@ class EmbeddingTable(EmbeddingTableBase):
             self.table.build(input_shapes)
         return super(EmbeddingTable, self).build(input_shapes)
 
-    def call(self, inputs: Union[tf.Tensor, TabularData], **kwargs) -> tf.Tensor:
+    def call(
+        self, inputs: Union[tf.Tensor, TabularData], **kwargs
+    ) -> Union[tf.Tensor, TabularData]:
         """
         Parameters
         ----------
         inputs : Union[tf.Tensor, tf.RaggedTensor, tf.SparseTensor]
-            Tensors representing the input batch
+            Tensors or dictionary of tensors representing the input batch.
 
         Returns
         -------
-        A tensor corresponding to the embeddings for inputs
+        A tensor or dict of tensors corresponding to the embeddings for inputs
         """
         return_dict = False
         if isinstance(inputs, dict):

--- a/merlin/models/tf/utils/testing_utils.py
+++ b/merlin/models/tf/utils/testing_utils.py
@@ -161,6 +161,7 @@ def numeric_test(actual, expected):
 @disable_cudnn_autotune
 def layer_test(
     layer_cls,
+    args=None,
     kwargs=None,
     input_shape=None,
     input_dtype=None,
@@ -234,8 +235,9 @@ def layer_test(
             assert_equal = numeric_test
 
     # instantiation
+    args = args or []
     kwargs = kwargs or {}
-    layer = layer_cls(**kwargs)
+    layer = layer_cls(*args, **kwargs)
 
     if supports_masking is not None and layer.supports_masking != supports_masking:
         raise AssertionError(
@@ -260,7 +262,7 @@ def layer_test(
     # test and instantiation from weights
     if "weights" in tf_inspect.getargspec(layer_cls.__init__):
         kwargs["weights"] = weights
-        layer = layer_cls(**kwargs)
+        layer = layer_cls(*args, **kwargs)
 
     # test in functional API
     x = tf.keras.layers.Input(shape=input_shape[1:], dtype=input_dtype)

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -65,7 +65,7 @@ class TestEmbeddingTable:
         column_schema = ColumnSchema("item_id")
         with pytest.raises(ValueError) as exc_info:
             mm.EmbeddingTable(16, column_schema)
-        assert "needs to have a int-domain" in str(exc_info.value)
+        assert "needs to have an int-domain" in str(exc_info.value)
 
     @pytest.mark.parametrize(
         ["dim", "kwargs", "inputs", "expected_output_shape"],

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -125,7 +125,7 @@ class TestEmbeddingTable:
         dim = np.random.randint(1, high=32)
         testing_utils.layer_test(
             mm.EmbeddingTable,
-            kwargs={"dim": dim, "col_schema": col_schema},
+            args=[dim, col_schema],
             input_data=tf.constant([[1], [2], [3]], dtype=tf.int32),
             expected_output_shape=tf.TensorShape([None, dim]),
             expected_output_dtype=tf.float32,

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -87,6 +87,8 @@ class TestEmbeddingTable:
         layer = mm.EmbeddingTable(dim, column_schema, **kwargs)
 
         output = layer(inputs)
+        if isinstance(output, dict):
+            output = output[column_schema.name]
         assert list(output.shape) == expected_output_shape
 
         if "sequence_combiner" in kwargs:
@@ -102,6 +104,8 @@ class TestEmbeddingTable:
         assert copied_layer.input_dim == layer.input_dim
 
         output = copied_layer(inputs)
+        if isinstance(output, dict):
+            output = output[column_schema.name]
         assert list(output.shape) == expected_output_shape
 
     def test_layer_simple(self):

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -232,6 +232,24 @@ class TestEmbeddingTable:
         else:
             np.testing.assert_array_almost_equal(weights, embedding_table.table.embeddings)
 
+    def test_multiple_features(self):
+        dim = 4
+        col_schema_a = ColumnSchema(
+            "a", dtype=np.int32, properties={"domain": {"min": 0, "max": 10}}
+        )
+        col_schema_b = ColumnSchema(
+            "b", dtype=np.int32, properties={"domain": {"min": 0, "max": 10}}
+        )
+        embedding_table = mm.EmbeddingTable(dim, col_schema_a)
+        embedding_table.add_feature(col_schema_b)
+        result = embedding_table(
+            {
+                "a": tf.constant([[1]]),
+                "b": tf.ragged.constant([[1]]),
+            }
+        )
+        np.testing.assert_array_equal(result["a"].numpy(), result["b"].numpy()[0])
+
 
 @pytest.mark.parametrize("trainable", [True, False])
 def test_pretrained_from_InputBlockV2(trainable, music_streaming_data: Dataset):


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Resolves #697 

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Support shared embedding tables with the `EmbeddingTable` layer.



### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

- Update `EmbeddingTable` to allow lookup of embeddings from multiple features passed in.
- Add support for `has_schema` and `schema`  (from the `SchemaMixin`) on the `EmbeddingTable`
- Adds support for creating an `EmbeddingTable` from more than one ColumnSchema
  - When more than one coluum schema is provided they are required to have the same value of int_domain.max and int_domain.name (if set)
```python
embedding_table = EmbeddingTable(dim, col_schema_a, col_schema_b)
# an alternative / additional method is provided for adding more features
embedding_table.add_feature(col_schema)
```
- Adds support for creating shared embedding table in `Embeddings` function where some column schemas share the same domain name

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

- Tests added for shared embedding domain functionality.