### PR TITLE
Add loader transforms

### DIFF
--- a/examples/03-Exploring-different-models.ipynb
+++ b/examples/03-Exploring-different-models.ipynb
@@ -341,7 +341,7 @@
     }
    },
    "source": [
-    "We're ready to start training, for that, we create our dataset objects, and under the hood we use Merlin `BatchedDataset` class for reading chunks of parquet files. `BatchedDataset` asynchronously iterate through CSV or Parquet dataframes on GPU by leveraging an NVTabular `Dataset`. To read more about Merlin optimized dataloaders visit [here](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/dataset.py#L141)."
+    "We're ready to start training, for that, we create our dataset objects, and under the hood we use Merlin `Loader` class for reading chunks of parquet files. `Loader` asynchronously iterate through CSV or Parquet dataframes on GPU by leveraging an NVTabular `Dataset`. To read more about Merlin optimized dataloaders visit [here](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/dataset.py#L141)."
    ]
   },
   {

--- a/examples/usecases/ecommerce-session-based-next-item-prediction-for-fashion.ipynb
+++ b/examples/usecases/ecommerce-session-based-next-item-prediction-for-fashion.ipynb
@@ -120,7 +120,6 @@
     "import tensorflow as tf\n",
     "\n",
     "from tensorflow.keras import regularizers\n",
-    "from merlin.models.tf.dataset import BatchedDataset\n",
     "\n",
     "import merlin.models.tf as mm\n",
     "from merlin.models.tf import InputBlock\n",
@@ -128,8 +127,7 @@
     "from merlin.models.tf.transforms.bias import LogitsTemperatureScaler\n",
     "from merlin.models.tf.prediction_tasks.next_item import ItemsPredictionWeightTying\n",
     "\n",
-    "from merlin.core.dispatch import get_lib\n",
-    "import merlin.models.tf.dataset as tf_dataloader"
+    "from merlin.core.dispatch import get_lib"
    ]
   },
   {
@@ -941,7 +939,7 @@
    "id": "c23313f7",
    "metadata": {},
    "source": [
-    "The default dataloader does shuffle by default. We will initialize the BatchedDataset `tf_dataloader.BatchedDataset` for the training dataset."
+    "The default dataloader does shuffle by default. We will initialize the Loader `Loader` for the training dataset."
    ]
   },
   {
@@ -951,7 +949,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_dl = tf_dataloader.BatchedDataset(\n",
+    "train_dl = mm.Loader(\n",
     "    train,\n",
     "    batch_size = BATCH_SIZE,\n",
     "    shuffle = False \n",

--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -76,7 +76,6 @@ from merlin.models.tf.core.combinators import (
     SequentialBlock,
 )
 from merlin.models.tf.core.encoder import EncoderBlock
-from merlin.models.tf.dataset import sample_batch
 from merlin.models.tf.inputs.base import InputBlock, InputBlockV2
 from merlin.models.tf.inputs.continuous import Continuous, ContinuousFeatures, ContinuousProjection
 from merlin.models.tf.inputs.embedding import (
@@ -90,6 +89,7 @@ from merlin.models.tf.inputs.embedding import (
     SequenceEmbeddingFeatures,
     TableConfig,
 )
+from merlin.models.tf.loader import KerasSequenceValidator, Loader, sample_batch
 from merlin.models.tf.losses import LossType
 from merlin.models.tf.metrics.topk import (
     AvgPrecisionAt,
@@ -248,4 +248,6 @@ __all__ = [
     "LossType",
     "sample_batch",
     "TensorInitializer",
+    "Loader",
+    "KerasSequenceValidator",
 ]

--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -129,6 +129,7 @@ from merlin.models.tf.transforms.features import (
     ToDense,
     ToOneHot,
     ToSparse,
+    ToTarget,
 )
 from merlin.models.tf.transforms.noise import StochasticSwapNoise
 from merlin.models.tf.transforms.regularization import L2Norm

--- a/merlin/models/tf/loader.py
+++ b/merlin/models/tf/loader.py
@@ -312,7 +312,7 @@ class Loader(tf.keras.utils.Sequence, DataLoader):
             sparse_max=sparse_max,
             sparse_as_dense=sparse_as_dense,
         )
-        self._transforms = [transform] if transform else []
+        self._transforms = [("all", transform)] if transform else []
         self.multi_label_as_dict = multi_label_as_dict
 
     def __len__(self):

--- a/merlin/models/tf/loader.py
+++ b/merlin/models/tf/loader.py
@@ -16,6 +16,7 @@
 import contextlib
 import logging
 import os
+from typing import Protocol
 
 import dask.dataframe as dd
 import numpy as np
@@ -27,7 +28,7 @@ from merlin.io import Dataset
 from merlin.models.loader.backend import DataLoader
 from merlin.models.loader.tf_utils import get_dataset_schema_from_feature_columns
 from merlin.models.utils.schema_utils import select_targets
-from merlin.schema import Tags
+from merlin.schema import Schema, Tags
 
 LOG = logging.getLogger("merlin.models")
 
@@ -133,7 +134,15 @@ def _get_schema(dataset):
     return None
 
 
-class BatchedDataset(tf.keras.utils.Sequence, DataLoader):
+class SchemaAwareTransform(Protocol):
+    def __call__(self, *args, **kwargs):
+        ...
+
+    def compute_output_schema(self, schema: Schema):
+        ...
+
+
+class Loader(tf.keras.utils.Sequence, DataLoader):
     """
     Override class to customize data loading for backward compatibility with
     older NVTabular releases.
@@ -199,6 +208,8 @@ class BatchedDataset(tf.keras.utils.Sequence, DataLoader):
         `reader_kwargs` will be ignored
     batch_size: int
         Number of samples to yield at each iteration
+    transform: Union[Callable, SchemaAwareTransform], optional
+        Transformation to apply to each batch of data.
     label_names: list(str)
         Column name of the target variable in the dataframe specified by
         `paths_or_dataset`
@@ -251,6 +262,7 @@ class BatchedDataset(tf.keras.utils.Sequence, DataLoader):
         self,
         paths_or_dataset,
         batch_size,
+        transform=None,
         label_names=None,
         feature_columns=None,
         cat_names=None,
@@ -300,9 +312,8 @@ class BatchedDataset(tf.keras.utils.Sequence, DataLoader):
             sparse_max=sparse_max,
             sparse_as_dense=sparse_as_dense,
         )
-        self._map_fns = []
-        if len(label_names) > 1 and multi_label_as_dict:
-            self._map_fns.append(lambda X, y: (X, dict(zip(label_names, y))))
+        self._transforms = [transform] if transform else []
+        self.multi_label_as_dict = multi_label_as_dict
 
     def __len__(self):
         """
@@ -325,25 +336,27 @@ class BatchedDataset(tf.keras.utils.Sequence, DataLoader):
         """
         return DataLoader.__next__(self)
 
-    def map(self, fn) -> "BatchedDataset":
+    def map(self, fn) -> "Loader":
         """
         Applying a function to each batch.
 
         This can for instance be used to add `sample_weight` to the model.
         """
-        self._map_fns.append(fn)
+        self._transforms.append(("all", fn))
 
         return self
 
-    def map_features(self, fn) -> "BatchedDataset":
+    def map_features(self, fn) -> "Loader":
         def wrapped_fn(*inputs):
             features = fn(inputs[0])
 
             return features, *inputs[1:]
 
-        return self.map(wrapped_fn)
+        self._transforms.append(("features", wrapped_fn))
 
-    def map_targets(self, fn) -> "BatchedDataset":
+        return self
+
+    def map_targets(self, fn) -> "Loader":
         def wrapped_fn(*inputs):
             targets = fn(inputs[1])
 
@@ -352,7 +365,9 @@ class BatchedDataset(tf.keras.utils.Sequence, DataLoader):
 
             return inputs[0], targets
 
-        return self.map(wrapped_fn)
+        self._transforms.append(("targets", wrapped_fn))
+
+        return self
 
     @contextlib.contextmanager
     def _get_device_ctx(self, dev):
@@ -491,13 +506,44 @@ class BatchedDataset(tf.keras.utils.Sequence, DataLoader):
     def _handle_tensors(self, cats, conts, labels):
         to_return = super()._handle_tensors(cats, conts, labels)
 
-        for map_fn in self._map_fns:
-            to_return = map_fn(*to_return)
+        if len(self.label_names) > 1 and self.multi_label_as_dict:
+            X, y = to_return
+            to_return = X, dict(zip(self.label_names, y))
+
+        for _, transform in self._transforms:
+            to_return = transform(*to_return)
 
         return to_return
 
+    @property
+    def input_schema(self) -> Schema:
+        return self.data.schema
 
-class DatasetValidator(tf.keras.callbacks.Callback):
+    @property
+    def output_schema(self) -> Schema:
+        schema = self.input_schema
+
+        for to, transform in self._transforms:
+            if hasattr(transform, "compute_output_schema"):
+                _schema = transform.compute_output_schema(schema)
+            else:
+                raise ValueError(f"Couldn't infer schema from transform {transform}")
+
+            if to == "all":
+                schema = _schema
+            elif to == "features":
+                targets_schema = schema.select_by_tag(Tags.Target)
+                schema = _schema + targets_schema
+            elif to == "targets":
+                features_schema = schema.remove_by_tag(Tags.Target)
+                schema = features_schema + _schema
+            else:
+                raise ValueError(f"Unknown schema target {to}")
+
+        return schema
+
+
+class KerasSequenceValidator(tf.keras.callbacks.Callback):
     # TODO: document
     _supports_tf_logs = True
 
@@ -558,8 +604,8 @@ def sample_batch(
 
     from merlin.models.tf.transforms.tensor import ListToDense, ListToRagged
 
-    if not isinstance(data, BatchedDataset):
-        data = BatchedDataset(data, batch_size=batch_size, shuffle=shuffle)
+    if not isinstance(data, Loader):
+        data = Loader(data, batch_size=batch_size, shuffle=shuffle)
 
     batch = next(iter(data))
     # batch could be of type Prediction, so we can't unpack directly

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -18,8 +18,8 @@ from merlin.models.tf.core.base import Block, ModelContext, PredictionOutput, is
 from merlin.models.tf.core.combinators import SequentialBlock
 from merlin.models.tf.core.prediction import Prediction, PredictionContext
 from merlin.models.tf.core.tabular import TabularBlock
-from merlin.models.tf.dataset import BatchedDataset
 from merlin.models.tf.inputs.base import InputBlock
+from merlin.models.tf.loader import Loader
 from merlin.models.tf.losses.base import loss_registry
 from merlin.models.tf.metrics.topk import TopKMetricsAggregator, filter_topk_metrics, split_metrics
 from merlin.models.tf.models.utils import parse_prediction_tasks
@@ -704,7 +704,7 @@ class BaseModel(tf.keras.Model):
         x = _maybe_convert_merlin_dataset(x, batch_size, **kwargs)
 
         # Bind schema from dataset to model in case we can't infer it from the inputs
-        if isinstance(x, BatchedDataset):
+        if isinstance(x, Loader):
             self.schema = x.schema
 
         validation_data = _maybe_convert_merlin_dataset(
@@ -1403,7 +1403,7 @@ def _maybe_convert_merlin_dataset(data, batch_size, shuffle=True, **kwargs):
         if not batch_size:
             raise ValueError("batch_size must be specified when using merlin-dataset.")
 
-        data = BatchedDataset(data, batch_size=batch_size, shuffle=shuffle, **kwargs)
+        data = Loader(data, batch_size=batch_size, shuffle=shuffle, **kwargs)
 
         if not shuffle:
             kwargs.pop("shuffle", None)

--- a/merlin/models/tf/transforms/negative_sampling.py
+++ b/merlin/models/tf/transforms/negative_sampling.py
@@ -42,7 +42,7 @@ class InBatchNegatives(tf.keras.layers.Layer):
         Whether the negative sampling should happen when testing=True, by default True
     return_tuple : bool, optional
         Whether to return a Prediction or a tuple. The tuple option should be used
-        when using UniformNegativeSampling with BatchedDataset.map()
+        when using UniformNegativeSampling with Loader.map()
         which accepts a tuple with length 2 or 3 (x,y,sample_weight), by default False
     """
 

--- a/merlin/models/tf/utils/batch_utils.py
+++ b/merlin/models/tf/utils/batch_utils.py
@@ -6,7 +6,7 @@ import tensorflow as tf
 
 from merlin.core.dispatch import DataFrameType, concat_columns, get_lib
 from merlin.models.tf.core.base import Block
-from merlin.models.tf.dataset import BatchedDataset
+from merlin.models.tf.loader import Loader
 from merlin.models.tf.models.base import Model, RetrievalModel
 from merlin.models.utils.schema_utils import select_targets
 from merlin.schema import Schema, Tags
@@ -175,7 +175,7 @@ def data_iterator_func(schema, batch_size: int = 512):
     targets = select_targets(schema).column_names
 
     def data_iterator(dataset):
-        return BatchedDataset(
+        return Loader(
             merlin.io.dataset.Dataset(dataset),
             batch_size=batch_size,
             cat_names=cat_cols,

--- a/merlin/models/tf/utils/testing_utils.py
+++ b/merlin/models/tf/utils/testing_utils.py
@@ -25,7 +25,7 @@ from keras.utils import tf_inspect
 from tensorflow.python.framework.test_util import disable_cudnn_autotune
 
 import merlin.io
-from merlin.models.tf.dataset import BatchedDataset, sample_batch
+from merlin.models.tf.loader import Loader, sample_batch
 from merlin.models.tf.models.base import Model
 from merlin.schema import Schema
 
@@ -76,7 +76,7 @@ def assert_model_is_retrainable(
 
 def model_test(
     model: Model,
-    dataset: Union[merlin.io.Dataset, BatchedDataset],
+    dataset: Union[merlin.io.Dataset, Loader],
     run_eagerly: bool = True,
     optimizer="adam",
     epochs: int = 1,

--- a/tests/unit/tf/core/test_index.py
+++ b/tests/unit/tf/core/test_index.py
@@ -17,7 +17,7 @@
 import pytest
 
 import merlin.models.tf as mm
-from merlin.io.dataset import Dataset
+from merlin.io import Dataset
 from merlin.schema import Tags
 
 
@@ -77,7 +77,6 @@ def test_topk_recommender_outputs(ecommerce_data: Dataset, batch_size=100):
     import numpy as np
     import tensorflow as tf
 
-    import merlin.models.tf.dataset as tf_dataloader
     from merlin.models.tf.core.index import IndexBlock
     from merlin.models.utils.dataset import unique_rows_by_features
 
@@ -120,7 +119,7 @@ def test_topk_recommender_outputs(ecommerce_data: Dataset, batch_size=100):
     tf.debugging.assert_equal(top_ids, topk_items)
 
     # Compute recall using top-k recommender
-    data_dl = tf_dataloader.BatchedDataset(
+    data_dl = mm.Loader(
         ecommerce_data,
         batch_size=batch_size,
         shuffle=False,

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -21,20 +21,19 @@ import pytest
 import tensorflow as tf
 from tensorflow.test import TestCase
 
-import merlin.models.tf as ml
+import merlin.models.tf as mm
 from merlin.datasets.synthetic import generate_data
 from merlin.io.dataset import Dataset
-from merlin.models.tf.dataset import BatchedDataset
 from merlin.models.tf.utils import testing_utils, tf_utils
 from merlin.schema import ColumnSchema, Schema, Tags
 
 
 @pytest.mark.parametrize("run_eagerly", [False])
 def test_simple_model(ecommerce_data: Dataset, run_eagerly):
-    model = ml.Model(
-        ml.InputBlock(ecommerce_data.schema),
-        ml.MLPBlock([4]),
-        ml.BinaryClassificationTask("click"),
+    model = mm.Model(
+        mm.InputBlock(ecommerce_data.schema),
+        mm.MLPBlock([4]),
+        mm.BinaryClassificationTask("click"),
     )
 
     loaded_model, _ = testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)
@@ -51,24 +50,24 @@ def test_fit_twice():
             ColumnSchema("target", dtype=np.int32, tags=[Tags.BINARY_CLASSIFICATION]),
         ]
     )
-    batched_dataset = BatchedDataset(dataset, batch_size=2, shuffle=False)
-    model = ml.Model(
+    loader = mm.Loader(dataset, batch_size=2, shuffle=False)
+    model = mm.Model(
         tf.keras.layers.Lambda(lambda x: x["feature"]),
         tf.keras.layers.Dense(1),
-        ml.BinaryClassificationTask("target"),
+        mm.BinaryClassificationTask("target"),
     )
     model.compile(run_eagerly=True, optimizer="adam")
-    model.fit(batched_dataset, epochs=2)
-    model.fit(batched_dataset, epochs=2)
+    model.fit(loader, epochs=2)
+    model.fit(loader, epochs=2)
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_model_from_block(ecommerce_data: Dataset, run_eagerly):
-    embedding_options = ml.EmbeddingOptions(embedding_dim_default=2)
-    model = ml.Model.from_block(
-        ml.MLPBlock([4]),
+    embedding_options = mm.EmbeddingOptions(embedding_dim_default=2)
+    model = mm.Model.from_block(
+        mm.MLPBlock([4]),
         ecommerce_data.schema,
-        prediction_tasks=ml.BinaryClassificationTask("click"),
+        prediction_tasks=mm.BinaryClassificationTask("click"),
         embedding_options=embedding_options,
     )
 
@@ -80,11 +79,11 @@ def test_model_from_block(ecommerce_data: Dataset, run_eagerly):
 
 
 def test_block_from_model_with_input(ecommerce_data: Dataset):
-    inputs = ml.InputBlock(ecommerce_data.schema)
-    block = inputs.connect(ml.MLPBlock([2]))
+    inputs = mm.InputBlock(ecommerce_data.schema)
+    block = inputs.connect(mm.MLPBlock([2]))
 
     with pytest.raises(ValueError) as excinfo:
-        ml.Model.from_block(
+        mm.Model.from_block(
             block,
             ecommerce_data.schema,
             input_block=inputs,
@@ -133,10 +132,10 @@ def test_train_metrics_steps(
     num_rows, batch_size, train_metrics_steps, expected_steps, expected_metrics_steps
 ):
     dataset = generate_data("e-commerce", num_rows=num_rows)
-    model = ml.Model(
-        ml.InputBlock(dataset.schema),
-        ml.MLPBlock([64]),
-        ml.BinaryClassificationTask("click"),
+    model = mm.Model(
+        mm.InputBlock(dataset.schema),
+        mm.MLPBlock([64]),
+        mm.BinaryClassificationTask("click"),
     )
     model.compile(
         run_eagerly=True,
@@ -163,32 +162,32 @@ def test_train_metrics_steps(
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_model_pre_post(ecommerce_data: Dataset, run_eagerly):
-    model = ml.Model(
-        ml.InputBlock(ecommerce_data.schema),
-        ml.MLPBlock([4]),
-        ml.BinaryClassificationTask("click"),
-        post=ml.NoOp(),
+    model = mm.Model(
+        mm.InputBlock(ecommerce_data.schema),
+        mm.MLPBlock([4]),
+        mm.BinaryClassificationTask("click"),
+        post=mm.NoOp(),
     )
 
-    model.pre = ml.StochasticSwapNoise(ecommerce_data.schema)
+    model.pre = mm.StochasticSwapNoise(ecommerce_data.schema)
 
     loaded_model, _ = testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)
 
-    assert isinstance(loaded_model.pre, ml.StochasticSwapNoise)
-    assert isinstance(loaded_model.post, ml.NoOp)
+    assert isinstance(loaded_model.pre, mm.StochasticSwapNoise)
+    assert isinstance(loaded_model.post, mm.NoOp)
 
 
 def test_sub_class_model(ecommerce_data: Dataset):
     blocks = ["input_block", "mlp", "prediction"]
 
     @tf.keras.utils.register_keras_serializable(package="merlin.models")
-    class SubClassedModel(ml.BaseModel):
+    class SubClassedModel(mm.BaseModel):
         def __init__(self, schema: Schema, target: str, **kwargs):
             super(SubClassedModel, self).__init__()
             if "input_block" not in kwargs:
-                self.input_block = ml.InputBlock(schema)
-                self.mlp = ml.MLPBlock([4])
-                self.prediction = ml.BinaryClassificationTask(target)
+                self.input_block = mm.InputBlock(schema)
+                self.mlp = mm.MLPBlock([4])
+                self.prediction = mm.BinaryClassificationTask(target)
             else:
                 self.input_block = kwargs["input_block"]
                 self.mlp = kwargs["mlp"]
@@ -218,13 +217,13 @@ def test_sub_class_model(ecommerce_data: Dataset):
 def test_find_blocks_and_sub_blocks(ecommerce_data):
     test_case = TestCase()
     schema = ecommerce_data.schema.select_by_name(names=["user_categories", "item_category"])
-    input_block = ml.InputBlockV2(schema)
-    layer_1 = ml.MLPBlock([64], name="layer_1")
-    layer_2 = ml.MLPBlock([1], no_activation_last_layer=True, name="layer_2")
-    two_layer = ml.SequentialBlock([layer_1, layer_2], name="two_layers")
+    input_block = mm.InputBlockV2(schema)
+    layer_1 = mm.MLPBlock([64], name="layer_1")
+    layer_2 = mm.MLPBlock([1], no_activation_last_layer=True, name="layer_2")
+    two_layer = mm.SequentialBlock([layer_1, layer_2], name="two_layers")
     body = input_block.connect(two_layer)
 
-    model = ml.Model(body, ml.BinaryClassificationTask("click"))
+    model = mm.Model(body, mm.BinaryClassificationTask("click"))
     testing_utils.model_test(model, ecommerce_data)
 
     print(model.summary(expand_nested=True, show_trainable=True, line_length=80))
@@ -293,11 +292,11 @@ def test_freeze_parallel_block(ecommerce_data, run_eagerly):
     schema = ecommerce_data.schema.select_by_name(
         names=["user_categories", "item_category", "click"]
     )
-    input_block = ml.InputBlockV2(schema)
-    layer_1 = ml.MLPBlock([64], name="layer_1")
+    input_block = mm.InputBlockV2(schema)
+    layer_1 = mm.MLPBlock([64], name="layer_1")
     body = input_block.connect(layer_1)
 
-    model = ml.Model(body, ml.BinaryClassificationTask("click"))
+    model = mm.Model(body, mm.BinaryClassificationTask("click"))
 
     # Compile(Make sure set run_eagerly mode) and fit -> model.freeze_blocks -> compile and fit
     # Set run_eagerly=True in order to avoid error: "Called a function referencing variables which
@@ -387,13 +386,13 @@ def test_freeze_parallel_block(ecommerce_data, run_eagerly):
 def test_freeze_sequential_block(ecommerce_data):
     test_case = TestCase()
     schema = ecommerce_data.schema.select_by_name(names=["user_categories", "item_category"])
-    input_block = ml.InputBlockV2(schema)
-    layer_1 = ml.MLPBlock([64], name="layer_1")
-    layer_2 = ml.MLPBlock([1], no_activation_last_layer=True, name="layer_2")
-    two_layer = ml.SequentialBlock([layer_1, layer_2], name="two_layers")
+    input_block = mm.InputBlockV2(schema)
+    layer_1 = mm.MLPBlock([64], name="layer_1")
+    layer_2 = mm.MLPBlock([1], no_activation_last_layer=True, name="layer_2")
+    two_layer = mm.SequentialBlock([layer_1, layer_2], name="two_layers")
     body = input_block.connect(two_layer)
 
-    model = ml.Model(body, ml.BinaryClassificationTask("click"))
+    model = mm.Model(body, mm.BinaryClassificationTask("click"))
     model.compile(run_eagerly=True, optimizer=tf.keras.optimizers.SGD(lr=0.1))
     model.fit(ecommerce_data, batch_size=128, epochs=1)
 
@@ -487,13 +486,13 @@ def test_freeze_sequential_block(ecommerce_data):
 
 def test_freeze_unfreeze(ecommerce_data):
     schema = ecommerce_data.schema.select_by_name(names=["user_categories", "item_category"])
-    input_block = ml.InputBlockV2(schema)
-    layer_1 = ml.MLPBlock([64], name="layer_1")
-    layer_2 = ml.MLPBlock([1], no_activation_last_layer=True, name="layer_2")
-    two_layer = ml.SequentialBlock([layer_1, layer_2], name="two_layers")
+    input_block = mm.InputBlockV2(schema)
+    layer_1 = mm.MLPBlock([64], name="layer_1")
+    layer_2 = mm.MLPBlock([1], no_activation_last_layer=True, name="layer_2")
+    two_layer = mm.SequentialBlock([layer_1, layer_2], name="two_layers")
     body = input_block.connect(two_layer)
 
-    model = ml.Model(body, ml.BinaryClassificationTask("click"))
+    model = mm.Model(body, mm.BinaryClassificationTask("click"))
     model.compile(run_eagerly=True, optimizer=tf.keras.optimizers.SGD(lr=0.1))
     model.fit(ecommerce_data, batch_size=128, epochs=1)
 
@@ -567,13 +566,13 @@ def test_freeze_unfreeze(ecommerce_data):
 
 def test_unfreeze_all_blocks(ecommerce_data):
     schema = ecommerce_data.schema.select_by_name(names=["user_categories", "item_category"])
-    input_block = ml.InputBlockV2(schema)
-    layer_1 = ml.MLPBlock([64], name="layer_1")
-    layer_2 = ml.MLPBlock([1], no_activation_last_layer=True, name="layer_2")
-    two_layer = ml.SequentialBlock([layer_1, layer_2], name="two_layers")
+    input_block = mm.InputBlockV2(schema)
+    layer_1 = mm.MLPBlock([64], name="layer_1")
+    layer_2 = mm.MLPBlock([1], no_activation_last_layer=True, name="layer_2")
+    two_layer = mm.SequentialBlock([layer_1, layer_2], name="two_layers")
     body = input_block.connect(two_layer)
 
-    model = ml.Model(body, ml.BinaryClassificationTask("click"))
+    model = mm.Model(body, mm.BinaryClassificationTask("click"))
     model.compile(run_eagerly=True, optimizer=tf.keras.optimizers.SGD(lr=0.1))
     model.fit(ecommerce_data, batch_size=128, epochs=1)
 

--- a/tests/unit/tf/models/test_ranking.py
+++ b/tests/unit/tf/models/test_ranking.py
@@ -19,21 +19,20 @@ import pytest
 import tensorflow as tf
 from tensorflow.keras import regularizers
 
-import merlin.models.tf as ml
+import merlin.models.tf as mm
 from merlin.datasets.synthetic import generate_data
 from merlin.io import Dataset
-from merlin.models.tf.dataset import BatchedDataset
 from merlin.models.tf.utils import testing_utils
 from merlin.schema import Tags
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_mf_model_single_binary_task(ecommerce_data, run_eagerly):
-    model = ml.MatrixFactorizationModel(
+    model = mm.MatrixFactorizationModel(
         ecommerce_data.schema,
         dim=4,
         aggregation="cosine",
-        prediction_tasks=ml.BinaryClassificationTask("click"),
+        prediction_tasks=mm.BinaryClassificationTask("click"),
     )
 
     testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)
@@ -44,11 +43,11 @@ def test_dlrm_model(music_streaming_data, run_eagerly):
     music_streaming_data.schema = music_streaming_data.schema.select_by_name(
         ["item_id", "user_age", "click"]
     )
-    model = ml.DLRMModel(
+    model = mm.DLRMModel(
         music_streaming_data.schema,
         embedding_dim=2,
-        bottom_block=ml.MLPBlock([2]),
-        prediction_tasks=ml.BinaryClassificationTask("click"),
+        bottom_block=mm.MLPBlock([2]),
+        prediction_tasks=mm.BinaryClassificationTask("click"),
     )
 
     loaded_model, _ = testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
@@ -66,11 +65,11 @@ def test_dlrm_model_with_embeddings(music_streaming_data, run_eagerly):
     )
     schema = music_streaming_data.schema
     embedding_dim = 4
-    model = ml.DLRMModel(
+    model = mm.DLRMModel(
         schema,
-        embeddings=ml.Embeddings(schema.select_by_tag(Tags.CATEGORICAL), dim=embedding_dim),
-        bottom_block=ml.MLPBlock([embedding_dim]),
-        prediction_tasks=ml.BinaryClassificationTask("click"),
+        embeddings=mm.Embeddings(schema.select_by_tag(Tags.CATEGORICAL), dim=embedding_dim),
+        bottom_block=mm.MLPBlock([embedding_dim]),
+        prediction_tasks=mm.BinaryClassificationTask("click"),
     )
 
     testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
@@ -86,15 +85,15 @@ def test_dlrm_model_with_sample_weights_and_weighted_metrics(music_streaming_dat
         sample_weight = tf.cast(features.pop(sample_weight_col_name), tf.float32)
         return features, labels, sample_weight
 
-    batched_ds = BatchedDataset(music_streaming_data, batch_size=10)
-    batched_ds = batched_ds.map(add_sample_weight)
-    batch = next(iter(batched_ds))
+    loader = mm.Loader(music_streaming_data, batch_size=10)
+    loader = loader.map(add_sample_weight)
+    batch = next(iter(loader))
 
-    model = ml.DLRMModel(
+    model = mm.DLRMModel(
         music_streaming_data.schema.select_by_name(["item_id", "click"]),
         embedding_dim=2,
-        bottom_block=ml.MLPBlock([2]),
-        prediction_tasks=ml.BinaryClassificationTask("click"),
+        bottom_block=mm.MLPBlock([2]),
+        prediction_tasks=mm.BinaryClassificationTask("click"),
     )
 
     weighted_metrics = (
@@ -129,11 +128,11 @@ def test_dlrm_model_without_continuous_features(ecommerce_data, run_eagerly):
     ecommerce_data.schema = ecommerce_data.schema.select_by_name(
         ["user_categories", "item_category", "click"]
     )
-    model = ml.DLRMModel(
+    model = mm.DLRMModel(
         ecommerce_data.schema,
         embedding_dim=2,
-        top_block=ml.MLPBlock([2]),
-        prediction_tasks=ml.BinaryClassificationTask("click"),
+        top_block=mm.MLPBlock([2]),
+        prediction_tasks=mm.BinaryClassificationTask("click"),
     )
 
     testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)
@@ -145,12 +144,12 @@ def test_dcn_model(music_streaming_data, stacked, run_eagerly):
     music_streaming_data.schema = music_streaming_data.schema.select_by_name(
         ["item_id", "user_age", "click"]
     )
-    model = ml.DCNModel(
+    model = mm.DCNModel(
         music_streaming_data.schema,
         depth=1,
-        deep_block=ml.MLPBlock([2]),
+        deep_block=mm.MLPBlock([2]),
         stacked=stacked,
-        prediction_tasks=ml.BinaryClassificationTask("click"),
+        prediction_tasks=mm.BinaryClassificationTask("click"),
     )
 
     testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
@@ -161,11 +160,11 @@ def test_deepfm_model_only_categ_feats(music_streaming_data, run_eagerly):
     music_streaming_data.schema = music_streaming_data.schema.select_by_name(
         ["item_id", "item_category", "user_id", "click"]
     )
-    model = ml.DeepFMModel(
+    model = mm.DeepFMModel(
         music_streaming_data.schema,
         embedding_dim=16,
-        deep_block=ml.MLPBlock([16]),
-        prediction_tasks=ml.BinaryClassificationTask("click"),
+        deep_block=mm.MLPBlock([16]),
+        prediction_tasks=mm.BinaryClassificationTask("click"),
     )
 
     testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
@@ -176,11 +175,11 @@ def test_deepfm_model_categ_and_continuous_feats(music_streaming_data, run_eager
     music_streaming_data.schema = music_streaming_data.schema.select_by_name(
         ["item_id", "item_category", "user_id", "user_age", "click"]
     )
-    model = ml.DeepFMModel(
+    model = mm.DeepFMModel(
         music_streaming_data.schema,
         embedding_dim=16,
-        deep_block=ml.MLPBlock([16]),
-        prediction_tasks=ml.BinaryClassificationTask("click"),
+        deep_block=mm.MLPBlock([16]),
+        prediction_tasks=mm.BinaryClassificationTask("click"),
     )
 
     testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
@@ -191,25 +190,25 @@ def test_dlrm_model_multi_task(music_streaming_data, run_eagerly):
     music_streaming_data.schema = music_streaming_data.schema.select_by_name(
         ["item_id", "user_age", "click", "play_percentage"]
     )
-    tasks_blocks = dict(click=ml.MLPBlock([2]), play_percentage=ml.MLPBlock([2]))
-    model = ml.Model(
-        ml.DLRMBlock(
+    tasks_blocks = dict(click=mm.MLPBlock([2]), play_percentage=mm.MLPBlock([2]))
+    model = mm.Model(
+        mm.DLRMBlock(
             music_streaming_data.schema,
             embedding_dim=2,
-            bottom_block=ml.MLPBlock([2]),
-            top_block=ml.MLPBlock([2]),
+            bottom_block=mm.MLPBlock([2]),
+            top_block=mm.MLPBlock([2]),
         ),
-        ml.MLPBlock([2]),
-        ml.PredictionTasks(music_streaming_data.schema, task_blocks=tasks_blocks),
+        mm.MLPBlock([2]),
+        mm.PredictionTasks(music_streaming_data.schema, task_blocks=tasks_blocks),
     )
 
     testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
 
 
-@pytest.mark.parametrize("prediction_task", [ml.BinaryClassificationTask, ml.RegressionTask])
+@pytest.mark.parametrize("prediction_task", [mm.BinaryClassificationTask, mm.RegressionTask])
 def test_serialization_model(ecommerce_data: Dataset, prediction_task):
-    model = ml.Model(
-        ml.InputBlock(ecommerce_data.schema), ml.MLPBlock([2]), prediction_task("click")
+    model = mm.Model(
+        mm.InputBlock(ecommerce_data.schema), mm.MLPBlock([2]), prediction_task("click")
     )
 
     testing_utils.model_test(model, ecommerce_data, reload_model=True)
@@ -222,12 +221,12 @@ def test_wide_deep_model(music_streaming_data, run_eagerly):
     wide_schema = music_streaming_data.schema.select_by_name(["country"])
     deep_schema = music_streaming_data.schema.select_by_name(["country", "user_age"])
 
-    model = ml.WideAndDeepModel(
+    model = mm.WideAndDeepModel(
         music_streaming_data.schema,
         wide_schema=wide_schema,
         deep_schema=deep_schema,
-        deep_block=ml.MLPBlock([32, 16]),
-        prediction_tasks=ml.BinaryClassificationTask("click"),
+        deep_block=mm.MLPBlock([32, 16]),
+        prediction_tasks=mm.BinaryClassificationTask("click"),
     )
 
     testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
@@ -239,13 +238,13 @@ def test_wide_deep_model_wide_categorical_one_hot(ecommerce_data, run_eagerly):
     wide_schema = ecommerce_data.schema.select_by_name(names=["user_categories", "item_category"])
     deep_schema = ecommerce_data.schema
 
-    model = ml.WideAndDeepModel(
+    model = mm.WideAndDeepModel(
         ecommerce_data.schema,
         wide_schema=wide_schema,
         deep_schema=deep_schema,
-        wide_preprocess=ml.CategoryEncoding(wide_schema, sparse=True),
-        deep_block=ml.MLPBlock([32, 16]),
-        prediction_tasks=ml.BinaryClassificationTask("click"),
+        wide_preprocess=mm.CategoryEncoding(wide_schema, sparse=True),
+        deep_block=mm.MLPBlock([32, 16]),
+        prediction_tasks=mm.BinaryClassificationTask("click"),
     )
 
     testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)
@@ -257,13 +256,13 @@ def test_wide_deep_model_hashed_cross(ecommerce_data, run_eagerly):
     wide_schema = ecommerce_data.schema.select_by_name(names=["user_categories", "item_category"])
     deep_schema = ecommerce_data.schema
 
-    model = ml.WideAndDeepModel(
+    model = mm.WideAndDeepModel(
         ecommerce_data.schema,
         wide_schema=wide_schema,
         deep_schema=deep_schema,
-        wide_preprocess=ml.HashedCross(wide_schema, 1000, sparse=True),
-        deep_block=ml.MLPBlock([32, 16]),
-        prediction_tasks=ml.BinaryClassificationTask("click"),
+        wide_preprocess=mm.HashedCross(wide_schema, 1000, sparse=True),
+        deep_block=mm.MLPBlock([32, 16]),
+        prediction_tasks=mm.BinaryClassificationTask("click"),
     )
 
     testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)
@@ -275,19 +274,19 @@ def test_wide_deep_embedding_custom_inputblock(music_streaming_data, run_eagerly
     schema = music_streaming_data.schema
     # prepare wide_schema
     wide_schema = schema.select_by_name(["country", "user_age"])
-    deep_embedding = ml.Embeddings(schema.select_by_tag(Tags.CATEGORICAL), dim=16)
+    deep_embedding = mm.Embeddings(schema.select_by_tag(Tags.CATEGORICAL), dim=16)
 
-    model = ml.WideAndDeepModel(
+    model = mm.WideAndDeepModel(
         schema,
-        deep_input_block=ml.InputBlockV2(schema=schema, categorical=deep_embedding),
+        deep_input_block=mm.InputBlockV2(schema=schema, categorical=deep_embedding),
         wide_schema=wide_schema,
-        wide_preprocess=ml.HashedCross(wide_schema, 1000, sparse=True),
-        deep_block=ml.MLPBlock([32, 16]),
+        wide_preprocess=mm.HashedCross(wide_schema, 1000, sparse=True),
+        deep_block=mm.MLPBlock([32, 16]),
         deep_regularizer=regularizers.l2(1e-5),
         wide_regularizer=regularizers.l2(1e-5),
         deep_dropout=0.1,
         wide_dropout=0.2,
-        prediction_tasks=ml.BinaryClassificationTask("click"),
+        prediction_tasks=mm.BinaryClassificationTask("click"),
     )
 
     testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
@@ -311,21 +310,21 @@ def test_wide_deep_model_wide_onehot_multihot_feature_interaction(ecommerce_data
 
     wide_preprocessing_blocks = [
         # One-hot features
-        ml.SequentialBlock(
-            ml.Filter(cat_schema_onehot),
-            ml.CategoryEncoding(cat_schema_onehot, sparse=True, output_mode="one_hot"),
+        mm.SequentialBlock(
+            mm.Filter(cat_schema_onehot),
+            mm.CategoryEncoding(cat_schema_onehot, sparse=True, output_mode="one_hot"),
         ),
         # Multi-hot features
-        ml.SequentialBlock(
-            ml.Filter(cat_schema_multihot),
-            ml.ListToDense(max_seq_length=6),
-            ml.CategoryEncoding(cat_schema_multihot, sparse=True, output_mode="multi_hot"),
+        mm.SequentialBlock(
+            mm.Filter(cat_schema_multihot),
+            mm.ListToDense(max_seq_length=6),
+            mm.CategoryEncoding(cat_schema_multihot, sparse=True, output_mode="multi_hot"),
         ),
         # 2nd level feature interactions of one-hot features
-        ml.SequentialBlock(
-            ml.Filter(cat_schema),
-            ml.ListToDense(max_seq_length=6),
-            ml.HashedCrossAll(
+        mm.SequentialBlock(
+            mm.Filter(cat_schema),
+            mm.ListToDense(max_seq_length=6),
+            mm.HashedCrossAll(
                 cat_schema,
                 num_bins=100,
                 max_level=2,
@@ -336,9 +335,9 @@ def test_wide_deep_model_wide_onehot_multihot_feature_interaction(ecommerce_data
         ),
     ]
 
-    batch = ml.sample_batch(ml_dataset, batch_size=100, include_targets=False)
+    batch = mm.sample_batch(ml_dataset, batch_size=100, include_targets=False)
 
-    output_wide_features = ml.ParallelBlock(wide_preprocessing_blocks)(batch)
+    output_wide_features = mm.ParallelBlock(wide_preprocessing_blocks)(batch)
     assert set(output_wide_features.keys()) == set(
         [
             "userId",
@@ -392,16 +391,16 @@ def test_wide_deep_model_wide_onehot_multihot_feature_interaction(ecommerce_data
         np.max(np.sum(tf.sparse.to_dense(output_wide_features["genres"]).numpy(), axis=1)) > 1.0
     ), "'genres' should be multi-hot"
 
-    model = ml.WideAndDeepModel(
+    model = mm.WideAndDeepModel(
         cat_schema,
         wide_schema=cat_schema,
         deep_schema=cat_schema,
-        wide_preprocess=ml.ParallelBlock(
+        wide_preprocess=mm.ParallelBlock(
             wide_preprocessing_blocks,
             aggregation="concat",
         ),
-        deep_block=ml.MLPBlock([32, 16]),
-        prediction_tasks=ml.BinaryClassificationTask(target_col),
+        deep_block=mm.MLPBlock([32, 16]),
+        prediction_tasks=mm.BinaryClassificationTask(target_col),
     )
 
     testing_utils.model_test(model, ml_dataset, run_eagerly=run_eagerly)
@@ -417,21 +416,21 @@ def test_wide_deep_model_wide_feature_interaction_multi_optimizer(ecommerce_data
         names=["user_categories", "item_category", "user_brands", "item_brand"]
     )
 
-    model = ml.WideAndDeepModel(
+    model = mm.WideAndDeepModel(
         ecommerce_data.schema,
         wide_schema=wide_schema,
         deep_schema=deep_schema,
-        wide_preprocess=ml.ParallelBlock(
+        wide_preprocess=mm.ParallelBlock(
             [
                 # One-hot representations of categorical features
-                ml.CategoryEncoding(wide_schema, sparse=True),
+                mm.CategoryEncoding(wide_schema, sparse=True),
                 # One-hot representations of hashed 2nd-level feature interactions
-                ml.HashedCrossAll(wide_schema, num_bins=1000, max_level=2, sparse=True),
+                mm.HashedCrossAll(wide_schema, num_bins=1000, max_level=2, sparse=True),
             ],
             aggregation="concat",
         ),
-        deep_block=ml.MLPBlock([31, 16]),
-        prediction_tasks=ml.BinaryClassificationTask("click"),
+        deep_block=mm.MLPBlock([31, 16]),
+        prediction_tasks=mm.BinaryClassificationTask("click"),
     )
 
     testing_utils.model_test(model, ecommerce_data, run_eagerly=True)
@@ -439,11 +438,11 @@ def test_wide_deep_model_wide_feature_interaction_multi_optimizer(ecommerce_data
     wide_model = model.blocks[0].parallel_layers["wide"]
     deep_model = model.blocks[0].parallel_layers["deep"]
 
-    multi_optimizer = ml.MultiOptimizer(
+    multi_optimizer = mm.MultiOptimizer(
         default_optimizer="adagrad",
         optimizers_and_blocks=[
-            ml.OptimizerBlocks("ftrl", wide_model),
-            ml.OptimizerBlocks("adagrad", deep_model),
+            mm.OptimizerBlocks("ftrl", wide_model),
+            mm.OptimizerBlocks("adagrad", deep_model),
         ],
     )
     testing_utils.model_test(

--- a/tests/unit/tf/models/test_ranking.py
+++ b/tests/unit/tf/models/test_ranking.py
@@ -85,8 +85,7 @@ def test_dlrm_model_with_sample_weights_and_weighted_metrics(music_streaming_dat
         sample_weight = tf.cast(features.pop(sample_weight_col_name), tf.float32)
         return features, labels, sample_weight
 
-    loader = mm.Loader(music_streaming_data, batch_size=10)
-    loader = loader.map(add_sample_weight)
+    loader = mm.Loader(music_streaming_data, batch_size=10, transform=add_sample_weight)
     batch = next(iter(loader))
 
     model = mm.DLRMModel(

--- a/tests/unit/tf/models/test_retrieval.py
+++ b/tests/unit/tf/models/test_retrieval.py
@@ -361,8 +361,9 @@ def test_youtube_dnn_retrieval(sequence_testing_data: Dataset):
 
         return inputs, targets
 
-    dataloader = mm.Loader(sequence_testing_data, batch_size=50)
-    dataloader = dataloader.map(last_interaction_as_target)
+    dataloader = mm.Loader(
+        sequence_testing_data, batch_size=50, transform=last_interaction_as_target
+    )
 
     losses = model.fit(dataloader, epochs=1)
 

--- a/tests/unit/tf/models/test_retrieval.py
+++ b/tests/unit/tf/models/test_retrieval.py
@@ -5,7 +5,6 @@ import tensorflow as tf
 
 import merlin.models.tf as mm
 from merlin.io import Dataset
-from merlin.models.tf.dataset import BatchedDataset
 from merlin.models.tf.metrics.topk import (
     AvgPrecisionAt,
     MRRAt,
@@ -362,7 +361,7 @@ def test_youtube_dnn_retrieval(sequence_testing_data: Dataset):
 
         return inputs, targets
 
-    dataloader = BatchedDataset(sequence_testing_data, batch_size=50)
+    dataloader = mm.Loader(sequence_testing_data, batch_size=50)
     dataloader = dataloader.map(last_interaction_as_target)
 
     losses = model.fit(dataloader, epochs=1)

--- a/tests/unit/tf/outputs/test_classification.py
+++ b/tests/unit/tf/outputs/test_classification.py
@@ -18,7 +18,6 @@ import tensorflow as tf
 
 import merlin.models.tf as mm
 from merlin.io import Dataset
-from merlin.models.tf.dataset import BatchedDataset
 from merlin.models.tf.outputs.classification import CategoricalTarget, EmbeddingTablePrediction
 from merlin.models.tf.utils import testing_utils
 from merlin.schema import Tags
@@ -102,6 +101,6 @@ def _next_item_loader(sequence_testing_data: Dataset):
 
     schema = sequence_testing_data.schema.select_by_tag(Tags.CATEGORICAL)
     sequence_testing_data.schema = schema
-    dataloader = BatchedDataset(sequence_testing_data, batch_size=50)
+    dataloader = mm.Loader(sequence_testing_data, batch_size=50)
     dataloader = dataloader.map(_last_interaction_as_target)
     return dataloader, schema

--- a/tests/unit/tf/outputs/test_contrastive.py
+++ b/tests/unit/tf/outputs/test_contrastive.py
@@ -18,7 +18,6 @@ import tensorflow as tf
 
 import merlin.models.tf as mm
 from merlin.io import Dataset
-from merlin.models.tf.dataset import BatchedDataset
 from merlin.models.tf.outputs.sampling.popularity import PopularityBasedSamplerV2
 from merlin.models.tf.transforms.features import Rename
 from merlin.models.tf.utils import testing_utils
@@ -214,6 +213,6 @@ def _next_item_loader(sequence_testing_data: Dataset, to_one_hot=True):
 
     schema = sequence_testing_data.schema.select_by_tag(Tags.CATEGORICAL)
     sequence_testing_data.schema = schema
-    dataloader = BatchedDataset(sequence_testing_data, batch_size=50)
-    dataloader = dataloader.map(_last_interaction_as_target)
-    return dataloader, schema
+    loader = mm.Loader(sequence_testing_data, batch_size=50)
+    loader = loader.map(_last_interaction_as_target)
+    return loader, schema

--- a/tests/unit/tf/test_loader.py
+++ b/tests/unit/tf/test_loader.py
@@ -24,7 +24,6 @@ import tensorflow as tf
 from sklearn.metrics import roc_auc_score
 
 import merlin.models.tf as mm
-import merlin.models.tf.dataset as tf_dataloader
 from merlin.core.dispatch import make_df
 from merlin.io.dataset import Dataset
 from merlin.models.utils.schema_utils import create_categorical_column
@@ -36,7 +35,7 @@ def test_lazy_dataset_map():
     data_df = pd.DataFrame({"feature": np.random.randint(100, size=dataset_size)})
     schema = Schema([ColumnSchema("feature", tags=[Tags.CATEGORICAL])])
     dataset = Dataset(data_df, schema=schema)
-    batched_dataset = tf_dataloader.BatchedDataset(dataset, batch_size=10)
+    loader = mm.Loader(dataset, batch_size=10)
 
     sleep_time_seconds = 0.5
 
@@ -44,9 +43,9 @@ def test_lazy_dataset_map():
         time.sleep(sleep_time_seconds)
         return (x, y)
 
-    batched_dataset = batched_dataset.map(identity)
+    loader = loader.map(identity)
 
-    elapsed_time_seconds = timeit.timeit(lambda: next(batched_dataset), number=1)
+    elapsed_time_seconds = timeit.timeit(lambda: next(loader), number=1)
 
     assert elapsed_time_seconds < 1
 
@@ -65,7 +64,7 @@ def test_nested_list():
         }
     )
 
-    train_dataset = tf_dataloader.BatchedDataset(
+    loader = mm.Loader(
         Dataset(df),
         cont_names=["data", "data2"],
         label_names=["label"],
@@ -73,7 +72,7 @@ def test_nested_list():
         shuffle=False,
     )
 
-    batch = next(iter(train_dataset))
+    batch = next(iter(loader))
     # [[1,2,3],[3,1],[...],[]]
     nested_data_col = tf.RaggedTensor.from_row_lengths(
         batch[0]["data"][0][:, 0], tf.cast(batch[0]["data"][1][:, 0], tf.int32)
@@ -100,11 +99,11 @@ def test_shuffling():
 
     df = pd.DataFrame({"a": np.asarray(range(num_rows)), "b": np.asarray([0] * num_rows)})
 
-    train_dataset = tf_dataloader.BatchedDataset(
+    loader = mm.Loader(
         Dataset(df), cont_names=["a"], label_names=["b"], batch_size=batch_size, shuffle=True
     )
 
-    batch = next(iter(train_dataset))
+    batch = next(iter(loader))
 
     first_batch = tf.reshape(tf.cast(batch[0]["a"].cpu(), tf.int32), (batch_size,))
     in_order = tf.range(0, batch_size, dtype=tf.int32)
@@ -134,7 +133,7 @@ def test_tf_drp_reset(tmpdir, batch_size, drop_last, num_rows):
     cont_names = ["cont3", "cont2", "cont1"]
     label_name = ["label"]
 
-    data_itr = tf_dataloader.BatchedDataset(
+    loader = mm.Loader(
         path,
         cat_names=cat_names,
         cont_names=cont_names,
@@ -144,9 +143,9 @@ def test_tf_drp_reset(tmpdir, batch_size, drop_last, num_rows):
         drop_last=drop_last,
     )
 
-    all_len = len(data_itr) if drop_last else len(data_itr) - 1
+    all_len = len(loader) if drop_last else len(loader) - 1
     all_rows = 0
-    for idx, (X, y) in enumerate(data_itr):
+    for idx, (X, y) in enumerate(loader):
         all_rows += len(X["cat1"])
         if idx < all_len:
             assert list(X["cat1"].numpy()) == [1] * batch_size
@@ -180,7 +179,7 @@ def test_tf_catname_ordering(tmpdir):
     cont_names = ["cont3", "cont2", "cont1"]
     label_name = ["label"]
 
-    data_itr = tf_dataloader.BatchedDataset(
+    loader = mm.Loader(
         path,
         cat_names=cat_names,
         cont_names=cont_names,
@@ -189,7 +188,7 @@ def test_tf_catname_ordering(tmpdir):
         shuffle=False,
     )
 
-    for X, y in data_itr:
+    for X, y in loader:
         assert list(X["cat1"].numpy()) == [1] * 10
         assert list(X["cat2"].numpy()) == [2] * 10
         assert list(X["cat3"].numpy()) == [3] * 10
@@ -221,7 +220,7 @@ def test_tf_map(tmpdir):
 
         return features, labels, sample_weight
 
-    data_itr = tf_dataloader.BatchedDataset(
+    loader = mm.Loader(
         path,
         cat_names=cat_names,
         cont_names=cont_names,
@@ -230,7 +229,7 @@ def test_tf_map(tmpdir):
         shuffle=False,
     ).map(add_sample_weight)
 
-    for X, y, sample_weight in data_itr:
+    for X, y, sample_weight in loader:
         assert list(X["cat1"].numpy()) == [1] * 10
         assert list(X["cat2"].numpy()) == [2] * 10
         assert list(X["cat3"].numpy()) == [3] * 10
@@ -241,13 +240,13 @@ def test_tf_map(tmpdir):
 
 
 @pytest.mark.parametrize("batch_size", [1, 2, 4])
-def test_validater(batch_size):
+def test_validator(batch_size):
     n_samples = 9
     rand = np.random.RandomState(0)
 
     gdf = make_df({"a": rand.randn(n_samples), "label": rand.randint(2, size=n_samples)})
 
-    dataloader = tf_dataloader.BatchedDataset(
+    loader = mm.Loader(
         Dataset(gdf),
         batch_size=batch_size,
         cat_names=[],
@@ -263,11 +262,11 @@ def test_validater(batch_size):
     model = tf.keras.Model(inputs=input_, outputs=x)
     model.compile("sgd", "binary_crossentropy", metrics=["accuracy", tf.keras.metrics.AUC()])
 
-    validater = tf_dataloader.DatasetValidator(dataloader)
-    model.fit(dataloader, epochs=2, verbose=0, callbacks=[validater])
+    validator = mm.KerasSequenceValidator(loader)
+    model.fit(loader, epochs=2, verbose=0, callbacks=[validator])
 
     predictions, labels = [], []
-    for X, y_true in dataloader:
+    for X, y_true in loader:
         y_pred = model(X)
         labels.extend(y_true.numpy()[:, 0])
         predictions.extend(y_pred.numpy()[:, 0])
@@ -275,7 +274,7 @@ def test_validater(batch_size):
     labels = np.array(labels)
 
     logs = {}
-    validater.on_epoch_end(0, logs)
+    validator.on_epoch_end(0, logs)
     auc_key = [i for i in logs if i.startswith("val_auc")][0]
 
     true_accuracy = (labels == (predictions > 0.5)).mean()
@@ -299,14 +298,14 @@ def test_block_with_sparse_inputs(music_streaming_data: Dataset):
             "user_id": np.random.randint(0, 10, (32,)).tolist(),
         }
     )
-    train_dataset = tf_dataloader.BatchedDataset(
+    loader = mm.Loader(
         Dataset(df),
         cat_names=["user_id", "item_genres"],
         batch_size=3,
         shuffle=False,
     )
 
-    batch = next(iter(train_dataset))[0]
+    batch = next(iter(loader))[0]
     out = block(batch)
     assert out.shape[-1] == 64
 

--- a/tests/unit/tf/test_loader.py
+++ b/tests/unit/tf/test_loader.py
@@ -35,7 +35,6 @@ def test_lazy_dataset_map():
     data_df = pd.DataFrame({"feature": np.random.randint(100, size=dataset_size)})
     schema = Schema([ColumnSchema("feature", tags=[Tags.CATEGORICAL])])
     dataset = Dataset(data_df, schema=schema)
-    loader = mm.Loader(dataset, batch_size=10)
 
     sleep_time_seconds = 0.5
 
@@ -43,7 +42,7 @@ def test_lazy_dataset_map():
         time.sleep(sleep_time_seconds)
         return (x, y)
 
-    loader = loader.map(identity)
+    loader = mm.Loader(dataset, batch_size=10, transform=identity)
 
     elapsed_time_seconds = timeit.timeit(lambda: next(loader), number=1)
 
@@ -227,7 +226,8 @@ def test_tf_map(tmpdir):
         batch_size=10,
         label_names=label_name,
         shuffle=False,
-    ).map(add_sample_weight)
+        transform=add_sample_weight,
+    )
 
     for X, y, sample_weight in loader:
         assert list(X["cat1"].numpy()) == [1] * 10

--- a/tests/unit/tf/transforms/test_negative_sampling.py
+++ b/tests/unit/tf/transforms/test_negative_sampling.py
@@ -21,7 +21,6 @@ import tensorflow as tf
 import merlin.models.tf as mm
 from merlin.io import Dataset
 from merlin.models.tf.core.prediction import Prediction
-from merlin.models.tf.dataset import BatchedDataset
 from merlin.models.tf.transforms.negative_sampling import InBatchNegatives
 from merlin.models.tf.utils import testing_utils
 from merlin.schema import ColumnSchema, Schema, Tags
@@ -68,9 +67,9 @@ class TestAddRandomNegativesToBatch:
         )
         input_df = input_df[sorted(input_df.columns)]
         dataset = Dataset(input_df, schema=schema)
-        batched_dataset = BatchedDataset(dataset, batch_size=10)
-        batched_dataset = batched_dataset.map(sampler)
-        first_batch_outputs = next(iter(batched_dataset))
+        loader = mm.Loader(dataset, batch_size=10)
+        loader = loader.map(sampler)
+        first_batch_outputs = next(iter(loader))
 
         outputs = first_batch_outputs.outputs
         targets = first_batch_outputs.targets
@@ -211,10 +210,10 @@ class TestAddRandomNegativesToBatch:
         )
 
         batch_size, n_per_positive = 10, 5
-        dataset = BatchedDataset(music_streaming_data, batch_size=batch_size)
-        dataset = dataset.map(add_negatives)
+        loader = mm.Loader(music_streaming_data, batch_size=batch_size)
+        loader = loader.map(add_negatives)
 
-        batch_output = next(iter(dataset))
+        batch_output = next(iter(loader))
         features, targets = batch_output
 
         expected_batch_size = batch_size + batch_size * n_per_positive
@@ -236,4 +235,4 @@ class TestAddRandomNegativesToBatch:
         assert model(features).shape[0] > batch_size
         assert model(features).shape[0] <= expected_batch_size
 
-        testing_utils.model_test(model, dataset)
+        testing_utils.model_test(model, loader)

--- a/tests/unit/tf/transforms/test_negative_sampling.py
+++ b/tests/unit/tf/transforms/test_negative_sampling.py
@@ -67,8 +67,7 @@ class TestAddRandomNegativesToBatch:
         )
         input_df = input_df[sorted(input_df.columns)]
         dataset = Dataset(input_df, schema=schema)
-        loader = mm.Loader(dataset, batch_size=10)
-        loader = loader.map(sampler)
+        loader = mm.Loader(dataset, batch_size=10, transform=sampler)
         first_batch_outputs = next(iter(loader))
 
         outputs = first_batch_outputs.outputs
@@ -210,8 +209,7 @@ class TestAddRandomNegativesToBatch:
         )
 
         batch_size, n_per_positive = 10, 5
-        loader = mm.Loader(music_streaming_data, batch_size=batch_size)
-        loader = loader.map(add_negatives)
+        loader = mm.Loader(music_streaming_data, batch_size=batch_size, transform=add_negatives)
 
         batch_output = next(iter(loader))
         features, targets = batch_output


### PR DESCRIPTION
Fixes #720

### Goals :soccer:
Introduce `Loader`. Introduce `ToTarget`.

### Implementation Details :construction:
- Rename `BatchedDataset` to `Loader`.
- Expose `Loader` in the user-facing API (i.e., `merlin/models/tf/__init__.py`)
- Add a `transform` parameter to `Loader`. This is meant to be an alternative to `Loader.map()` which is somewhat awkward to use.
- Adds a new `transform` op named `ToTarget`. More details in #720.

### Testing Details :mag:
- Changed unit tests that were using `Loader.map(func)` to use the new `Loader(..., transform=func)` interface.
- Added new unit tests for `ToTarget`.
