### PR TITLE
Introducing RetrievalModelV2 to unify two-tower & session-based enhancement

### DIFF
--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -75,7 +75,7 @@ from merlin.models.tf.core.combinators import (
     ResidualBlock,
     SequentialBlock,
 )
-from merlin.models.tf.core.encoder import EncoderBlock, TopKEncoder
+from merlin.models.tf.core.encoder import EmbeddingEncoder, Encoder, TopKEncoder
 from merlin.models.tf.inputs.base import InputBlock, InputBlockV2
 from merlin.models.tf.inputs.continuous import Continuous, ContinuousFeatures, ContinuousProjection
 from merlin.models.tf.inputs.embedding import (
@@ -100,7 +100,7 @@ from merlin.models.tf.metrics.topk import (
     TopKMetricsAggregator,
 )
 from merlin.models.tf.models import benchmark
-from merlin.models.tf.models.base import BaseModel, Model, RetrievalModel
+from merlin.models.tf.models.base import BaseModel, Model, RetrievalModel, RetrievalModelV2
 from merlin.models.tf.models.ranking import DCNModel, DeepFMModel, DLRMModel, WideAndDeepModel
 from merlin.models.tf.models.retrieval import (
     MatrixFactorizationModel,
@@ -179,8 +179,9 @@ __all__ = [
     "SequentialBlock",
     "ResidualBlock",
     "DualEncoderBlock",
-    "EncoderBlock",
     "TopKEncoder",
+    "Encoder",
+    "EmbeddingEncoder",
     "CrossBlock",
     "DLRMBlock",
     "MLPBlock",
@@ -251,6 +252,7 @@ __all__ = [
     "TopKMetricsAggregator",
     "Model",
     "RetrievalModel",
+    "RetrievalModelV2",
     "InputBlock",
     "InputBlockV2",
     "PredictionTasks",

--- a/merlin/models/tf/core/encoder.py
+++ b/merlin/models/tf/core/encoder.py
@@ -454,5 +454,5 @@ class EmbeddingEncoder(Encoder):
 
         super().__init__(table, tf.keras.layers.Lambda(lambda x: x[col_name]))
 
-    def to_dataset(self, gpu=True) -> merlin.io.Dataset:
+    def to_dataset(self, gpu=None) -> merlin.io.Dataset:
         return self.blocks[0].to_dataset(gpu=gpu)

--- a/merlin/models/tf/core/encoder.py
+++ b/merlin/models/tf/core/encoder.py
@@ -434,6 +434,8 @@ class EmbeddingEncoder(Encoder):
             col = schema
         else:
             col = schema.first
+        col_name = col.name
+
         table = EmbeddingTable(
             dim,
             col,
@@ -450,7 +452,7 @@ class EmbeddingEncoder(Encoder):
             dynamic=dynamic,
         )
 
-        super().__init__(table, tf.keras.layers.Lambda(lambda x: x[col.name]))
+        super().__init__(table, tf.keras.layers.Lambda(lambda x: x[col_name]))
 
     def to_dataset(self, gpu=True) -> merlin.io.Dataset:
         return self.blocks[0].to_dataset(gpu=gpu)

--- a/merlin/models/tf/core/encoder.py
+++ b/merlin/models/tf/core/encoder.py
@@ -8,9 +8,9 @@ import merlin.io
 from merlin.models.tf.core import combinators
 from merlin.models.tf.core.prediction import TopKPrediction
 from merlin.models.tf.inputs.base import InputBlockV2
+from merlin.models.tf.inputs.embedding import CombinerType, EmbeddingTable
 from merlin.models.tf.models.base import BaseModel
 from merlin.models.tf.outputs.topk import TopKOutput
-from merlin.models.tf.inputs.embedding import CombinerType, EmbeddingTable
 from merlin.models.tf.utils import tf_utils
 from merlin.schema import ColumnSchema, Schema, Tags
 

--- a/merlin/models/tf/core/index.py
+++ b/merlin/models/tf/core/index.py
@@ -23,7 +23,6 @@ import merlin.io
 from merlin.core.dispatch import DataFrameType
 from merlin.models.tf.core.base import Block, PredictionOutput
 from merlin.models.tf.utils import tf_utils
-from merlin.models.tf.utils.batch_utils import TFModelEncode
 from merlin.models.utils.constants import MIN_FLOAT
 from merlin.schema import Tags
 
@@ -104,6 +103,8 @@ class IndexBlock(Block):
     def get_candidates_dataset(
         cls, block: Block, data: merlin.io.Dataset, id_column: Optional[str] = None
     ):
+        from merlin.models.tf.utils.batch_utils import TFModelEncode
+
         if not id_column and getattr(block, "schema", None):
             tagged = block.schema.select_by_tag(Tags.ITEM_ID)
             if tagged.column_schemas:

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -340,10 +340,10 @@ class EmbeddingTable(EmbeddingTableBase):
             data, trainable=trainable, name=name, col_schema=col_schema, **kwargs
         )
 
-    def to_dataset(self, gpu=True) -> merlin.io.Dataset:
+    def to_dataset(self, gpu=None) -> merlin.io.Dataset:
         return merlin.io.Dataset(self.to_df(gpu=gpu))
 
-    def to_df(self, gpu=True):
+    def to_df(self, gpu=None):
         return tensor_to_df(self.table.embeddings, gpu=gpu)
 
     def _maybe_build(self, inputs):

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -16,7 +16,6 @@ from tensorflow.keras.utils import unpack_x_y_sample_weight
 import merlin.io
 from merlin.models.tf.core.base import Block, ModelContext, PredictionOutput, is_input_block
 from merlin.models.tf.core.combinators import ParallelBlock, SequentialBlock
-from merlin.models.tf.core.encoder import Encoder
 from merlin.models.tf.core.prediction import Prediction, PredictionContext
 from merlin.models.tf.core.tabular import TabularBlock
 from merlin.models.tf.inputs.base import InputBlock
@@ -39,6 +38,7 @@ from merlin.models.utils.dataset import unique_rows_by_features
 from merlin.schema import ColumnSchema, Schema, Tags
 
 if TYPE_CHECKING:
+    from merlin.models.tf.core.encoder import Encoder
     from merlin.models.tf.core.index import TopKIndexBlock
 
 
@@ -1502,6 +1502,9 @@ class RetrievalModelV2(Model):
 
     def _check_encoder(self, maybe_encoder):
         output = maybe_encoder
+
+        from merlin.models.tf.core.encoder import Encoder
+
         if isinstance(output, SequentialBlock):
             output = Encoder(*maybe_encoder.layers)
 

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -1491,9 +1491,10 @@ class RetrievalModelV2(Model):
 
     @property
     def candidate_encoder(self) -> Encoder:
-        output = self.encoder
+        output = None
         if self.has_candidate_encoder:
             output = self.encoder[self._candidate_name]
+
         if output:
             return self._check_encoder(output)
 

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -1441,7 +1441,7 @@ class RetrievalModelV2(Model):
             return query.encode(dataset, id_col=id_col, **kwargs)
 
         if hasattr(query, "to_dataset"):
-            return query.to_dataset()
+            return query.to_dataset(**kwargs)
 
         return query.encode(dataset, id_col=id_col, **kwargs)
 
@@ -1458,7 +1458,7 @@ class RetrievalModelV2(Model):
                 return candidate.encode(dataset, id_col=id_col, **kwargs)
 
             if hasattr(candidate, "to_dataset"):
-                return candidate.to_dataset()
+                return candidate.to_dataset(**kwargs)
 
             return candidate.encode(dataset, id_col=id_col, **kwargs)
 

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -1432,35 +1432,35 @@ class RetrievalModelV2(Model):
     def query_embeddings(
         self,
         dataset: Optional[merlin.io.Dataset] = None,
-        id_col: Optional[Union[str, ColumnSchema, Schema, Tags]] = None,
+        index: Optional[Union[str, ColumnSchema, Schema, Tags]] = None,
         **kwargs,
     ) -> merlin.io.Dataset:
         query = self.query_encoder if self.has_candidate_encoder else self.encoder
 
         if dataset is not None and hasattr(query, "encode"):
-            return query.encode(dataset, id_col=id_col, **kwargs)
+            return query.encode(dataset, index=index, **kwargs)
 
         if hasattr(query, "to_dataset"):
             return query.to_dataset(**kwargs)
 
-        return query.encode(dataset, id_col=id_col, **kwargs)
+        return query.encode(dataset, index=index, **kwargs)
 
     def candidate_embeddings(
         self,
         dataset: Optional[merlin.io.Dataset] = None,
-        id_col: Optional[Union[str, ColumnSchema, Schema, Tags]] = None,
+        index: Optional[Union[str, ColumnSchema, Schema, Tags]] = None,
         **kwargs,
     ) -> merlin.io.Dataset:
         if self.has_candidate_encoder:
             candidate = self.candidate_encoder
 
             if dataset is not None and hasattr(candidate, "encode"):
-                return candidate.encode(dataset, id_col=id_col, **kwargs)
+                return candidate.encode(dataset, index=index, **kwargs)
 
             if hasattr(candidate, "to_dataset"):
                 return candidate.to_dataset(**kwargs)
 
-            return candidate.encode(dataset, id_col=id_col, **kwargs)
+            return candidate.encode(dataset, index=index, **kwargs)
 
         if isinstance(self.last, ContrastiveOutput):
             return self.last.to_dataset()

--- a/merlin/models/tf/outputs/classification.py
+++ b/merlin/models/tf/outputs/classification.py
@@ -292,13 +292,6 @@ class CategoricalTarget(tf.keras.layers.Dense):
     def embeddings(self):
         return tf.transpose(self.kernel)
 
-    @classmethod
-    def from_config(cls, config, custom_objects=None):
-        output = tf.keras.layers.Dense.from_config(config, custom_objects=custom_objects)
-        output.__class__ = cls
-
-        return output
-
 
 @tf.keras.utils.register_keras_serializable(package="merlin.models")
 class EmbeddingTablePrediction(Layer):

--- a/merlin/models/tf/outputs/contrastive.py
+++ b/merlin/models/tf/outputs/contrastive.py
@@ -293,7 +293,7 @@ class ContrastiveOutput(ModelOutput):
     def embedding_lookup(self, ids: tf.Tensor):
         return self.to_call.embedding_lookup(tf.squeeze(ids))
 
-    def to_dataset(self, gpu=True) -> merlin.io.Dataset:
+    def to_dataset(self, gpu=None) -> merlin.io.Dataset:
         return merlin.io.Dataset(tf_utils.tensor_to_df(self.to_call.embeddings, gpu=gpu))
 
     @property

--- a/merlin/models/tf/outputs/contrastive.py
+++ b/merlin/models/tf/outputs/contrastive.py
@@ -19,6 +19,7 @@ from typing import List, Optional, Protocol, Union, runtime_checkable
 import tensorflow as tf
 from tensorflow.keras.layers import Layer
 
+import merlin.io
 from merlin.models.tf.core.prediction import Prediction
 from merlin.models.tf.inputs.embedding import EmbeddingTable
 from merlin.models.tf.outputs.base import DotProduct, MetricsFn, ModelOutput
@@ -292,6 +293,9 @@ class ContrastiveOutput(ModelOutput):
     def embedding_lookup(self, ids: tf.Tensor):
         return self.to_call.embedding_lookup(tf.squeeze(ids))
 
+    def to_dataset(self, gpu=True) -> merlin.io.Dataset:
+        return merlin.io.Dataset(tf_utils.tensor_to_df(self.to_call.embeddings, gpu=gpu))
+
     @property
     def has_candidate_weights(self) -> bool:
         if isinstance(self.to_call, DotProduct):
@@ -337,6 +341,10 @@ class ContrastiveOutput(ModelOutput):
 @runtime_checkable
 class LookUpProtocol(Protocol):
     """Protocol for embedding lookup layers"""
+
+    @property
+    def embeddings(self):
+        pass
 
     def embedding_lookup(self, inputs, **kwargs):
         pass

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -275,11 +275,17 @@ def df_to_tensor(gdf, dtype=None):
     return x
 
 
-def tensor_to_df(tensor, gpu=True):
-    if gpu:
-        import cudf
-        import cupy
+def tensor_to_df(tensor, gpu=None):
+    if gpu is None:
+        try:
+            import cudf  # noqa: F401
+            import cupy
 
+            gpu = True
+        except ImportError:
+            gpu = False
+
+    if gpu:
         # Note: It is not possible to convert Tensorflow tensors to the cudf dataframe
         # directly using dlPack (as the example commented below) because cudf.from_dlpack()
         # expects the 2D tensor to be in Fortran order (column-major), which is not

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -275,7 +275,7 @@ def df_to_tensor(gdf, dtype=None):
     return x
 
 
-def tensor_to_df(tensor, gpu=None):
+def tensor_to_df(tensor, index=None, gpu=None):
     if gpu is None:
         try:
             import cudf  # noqa: F401
@@ -294,13 +294,17 @@ def tensor_to_df(tensor, gpu=None):
         tensor_cupy = cupy.fromDlpack(to_dlpack(tf.convert_to_tensor(tensor)))
         df = cudf.DataFrame(tensor_cupy)
         df.columns = [str(col) for col in list(df.columns)]
-        df.set_index(cudf.RangeIndex(0, tensor.shape[0]))
+        if not index:
+            index = cudf.RangeIndex(0, tensor.shape[0])
+        df.set_index(index)
     else:
         import pandas as pd
 
         df = pd.DataFrame(tensor.numpy())
         df.columns = [str(col) for col in list(df.columns)]
-        df.set_index(pd.RangeIndex(0, tensor.shape[0]))
+        if not index:
+            index = pd.RangeIndex(0, tensor.shape[0])
+        df.set_index(index)
 
     return df
 

--- a/tests/unit/tf/core/test_encoder.py
+++ b/tests/unit/tf/core/test_encoder.py
@@ -15,9 +15,9 @@ def test_encoder_block(music_streaming_data: Dataset):
 
     schema = music_streaming_data.schema
     user_schema = schema.select_by_name(["user_id", "user_genres"])
-    user_encoder = mm.EncoderBlock(user_schema, mm.MLPBlock([4]), name="query")
+    user_encoder = mm.Encoder(user_schema, mm.MLPBlock([4]), name="query")
     item_schema = schema.select_by_name(["item_id"])
-    item_encoder = mm.EncoderBlock(item_schema, mm.MLPBlock([4]), name="candidate")
+    item_encoder = mm.Encoder(item_schema, mm.MLPBlock([4]), name="candidate")
 
     model = mm.Model(
         mm.ParallelBlock(user_encoder, item_encoder),
@@ -27,7 +27,7 @@ def test_encoder_block(music_streaming_data: Dataset):
     assert model.blocks[0]["query"] == user_encoder
     assert model.blocks[0]["candidate"] == item_encoder
 
-    testing_utils.model_test(model, music_streaming_data)
+    testing_utils.model_test(model, music_streaming_data, reload_model=True)
 
     with pytest.raises(Exception) as excinfo:
         user_encoder.compile("adam")

--- a/tests/unit/tf/core/test_encoder.py
+++ b/tests/unit/tf/core/test_encoder.py
@@ -111,6 +111,7 @@ def test_topk_encoder(music_streaming_data: Dataset):
         topk_encoder.save(tmpdir)
         loaded_topk_encoder = tf.keras.models.load_model(tmpdir)
     batch_output = loaded_topk_encoder(batch[0])
+
     assert list(batch_output.scores.shape) == [32, TOP_K]
     tf.debugging.assert_equal(
         topk_encoder.topk_layer._candidates,

--- a/tests/unit/tf/core/test_encoder.py
+++ b/tests/unit/tf/core/test_encoder.py
@@ -53,9 +53,9 @@ def test_topk_encoder(music_streaming_data: Dataset):
     # 1. Train a retrieval model
     schema = music_streaming_data.schema
     user_schema = schema.select_by_name(["user_id", "country", "user_age"])
-    user_encoder = mm.EncoderBlock(user_schema, mm.MLPBlock([4]), name="query")
+    user_encoder = mm.Encoder(user_schema, mm.MLPBlock([4]), name="query")
     item_schema = schema.select_by_name(["item_id"])
-    item_encoder = mm.EncoderBlock(item_schema, mm.MLPBlock([4]), name="candidate")
+    item_encoder = mm.Encoder(item_schema, mm.MLPBlock([4]), name="candidate")
     retrieval_model = mm.Model(
         mm.ParallelBlock(user_encoder, item_encoder),
         mm.ContrastiveOutput(item_schema, "in-batch"),

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -673,6 +673,13 @@ def test_unfreeze_all_blocks(ecommerce_data):
 
 
 def test_retrieval_model_query(ecommerce_data: Dataset, run_eagerly=True):
+    try:
+        import cudf  # noqa: F401
+
+        gpu = True
+    except ImportError:
+        gpu = False
+
     query = ecommerce_data.schema.select_by_tag(Tags.USER_ID)
     candidate = ecommerce_data.schema.select_by_tag(Tags.ITEM_ID)
 
@@ -693,10 +700,10 @@ def test_retrieval_model_query(ecommerce_data: Dataset, run_eagerly=True):
     assert isinstance(model.query_encoder, mm.EmbeddingEncoder)
     assert isinstance(model.candidate_encoder, mm.EmbeddingEncoder)
 
-    queries = model.query_embeddings(gpu=False)
+    queries = model.query_embeddings(gpu=gpu)
     assert isinstance(queries, merlin.io.Dataset)
 
-    candidates = model.candidate_embeddings(gpu=False)
+    candidates = model.candidate_embeddings(gpu=gpu)
     assert isinstance(candidates, merlin.io.Dataset)
 
 

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -673,13 +673,6 @@ def test_unfreeze_all_blocks(ecommerce_data):
 
 
 def test_retrieval_model_query(ecommerce_data: Dataset, run_eagerly=True):
-    try:
-        import cudf  # noqa: F401
-
-        gpu = True
-    except ImportError:
-        gpu = False
-
     query = ecommerce_data.schema.select_by_tag(Tags.USER_ID)
     candidate = ecommerce_data.schema.select_by_tag(Tags.ITEM_ID)
 
@@ -700,10 +693,10 @@ def test_retrieval_model_query(ecommerce_data: Dataset, run_eagerly=True):
     assert isinstance(model.query_encoder, mm.EmbeddingEncoder)
     assert isinstance(model.candidate_encoder, mm.EmbeddingEncoder)
 
-    queries = model.query_embeddings(gpu=gpu)
+    queries = model.query_embeddings()
     assert isinstance(queries, merlin.io.Dataset)
 
-    candidates = model.candidate_embeddings(gpu=gpu)
+    candidates = model.candidate_embeddings()
     assert isinstance(candidates, merlin.io.Dataset)
 
 

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -690,7 +690,7 @@ def test_retrieval_model_query(ecommerce_data: Dataset, run_eagerly=True):
     model, _ = testing_utils.model_test(model, loader, reload_model=True, run_eagerly=run_eagerly)
 
     assert isinstance(model.query_encoder, mm.EmbeddingEncoder)
-    assert isinstance(model.candidate_encoder, mm.EmbeddingEncoder)
+    assert isinstance(model.last, mm.ContrastiveOutput)
 
     queries = model.query_embeddings().compute()
     _check_embeddings(queries, 1001)

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -688,7 +688,7 @@ def test_retrieval_model_query(ecommerce_data: Dataset, run_eagerly=True):
         output=mm.ContrastiveOutput(candidate, "in-batch"),
     )
 
-    model, _ = testing_utils.model_test(model, loader)
+    model, _ = testing_utils.model_test(model, loader, reload_model=True, run_eagerly=run_eagerly)
 
     assert isinstance(model.query_encoder, mm.EmbeddingEncoder)
     assert isinstance(model.candidate_encoder, mm.EmbeddingEncoder)


### PR DESCRIPTION
### Fixes
- #729

### Goals :soccer:
Introduce a new `RetrievalModelV2` that works for mf/two-tower as well as YouTube-dnn + session-based.

![CleanShot 2022-10-05 at 12 59 13](https://user-images.githubusercontent.com/3015785/194045277-b1a560a7-13a9-46b4-8ef1-b22a05a88e39.png)

### Implementation Details :construction:

Using the `RetrievalModelV2` to create:

#### MF
```python
user = schema.select_by_tag(Tags.USER_ID)
item = schema.select_by_tag(Tags.ITEM_ID)
model = mm.RetrievalModelV2(
        query=mm.EmbeddingEncoder(user, dim=8),
        candidate=mm.EmbeddingEncoder(item, dim=8),
        output=mm.ContrastiveOutput(candidate, "in-batch"),
 )
```

#### Two-tower
```python
user = schema.select_by_tag(Tags.USER)
item = schema.select_by_tag(Tags.ITEM)
model = mm.RetrievalModelV2(
        query=mm.Encoder(user, dim=8),
        candidate=mm.Encoder(item, dim=8),
        output=mm.ContrastiveOutput(item, "in-batch"),
 )
```


#### Session-based style
```python
user = schema.select_by_tag(Tags.USER)
item = schema.select_by_tag(Tags.ITEM_ID)
model = mm.RetrievalModelV2(
        query=mm.EmbeddingEncoder(user, dim=8),
        output=mm.ContrastiveOutput(item, "in-batch"),
)
```
