### PR TITLE
Added InputBlockV2 support to DeepFMModel (refactored and fixed) and DCNModel

### DIFF
--- a/examples/usecases/entertainment-with-pretrained-embeddings.ipynb
+++ b/examples/usecases/entertainment-with-pretrained-embeddings.ipynb
@@ -494,7 +494,7 @@
     "    trainable={'movieId': False},\n",
     "    dim=embed_dims,\n",
     ")\n",
-    "input_block = mm.InputBlockV2(train.schema, embeddings=embeddings_block)"
+    "input_block = mm.InputBlockV2(train.schema, categorical=embeddings_block)"
    ]
   },
   {

--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -126,9 +126,9 @@ from merlin.models.tf.transforms.features import (
     CategoryEncoding,
     HashedCross,
     HashedCrossAll,
-    ToDenseFeatures,
+    ToDense,
     ToOneHot,
-    ToSparseFeatures,
+    ToSparse,
 )
 from merlin.models.tf.transforms.noise import StochasticSwapNoise
 from merlin.models.tf.transforms.regularization import L2Norm
@@ -184,8 +184,8 @@ __all__ = [
     "ListToDense",
     "ListToRagged",
     "ListToSparse",
-    "ToSparseFeatures",
-    "ToDenseFeatures",
+    "ToSparse",
+    "ToDense",
     "CategoryEncoding",
     "HashedCross",
     "HashedCrossAll",

--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -33,7 +33,11 @@ from merlin.models.loader.tf_utils import configure_tensorflow
 from merlin.models.tf.blocks.cross import CrossBlock
 from merlin.models.tf.blocks.dlrm import DLRMBlock
 from merlin.models.tf.blocks.experts import CGCBlock, MMOEBlock, MMOEGate
-from merlin.models.tf.blocks.interaction import DotProductInteraction, FMPairwiseInteraction
+from merlin.models.tf.blocks.interaction import (
+    DotProductInteraction,
+    FMBlock,
+    FMPairwiseInteraction,
+)
 from merlin.models.tf.blocks.mlp import DenseResidualBlock, MLPBlock
 from merlin.models.tf.blocks.optimizer import (
     LazyAdam,

--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -126,7 +126,9 @@ from merlin.models.tf.transforms.features import (
     CategoryEncoding,
     HashedCross,
     HashedCrossAll,
+    ToDenseFeatures,
     ToOneHot,
+    ToSparseFeatures,
 )
 from merlin.models.tf.transforms.noise import StochasticSwapNoise
 from merlin.models.tf.transforms.regularization import L2Norm
@@ -182,6 +184,8 @@ __all__ = [
     "ListToDense",
     "ListToRagged",
     "ListToSparse",
+    "ToSparseFeatures",
+    "ToDenseFeatures",
     "CategoryEncoding",
     "HashedCross",
     "HashedCrossAll",

--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -194,6 +194,7 @@ __all__ = [
     "StackFeatures",
     "DotProductInteraction",
     "FMPairwiseInteraction",
+    "FMBlock",
     "ToOneHot",
     "ModelOutput",
     "BinaryOutput",

--- a/merlin/models/tf/blocks/interaction.py
+++ b/merlin/models/tf/blocks/interaction.py
@@ -304,7 +304,7 @@ def FMBlock(
 
     fm_input_block = fm_input_block or InputBlockV2(
         cat_schema,
-        embeddings=Embeddings(schema.select_by_tag(Tags.CATEGORICAL), dim=factors_dim),
+        embeddings=Embeddings(schema, dim=factors_dim),
         aggregation=None,
     )
     pairwise_interaction = SequentialBlock(

--- a/merlin/models/tf/blocks/interaction.py
+++ b/merlin/models/tf/blocks/interaction.py
@@ -304,7 +304,7 @@ def FMBlock(
 
     fm_input_block = fm_input_block or InputBlockV2(
         cat_schema,
-        embeddings=Embeddings(schema, dim=factors_dim),
+        categorical=Embeddings(schema, dim=factors_dim),
         aggregation=None,
     )
     pairwise_interaction = SequentialBlock(

--- a/merlin/models/tf/blocks/interaction.py
+++ b/merlin/models/tf/blocks/interaction.py
@@ -294,7 +294,7 @@ def FMBlock(
     wide_input_block = wide_input_block or ParallelBlock(
         {
             "categorical": CategoryEncoding(cat_schema, output_mode="multi_hot", sparse=True),
-            "continuous": Filter(cont_schema, post=ToSparse()),
+            "continuous": Filter(cont_schema).connect(ToSparse()),
         },
         aggregation="concat",
     )
@@ -304,7 +304,7 @@ def FMBlock(
 
     fm_input_block = fm_input_block or InputBlockV2(
         cat_schema,
-        categorical=Embeddings(schema, dim=factors_dim),
+        categorical=Embeddings(cat_schema, dim=factors_dim),
         aggregation=None,
     )
     pairwise_interaction = SequentialBlock(

--- a/merlin/models/tf/blocks/interaction.py
+++ b/merlin/models/tf/blocks/interaction.py
@@ -240,7 +240,6 @@ class FMPairwiseInteraction(Block):
         return (input_shapes[0], input_shapes[2])
 
 
-@tf.keras.utils.register_keras_serializable(package="merlin.models")
 def FMBlock(
     schema: Schema,
     fm_input_block: Optional[Block] = None,

--- a/merlin/models/tf/blocks/interaction.py
+++ b/merlin/models/tf/blocks/interaction.py
@@ -202,14 +202,6 @@ class FMPairwiseInteraction(Block):
     Conference on Data Mining, 2010. https://ieeexplore.ieee.org/document/5694074
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-    def build(self, input_shapes):
-        if len(input_shapes) != 3:
-            raise ValueError("Found shape {} without 3 dimensions".format(input_shapes))
-        super(FMPairwiseInteraction, self).build(input_shapes)
-
     def call(self, inputs: tf.Tensor, **kwargs) -> tf.Tensor:
         """
         Parameters
@@ -234,4 +226,6 @@ class FMPairwiseInteraction(Block):
         return 0.5 * tf.subtract(summed_square, squared_sum)
 
     def compute_output_shape(self, input_shapes):
+        if len(input_shapes) != 3:
+            raise ValueError("Found shape {} without 3 dimensions".format(input_shapes))
         return (input_shapes[0], input_shapes[2])

--- a/merlin/models/tf/blocks/interaction.py
+++ b/merlin/models/tf/blocks/interaction.py
@@ -23,8 +23,8 @@ from merlin.models.tf.core.aggregation import StackFeatures
 from merlin.models.tf.core.base import Block
 from merlin.models.tf.core.combinators import MapValues, ParallelBlock, SequentialBlock
 from merlin.models.tf.core.tabular import Filter
-from merlin.models.tf.core.transformations import CategoryEncoding, ToSparseFeatures
 from merlin.models.tf.inputs.base import InputBlockV2
+from merlin.models.tf.transforms.features import CategoryEncoding, ToSparseFeatures
 from merlin.schema import Schema, Tags
 
 _INTERACTION_TYPES = (None, "field_all", "field_each", "field_interaction")

--- a/merlin/models/tf/inputs/base.py
+++ b/merlin/models/tf/inputs/base.py
@@ -179,7 +179,9 @@ def InputBlock(
         if max_seq_length and seq:
             pre = ListToDense(max_seq_length)
         branches["continuous"] = ContinuousFeatures.from_schema(  # type: ignore
-            schema, tags=continuous_tags, pre=pre,
+            schema,
+            tags=continuous_tags,
+            pre=pre,
         )
     if (
         add_embedding_branch
@@ -282,7 +284,6 @@ def InputBlockV2(
     **branches : dict
         Extra branches to add to the input block.
 
-
     Returns
     -------
     ParallelBlock
@@ -309,5 +310,9 @@ def InputBlockV2(
     if not parsed:
         raise ValueError("No columns selected for the input block")
 
-    return ParallelBlock(parsed, pre=pre, post=post, aggregation=aggregation,)
-
+    return ParallelBlock(
+        parsed,
+        pre=pre,
+        post=post,
+        aggregation=aggregation,
+    )

--- a/merlin/models/tf/inputs/base.py
+++ b/merlin/models/tf/inputs/base.py
@@ -179,9 +179,7 @@ def InputBlock(
         if max_seq_length and seq:
             pre = ListToDense(max_seq_length)
         branches["continuous"] = ContinuousFeatures.from_schema(  # type: ignore
-            schema,
-            tags=continuous_tags,
-            pre=pre,
+            schema, tags=continuous_tags, pre=pre,
         )
     if (
         add_embedding_branch
@@ -311,9 +309,5 @@ def InputBlockV2(
     if not parsed:
         raise ValueError("No columns selected for the input block")
 
-    return ParallelBlock(
-        parsed,
-        pre=pre,
-        post=post,
-        aggregation=aggregation,
-    )
+    return ParallelBlock(parsed, pre=pre, post=post, aggregation=aggregation,)
+

--- a/merlin/models/tf/models/ranking.py
+++ b/merlin/models/tf/models/ranking.py
@@ -211,7 +211,7 @@ def DeepFMModel(
     input_block = input_block or InputBlockV2(
         schema,
         aggregation=None,
-        embeddings=Embeddings(schema.select_by_tag(Tags.CATEGORICAL), dim=embedding_dim),
+        categorical=Embeddings(schema.select_by_tag(Tags.CATEGORICAL), dim=embedding_dim),
     )
 
     fm_tower = FMBlock(
@@ -282,7 +282,7 @@ def WideAndDeepModel(
         deep_embedding = ml.Embeddings(schema, embedding_dim_default=8, infer_embedding_sizes=False)
         model = ml.WideAndDeepModel(
             schema,
-            deep_input_block = ml.InputBlockV2(schema=schema, embeddings=deep_embedding),
+            deep_input_block = ml.InputBlockV2(schema=schema, categorical=deep_embedding),
             wide_schema=wide_schema,
             wide_preprocess=ml.CategoryEncoding(wide_schema, output_mode="multi_hot", sparse=True),
             deep_block=ml.MLPBlock([32, 16]),

--- a/merlin/models/tf/models/ranking.py
+++ b/merlin/models/tf/models/ranking.py
@@ -154,6 +154,7 @@ def DeepFMModel(
     embedding_dim: Optional[int] = None,
     deep_block: Optional[Block] = None,
     input_block: Optional[Block] = None,
+    wide_input_block: Optional[Block] = None,
     prediction_tasks: Optional[
         Union[PredictionTask, List[PredictionTask], ParallelPredictionBlock]
     ] = None,
@@ -193,6 +194,10 @@ def DeepFMModel(
         based on the schema, with the specified embedding_dim.
         For a custom representation of input data you can instantiate
         and provide an `InputBlockV2` instance.
+    wide_input_block: Optional[Block], by default None
+        The input for the wide block. If not provided,
+        creates a default block that encodes categorical features
+        with one-hot / multi-hot representation and also includes the continuous features.
     prediction_tasks: optional
         The prediction tasks to be used, by default this will be inferred from the Schema.
         Defaults to None
@@ -205,7 +210,9 @@ def DeepFMModel(
     input_block = input_block or InputBlockV2(schema, dim=embedding_dim, aggregation=None, **kwargs)
 
     fm_tower = FMBlock(
-        schema, fm_input_block=SequentialBlock(input_block, Filter(Tags.CATEGORICAL))
+        schema,
+        fm_input_block=SequentialBlock(input_block, Filter(Tags.CATEGORICAL)),
+        wide_input_block=wide_input_block,
     )
 
     if deep_block is None:

--- a/merlin/models/tf/models/ranking.py
+++ b/merlin/models/tf/models/ranking.py
@@ -8,7 +8,6 @@ from merlin.models.tf.blocks.mlp import MLPBlock, RegularizerType
 from merlin.models.tf.core.aggregation import ConcatFeatures
 from merlin.models.tf.core.base import Block
 from merlin.models.tf.core.combinators import ParallelBlock, TabularBlock
-from merlin.models.tf.core.tabular import Filter
 from merlin.models.tf.inputs.base import InputBlockV2
 from merlin.models.tf.inputs.embedding import EmbeddingOptions, Embeddings
 from merlin.models.tf.models.base import Model
@@ -216,7 +215,7 @@ def DeepFMModel(
 
     fm_tower = FMBlock(
         schema,
-        fm_input_block=input_block.connect(Filter(Tags.CATEGORICAL)),
+        fm_input_block=input_block,
         wide_input_block=wide_input_block,
     )
 

--- a/merlin/models/tf/models/ranking.py
+++ b/merlin/models/tf/models/ranking.py
@@ -7,7 +7,7 @@ from merlin.models.tf.blocks.interaction import FMBlock
 from merlin.models.tf.blocks.mlp import MLPBlock, RegularizerType
 from merlin.models.tf.core.aggregation import ConcatFeatures
 from merlin.models.tf.core.base import Block
-from merlin.models.tf.core.combinators import ParallelBlock, SequentialBlock, TabularBlock
+from merlin.models.tf.core.combinators import ParallelBlock, TabularBlock
 from merlin.models.tf.core.tabular import Filter
 from merlin.models.tf.inputs.base import InputBlockV2
 from merlin.models.tf.inputs.embedding import EmbeddingOptions, Embeddings
@@ -215,7 +215,7 @@ def DeepFMModel(
 
     fm_tower = FMBlock(
         schema,
-        fm_input_block=SequentialBlock(input_block, Filter(Tags.CATEGORICAL)),
+        fm_input_block=input_block.connect(Filter(Tags.CATEGORICAL)),
         wide_input_block=wide_input_block,
     )
 

--- a/merlin/models/tf/models/ranking.py
+++ b/merlin/models/tf/models/ranking.py
@@ -14,6 +14,7 @@ from merlin.models.tf.inputs.embedding import EmbeddingOptions, Embeddings
 from merlin.models.tf.models.base import Model
 from merlin.models.tf.models.utils import parse_prediction_tasks
 from merlin.models.tf.prediction_tasks.base import ParallelPredictionBlock, PredictionTask
+from merlin.models.tf.transforms.features import CategoryEncoding
 from merlin.schema import Schema, Tags
 
 

--- a/merlin/models/tf/models/ranking.py
+++ b/merlin/models/tf/models/ranking.py
@@ -459,7 +459,10 @@ def WideAndDeepModel(
 
     if not deep_input_block:
         if deep_schema is not None and len(deep_schema) > 0:
-            deep_input_block = InputBlockV2(deep_schema, **kwargs,)
+            deep_input_block = InputBlockV2(
+                deep_schema,
+                **kwargs,
+            )
     if deep_input_block:
         deep_body = deep_input_block.connect(deep_block).connect(
             MLPBlock(
@@ -498,8 +501,8 @@ def WideAndDeepModel(
 
     if len(branches) == 0:
         raise ValueError(
-            "At least the deep part (deep_schema/deep_input_block) "
-            "or wide part (wide_schema/wide_input_block) must be provided."
+            "At least the deep part (deep_schema/deep_input_block)"
+            " or wide part (wide_schema/wide_input_block) must be provided."
         )
 
     wide_and_deep_body = ParallelBlock(branches, aggregation="element-wise-sum")

--- a/merlin/models/tf/models/ranking.py
+++ b/merlin/models/tf/models/ranking.py
@@ -207,10 +207,6 @@ def DeepFMModel(
         schema.select_by_tag(Tags.CATEGORICAL), dim=embedding_dim, aggregation=None, **kwargs
     )
 
-    # TODO: Identify why we need to set the schema manually for `InputBlockV2`
-    # to avoid an error of ParallelBlock without schema?
-    input_block.set_schema(schema)
-
     pairwise_block = FMPairwiseInteraction().prepare(aggregation=StackFeatures(axis=-1))
     deep_block = deep_block.prepare(aggregation=ConcatFeatures())
     deep_pairwise = input_block.connect_branch(pairwise_block, deep_block, aggregation="concat")

--- a/merlin/models/tf/transforms/features.py
+++ b/merlin/models/tf/transforms/features.py
@@ -51,6 +51,9 @@ class FeaturesTensorTypeConversion(TabularBlock):
         if schema is not None:
             self.column_names = schema.column_names
 
+    def call(self, inputs: TabularData, **kwargs) -> TabularData:
+        raise NotImplementedError("The call method need to be implemented by child clases")
+
     def compute_output_shape(self, input_shapes):
         output_shapes = {}
         for k, v in input_shapes.items():

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -58,15 +58,10 @@ def get_output_sizes_from_schema(schema, batch_size=0, max_sequence_length=None)
 
 
 def calculate_batch_size_from_input_shapes(input_shapes):
-    values = []
-
-    for val in input_shapes.values():
-        if isinstance(val, tuple) and isinstance(val[0], tf.TensorShape):
-            values.append(val[1])
-        else:
-            values.append(val)
-
-    return values[0][0]
+    val = list(input_shapes.values())[0]
+    if isinstance(val, tuple) and isinstance(val[1], tf.TensorShape):
+        val = val[1]
+    return val[0]
 
 
 def maybe_serialize_keras_objects(

--- a/tests/unit/tf/blocks/test_interactions.py
+++ b/tests/unit/tf/blocks/test_interactions.py
@@ -55,7 +55,7 @@ def test_fm_block_with_multi_hot_categ_features(testing_data: Dataset):
 
     input_block = mm.InputBlockV2(
         schema,
-        embeddings=mm.Embeddings(
+        categorical=mm.Embeddings(
             cat_schema,
             dim=32,
             sequence_combiner="mean",
@@ -65,8 +65,7 @@ def test_fm_block_with_multi_hot_categ_features(testing_data: Dataset):
 
     wide_input_block = mm.ParallelBlock(
         {
-            "categorical_ohe": mm.SequentialBlock(
-                mm.Filter(cat_schema_onehot),
+            "categorical_ohe": mm.Filter(cat_schema_onehot).connect(
                 mm.CategoryEncoding(cat_schema_onehot, sparse=True, output_mode="one_hot"),
             ),
             "categorical_mhe": mm.SequentialBlock(

--- a/tests/unit/tf/blocks/test_interactions.py
+++ b/tests/unit/tf/blocks/test_interactions.py
@@ -71,7 +71,7 @@ def test_fm_block_with_multi_hot_categ_features(testing_data: Dataset):
             ),
             "categorical_mhe": mm.SequentialBlock(
                 mm.Filter(cat_schema_multihot),
-                mm.AsDenseFeatures(max_seq_length=cat_schema_multihot["categories"].int_domain.max),
+                mm.ListToDense(max_seq_length=cat_schema_multihot["categories"].int_domain.max),
                 mm.CategoryEncoding(cat_schema_multihot, sparse=True, output_mode="multi_hot"),
             ),
             "continuous": mm.SequentialBlock(

--- a/tests/unit/tf/blocks/test_interactions.py
+++ b/tests/unit/tf/blocks/test_interactions.py
@@ -75,7 +75,7 @@ def test_fm_block_with_multi_hot_categ_features(testing_data: Dataset):
                 mm.CategoryEncoding(cat_schema_multihot, sparse=True, output_mode="multi_hot"),
             ),
             "continuous": mm.SequentialBlock(
-                mm.Filter(schema.select_by_tag(Tags.CONTINUOUS)), mm.ToSparseFeatures()
+                mm.Filter(schema.select_by_tag(Tags.CONTINUOUS)), mm.ToSparse()
             ),
         },
         aggregation="concat",

--- a/tests/unit/tf/models/test_ranking.py
+++ b/tests/unit/tf/models/test_ranking.py
@@ -279,7 +279,7 @@ def test_wide_deep_embedding_custom_inputblock(music_streaming_data, run_eagerly
 
     model = ml.WideAndDeepModel(
         schema,
-        deep_input_block=ml.InputBlockV2(schema=schema, embeddings=deep_embedding),
+        deep_input_block=ml.InputBlockV2(schema=schema, categorical=deep_embedding),
         wide_schema=wide_schema,
         wide_preprocess=ml.HashedCross(wide_schema, 1000, sparse=True),
         deep_block=ml.MLPBlock([32, 16]),

--- a/tests/unit/tf/models/test_ranking.py
+++ b/tests/unit/tf/models/test_ranking.py
@@ -157,9 +157,24 @@ def test_dcn_model(music_streaming_data, stacked, run_eagerly):
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
-def test_deepfm_model(music_streaming_data, run_eagerly):
+def test_deepfm_model_only_categ_feats(music_streaming_data, run_eagerly):
     music_streaming_data.schema = music_streaming_data.schema.select_by_name(
         ["item_id", "item_category", "user_id", "click"]
+    )
+    model = ml.DeepFMModel(
+        music_streaming_data.schema,
+        embedding_dim=16,
+        deep_block=ml.MLPBlock([16]),
+        prediction_tasks=ml.BinaryClassificationTask("click"),
+    )
+
+    testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
+
+
+@pytest.mark.parametrize("run_eagerly", [True, False])
+def test_deepfm_model_categ_and_continuous_feats(music_streaming_data, run_eagerly):
+    music_streaming_data.schema = music_streaming_data.schema.select_by_name(
+        ["item_id", "item_category", "user_id", "user_age", "click"]
     )
     model = ml.DeepFMModel(
         music_streaming_data.schema,

--- a/tests/unit/tf/models/test_ranking.py
+++ b/tests/unit/tf/models/test_ranking.py
@@ -150,12 +150,21 @@ def test_dcn_model(music_streaming_data, stacked, run_eagerly):
         depth=1,
         deep_block=ml.MLPBlock([2]),
         stacked=stacked,
-        embedding_options=ml.EmbeddingOptions(
-            embedding_dims=None,
-            embedding_dim_default=2,
-            infer_embedding_sizes=True,
-            infer_embedding_sizes_multiplier=0.2,
-        ),
+        prediction_tasks=ml.BinaryClassificationTask("click"),
+    )
+
+    testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
+
+
+@pytest.mark.parametrize("run_eagerly", [True, False])
+def test_deepfm_model(music_streaming_data, run_eagerly):
+    music_streaming_data.schema = music_streaming_data.schema.select_by_name(
+        ["item_id", "item_category", "user_id", "click"]
+    )
+    model = ml.DeepFMModel(
+        music_streaming_data.schema,
+        embedding_dim=16,
+        deep_block=ml.MLPBlock([16]),
         prediction_tasks=ml.BinaryClassificationTask("click"),
     )
 

--- a/tests/unit/tf/outputs/test_classification.py
+++ b/tests/unit/tf/outputs/test_classification.py
@@ -84,7 +84,7 @@ def test_next_item_prediction(sequence_testing_data: Dataset, run_eagerly):
 
     for target in predictions:
         model = mm.Model(
-            mm.InputBlockV2(schema, embeddings=embeddings),
+            mm.InputBlockV2(schema, categorical=embeddings),
             mm.MLPBlock([32]),
             mm.CategoricalOutput(target),
         )


### PR DESCRIPTION
Fixes #604 

### Goals :soccer:
- Sets `InputBlockV2` as the default input block for `DCNModel` and `DeepFMModel`
- Creates `ToSparseFeatures` and `ToDenseFeatures` to convert tensor types for selected or all features
- Refactors `DeepFMModel` to extract the `FMBlock` and fixes the implemenation to match the one described in the original papers: (Fixes #742 )
```
[1] Huifeng, Guo, et al. "DeepFM: A Factorization-Machine based Neural Network for CTR Prediction". arXiv:1703.04247  (2017).
[2] Steffen, Rendle, "Factorization Machines" IEEE International Conference on Data Mining, 2010.
```

### Implementation Details :construction:
- Previously the `InputBlock` was used for `DCNModel` and `DeepFMModel`
- For `DCNModel`, the user were allowed to set `embedding_options`. Now the user can provide its own `InputBlock`, or provide custom args for the `Embeddings()` via `InputBlockV2(..., **kwargs)` 
- The previous implementation of `DeepFMModel` had the following issues that are fixed here:
    - In the wide part the one-hot categorical features was not sparse, which might cause OOM for high cardinality features.
    - The DeepFMModel supported only categorical features. If continuous features were passed the branch with FMPairwiseInteraction an error were raised
    - The FM and deep tower output should be 1d and summed. But instead those towers were outputing multiple dimensions (>1), which were projected to a single dim by an MLP layer, which is not part of the original architectures described in the papers.

### Testing Details :mag:
- There was no test for `DeepFMModel`, so added some and fixed bugs
