### PR TITLE
Return correct type from data augmentation layer depending on the context

### DIFF
--- a/merlin/models/tf/transforms/negative_sampling.py
+++ b/merlin/models/tf/transforms/negative_sampling.py
@@ -64,7 +64,7 @@ class InBatchNegatives(tf.keras.layers.Layer):
         """Extend batch of inputs and targets with negatives."""
 
         def get_tuple(x, y):
-            if training or testing:
+            if training or testing or y is None:
                 return Prediction(x, y)
             return (x, y)
 

--- a/merlin/models/tf/transforms/negative_sampling.py
+++ b/merlin/models/tf/transforms/negative_sampling.py
@@ -40,10 +40,6 @@ class InBatchNegatives(tf.keras.layers.Layer):
         The random seed, by default None
     run_when_testing : bool, optional
         Whether the negative sampling should happen when testing=True, by default True
-    return_tuple : bool, optional
-        Whether to return a Prediction or a tuple. The tuple option should be used
-        when using UniformNegativeSampling with Loader.map()
-        which accepts a tuple with length 2 or 3 (x,y,sample_weight), by default False
     """
 
     def __init__(
@@ -52,7 +48,6 @@ class InBatchNegatives(tf.keras.layers.Layer):
         n_per_positive: int,
         seed: Optional[int] = None,
         run_when_testing: bool = True,
-        return_tuple: bool = False,
         **kwargs
     ):
 
@@ -62,7 +57,6 @@ class InBatchNegatives(tf.keras.layers.Layer):
         self.schema = schema.select_by_tag(Tags.ITEM)
         self.seed = seed
         self.run_when_testing = run_when_testing
-        self.return_tuple = return_tuple
 
     def call(
         self, inputs: TabularData, targets=None, training=False, testing=False, **kwargs
@@ -159,7 +153,6 @@ class InBatchNegatives(tf.keras.layers.Layer):
         config["n_per_positive"] = self.n_per_positive
         config["seed"] = self.seed
         config["run_when_testing"] = self.run_when_testing
-        config["return_tuple"] = self.return_tuple
         return config
 
     @classmethod
@@ -167,12 +160,11 @@ class InBatchNegatives(tf.keras.layers.Layer):
         """Creates layer from its config. Returning the instance."""
         schema = schema_utils.tensorflow_metadata_json_to_schema(config.pop("schema"))
         n_per_positive = config.pop("n_per_positive")
-        return_tuple = config.pop("return_tuple")
         seed = None
         if "seed" in config:
             seed = config.pop("seed")
         kwargs = config
-        return cls(schema, n_per_positive, seed=seed, return_tuple=return_tuple, **kwargs)
+        return cls(schema, n_per_positive, seed=seed, **kwargs)
 
     def compute_output_shape(self, input_shape):
         """Computes the output shape of the layer."""

--- a/merlin/models/tf/utils/testing_utils.py
+++ b/merlin/models/tf/utils/testing_utils.py
@@ -97,7 +97,7 @@ def model_test(
 
         assert isinstance(loaded_model, type(model))
 
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             model.predict(batch[0]),
             loaded_model.predict(batch[0]),
         )

--- a/merlin/models/tf/utils/testing_utils.py
+++ b/merlin/models/tf/utils/testing_utils.py
@@ -97,7 +97,7 @@ def model_test(
 
         assert isinstance(loaded_model, type(model))
 
-        np.array_equal(
+        np.testing.assert_array_equal(
             model.predict(batch[0]),
             loaded_model.predict(batch[0]),
         )

--- a/merlin/models/tf/utils/testing_utils.py
+++ b/merlin/models/tf/utils/testing_utils.py
@@ -81,6 +81,7 @@ def model_test(
     optimizer="adam",
     epochs: int = 1,
     reload_model: bool = False,
+    to_ragged=False,
     **kwargs,
 ) -> Tuple[Model, Any]:
     """Generic model test. It will compile & fit the model and make sure it can be re-trained."""
@@ -88,7 +89,7 @@ def model_test(
     model.compile(run_eagerly=run_eagerly, optimizer=optimizer, **kwargs)
     losses = model.fit(dataset, batch_size=50, epochs=epochs, steps_per_epoch=1)
 
-    batch = sample_batch(dataset, batch_size=50, to_ragged=True)
+    batch = sample_batch(dataset, batch_size=50, to_ragged=to_ragged)
 
     if reload_model:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/merlin/models/tf/utils/testing_utils.py
+++ b/merlin/models/tf/utils/testing_utils.py
@@ -88,7 +88,7 @@ def model_test(
     model.compile(run_eagerly=run_eagerly, optimizer=optimizer, **kwargs)
     losses = model.fit(dataset, batch_size=50, epochs=epochs, steps_per_epoch=1)
 
-    batch = sample_batch(dataset, batch_size=50)
+    batch = sample_batch(dataset, batch_size=50, to_ragged=True)
 
     if reload_model:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/unit/tf/transforms/test_negative_sampling.py
+++ b/tests/unit/tf/transforms/test_negative_sampling.py
@@ -194,7 +194,9 @@ class TestAddRandomNegativesToBatch:
         preds = model.predict(features)
         assert preds.shape[0] == batch_size
 
-        testing_utils.model_test(model, dataset, run_eagerly=run_eagerly, reload_model=True)
+        testing_utils.model_test(
+            model, dataset, run_eagerly=run_eagerly, reload_model=True, to_ragged=True
+        )
 
     def test_model_with_dataloader(self, music_streaming_data: Dataset, tf_random_seed: int):
         dataset = music_streaming_data

--- a/tests/unit/tf/transforms/test_negative_sampling.py
+++ b/tests/unit/tf/transforms/test_negative_sampling.py
@@ -68,10 +68,7 @@ class TestAddRandomNegativesToBatch:
         input_df = input_df[sorted(input_df.columns)]
         dataset = Dataset(input_df, schema=schema)
         loader = mm.Loader(dataset, batch_size=10, transform=sampler)
-        first_batch_outputs = next(iter(loader))
-
-        outputs = first_batch_outputs.outputs
-        targets = first_batch_outputs.targets
+        outputs, targets = next(iter(loader))
 
         output_dict = {
             key: output_tensor.numpy().reshape(-1) for key, output_tensor in outputs.items()
@@ -113,8 +110,7 @@ class TestAddRandomNegativesToBatch:
 
         sampler = InBatchNegatives(schema, n_per_positive, seed=tf_random_seed)
 
-        with_negatives = sampler(features)
-        outputs = with_negatives.outputs
+        outputs, targets = sampler(features)
 
         def assert_fn(output_batch_size):
             assert output_batch_size == batch_size
@@ -131,9 +127,7 @@ class TestAddRandomNegativesToBatch:
 
         sampler = InBatchNegatives(schema, 5, seed=tf_random_seed)
 
-        with_negatives = sampler(inputs, targets=targets)
-        outputs = with_negatives.outputs
-        targets = with_negatives.targets
+        outputs, targets = sampler(inputs, targets=targets)
 
         max_batch_size = batch_size + batch_size * n_per_positive
 
@@ -211,8 +205,7 @@ class TestAddRandomNegativesToBatch:
         batch_size, n_per_positive = 10, 5
         loader = mm.Loader(music_streaming_data, batch_size=batch_size, transform=add_negatives)
 
-        batch_output = next(iter(loader))
-        features, targets = batch_output
+        features, targets = next(iter(dataset))
 
         expected_batch_size = batch_size + batch_size * n_per_positive
 

--- a/tests/unit/tf/transforms/test_negative_sampling.py
+++ b/tests/unit/tf/transforms/test_negative_sampling.py
@@ -194,9 +194,7 @@ class TestAddRandomNegativesToBatch:
         preds = model.predict(features)
         assert preds.shape[0] == batch_size
 
-        testing_utils.model_test(
-            model, dataset, run_eagerly=run_eagerly, reload_model=True, to_ragged=True
-        )
+        testing_utils.model_test(model, dataset, run_eagerly=run_eagerly, reload_model=True)
 
     def test_model_with_dataloader(self, music_streaming_data: Dataset, tf_random_seed: int):
         dataset = music_streaming_data

--- a/tests/unit/tf/transforms/test_negative_sampling.py
+++ b/tests/unit/tf/transforms/test_negative_sampling.py
@@ -207,7 +207,7 @@ class TestAddRandomNegativesToBatch:
         batch_size, n_per_positive = 10, 5
         loader = mm.Loader(dataset, batch_size=batch_size, transform=add_negatives)
 
-        features, targets = next(iter(dataset))
+        features, targets = next(iter(loader))
 
         expected_batch_size = batch_size + batch_size * n_per_positive
 


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Related to https://github.com/NVIDIA-Merlin/models/issues/596 and https://github.com/NVIDIA-Merlin/models/issues/626

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Enable the negative sampling (data augmentation) layer to be used both in the dataset (Loader.map / transform) and as part of the model without requiring a parameter to control the correct output type.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

- removes `return_tuple` parameter from `InBatchNegatives`
- detect whether in training or testing and return a tuple or Prediction (namedtuple) depending on the context.

We can determine if the layer is being called from the Model (either `train_step` or `test_step` because these custom methods on our Model pass in the keyword arguments `training` and `testing` depending on the type of step.

This enables us to return the correct type from the call method depending on whether this is being run inside a model or in the a dataset map step.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Updates existing tests to unpack the return value correctly.