### PR TITLE
Add test for `TwoTowerModel` with `InputBlockV2` and `Embeddings`

### DIFF
--- a/merlin/models/tf/inputs/base.py
+++ b/merlin/models/tf/inputs/base.py
@@ -315,4 +315,6 @@ def InputBlockV2(
         pre=pre,
         post=post,
         aggregation=aggregation,
+        is_input=True,
+        schema=schema,
     )


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Supports #747 

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

- Support usage of `InputBlockV2` with `TwoTowerModel`

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

- Setting `is_input=True` in ParallelBlock of `InputBlockV2`
  The `TwoTowerModel` relies on the `is_input` attribute to figure out if the SequentialBlock contains and Input block as the first layer..
- Passing the `schema` through to the `ParallelBlock` of `InputBlockV2` for the `TowerBlock/ModelBlock` to work correctly.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

- Adds a test for the `TwoTowerModel` with an `InputBlockV2` and `Embeddings` as part of the towers