### PR TITLE
Bug when predicting with list-column

### DIFF
--- a/merlin/models/tf/utils/testing_utils.py
+++ b/merlin/models/tf/utils/testing_utils.py
@@ -88,7 +88,7 @@ def model_test(
     model.compile(run_eagerly=run_eagerly, optimizer=optimizer, **kwargs)
     losses = model.fit(dataset, batch_size=50, epochs=epochs, steps_per_epoch=1)
 
-    batch = sample_batch(dataset, batch_size=50)
+    batch = sample_batch(dataset, batch_size=50, to_ragged=reload_model)
 
     if reload_model:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/unit/tf/models/test_ranking.py
+++ b/tests/unit/tf/models/test_ranking.py
@@ -55,7 +55,7 @@ def test_dlrm_model(music_streaming_data, run_eagerly):
     )
 
     features = testing_utils.get_model_inputs(
-        music_streaming_data.schema.remove_by_tag(Tags.TARGET)
+        music_streaming_data.schema.remove_by_tag(Tags.TARGET), ["item_genres"]
     )
     testing_utils.test_model_signature(loaded_model, features, ["click/binary_classification_task"])
 

--- a/tests/unit/tf/models/test_ranking.py
+++ b/tests/unit/tf/models/test_ranking.py
@@ -41,7 +41,7 @@ def test_mf_model_single_binary_task(ecommerce_data, run_eagerly):
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_dlrm_model(music_streaming_data, run_eagerly):
     music_streaming_data.schema = music_streaming_data.schema.select_by_name(
-        ["item_id", "user_age", "click"]
+        ["item_id", "user_age", "click", "item_genres"]
     )
     model = mm.DLRMModel(
         music_streaming_data.schema,
@@ -50,7 +50,9 @@ def test_dlrm_model(music_streaming_data, run_eagerly):
         prediction_tasks=mm.BinaryClassificationTask("click"),
     )
 
-    loaded_model, _ = testing_utils.model_test(model, music_streaming_data, run_eagerly=run_eagerly)
+    loaded_model, _ = testing_utils.model_test(
+        model, music_streaming_data, run_eagerly=run_eagerly, reload_model=True
+    )
 
     features = testing_utils.get_model_inputs(
         music_streaming_data.schema.remove_by_tag(Tags.TARGET)


### PR DESCRIPTION
### Goals :soccer:
Right now calling `model.predict` with a batch of data fails when the list-columns are not represented as ragged-tensors. This PR makes sure we use the ragged-tensor representation in `model_test` when `reload_model=True`