### PR TITLE
Update tensorflow version test matrix version specifiers for clarity 

### DIFF
--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         python-version: [3.9.7]
         os: [ubuntu-latest]
-        tf-max: ["2.9", "2.10"]
+        tensorflow-version: ["~=2.8.0", "~=2.9.0"]
 
     steps:
       - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
           pip install "merlin-core@git+https://github.com/NVIDIA-Merlin/core.git"
       - name: Install dependencies
         run: |
-          python -m pip install "tensorflow<${{ matrix.tf-max }}"
+          python -m pip install "tensorflow${{ matrix.tensorflow-version }}"
           python -m pip install .[tensorflow-dev]
       - name: Build
         run: |
@@ -73,7 +73,7 @@ jobs:
       matrix:
         python-version: [ 3.9.7 ]
         os: [ ubuntu-latest ]
-        tf-max: ["2.9"]
+        tensorflow-version: ["~=2.8.0", "~=2.9.0"]
 
     steps:
       - uses: actions/checkout@v2
@@ -97,7 +97,7 @@ jobs:
           pip install "merlin-core@git+https://github.com/NVIDIA-Merlin/core.git"
       - name: Install dependencies
         run: |
-          python -m pip install "tensorflow<${{ matrix.tf-max }}"
+          python -m pip install "tensorflow${{ matrix.tensorflow-version }}"
           python -m pip install .[tensorflow-dev]
       - name: Build
         run: |


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->


### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

- Make Tensorflow Versions in GitHub Actions Clearer

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

- Changes the GitHub workflow matrix specification for tensorflow versions to improve clarity. (Using the [compatible release clause](https://peps.python.org/pep-0440/#compatible-release))
- ~Update `ItemRetrievalScorer` to use `tf_inspect` to get call args instead of `_call_fn_args` which stopped working in 2.10~ (Update: this was moved to #756 )

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

- Existing test coverage should pass with all versions in the testing matrix 