### PR TITLE
Revert "XGBoost - Use DaskDMatrix for evals data to ensure metrics in logs match result of evaluate"

### DIFF
--- a/merlin/models/xgb/__init__.py
+++ b/merlin/models/xgb/__init__.py
@@ -171,10 +171,7 @@ class XGBoost:
                 self.target_columns,
                 self.qid_column,
             )
-            # using the quantile DMatrix as part of evals results in a
-            # discrepancy between metrics reported in logs and result
-            # of evaluate
-            d_eval = xgb.dask.DaskDMatrix(self.dask_client, X, label=y, qid=qid)
+            d_eval = dmatrix_cls(self.dask_client, X, label=y, qid=qid)
             watchlist.append((d_eval, name))
 
         train_res = xgb.dask.train(


### PR DESCRIPTION
Reverts NVIDIA-Merlin/models#682

We're getting an error in our container builds from `test_gpu_hist_dmatrix`. 

I don't know for sure if this PR caused it and don't have an explanation for how this change relates to the error, but based on the timing it could be. And can't think of any other things to try to fix it for now apart from reverting this change. 

```
tests/unit/xgb/test_xgboost.py ........FF..........                      [100%]

=================================== FAILURES ===================================
_________ test_gpu_hist_dmatrix[fit_kwargs0-DaskDeviceQuantileDMatrix] _________

mock_train = <MagicMock name='train' id='140317824645680'>, fit_kwargs = {}
expected_dtrain_cls = <class 'xgboost.dask.DaskDeviceQuantileDMatrix'>
dask_client = <Client: 'tcp://127.0.0.1:39981' processes=5 threads=10, memory=20.00 GiB>

    @pytest.mark.skipif(not HAS_GPU, reason="No GPU available")
    @pytest.mark.parametrize(
        ["fit_kwargs", "expected_dtrain_cls"],
        [
            ({}, xgboost.dask.DaskDeviceQuantileDMatrix),
            ({"use_quantile": False}, xgboost.dask.DaskDMatrix),
        ],
    )
    @patch("xgboost.dask.train", side_effect=xgboost.dask.train)
    def test_gpu_hist_dmatrix(mock_train, fit_kwargs, expected_dtrain_cls, dask_client):
        train, valid = generate_data("music-streaming", num_rows=100, set_sizes=(0.5, 0.5))
        schema = train.schema
        model = XGBoost(schema, objective="reg:logistic", tree_method="gpu_hist")
>       model.fit(train, evals=[(valid, "valid")], **fit_kwargs)

tests/unit/xgb/test_xgboost.py:128: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
merlin/models/xgb/__init__.py:180: in fit
    train_res = xgb.dask.train(
/usr/lib/python3.8/unittest/mock.py:1081: in __call__
    return self._mock_call(*args, **kwargs)
/usr/lib/python3.8/unittest/mock.py:1085: in _mock_call
    return self._execute_mock_call(*args, **kwargs)
/usr/lib/python3.8/unittest/mock.py:1146: in _execute_mock_call
    result = effect(*args, **kwargs)
/usr/local/lib/python3.8/dist-packages/xgboost/core.py:575: in inner_f
    return f(**kwargs)
/usr/local/lib/python3.8/dist-packages/xgboost/dask.py:1072: in train
    return client.sync(
/usr/local/lib/python3.8/dist-packages/distributed/utils.py:320: in sync
    return sync(
/usr/local/lib/python3.8/dist-packages/distributed/utils.py:387: in sync
    raise exc.with_traceback(tb)
/usr/local/lib/python3.8/dist-packages/distributed/utils.py:360: in f
    result = yield future
/usr/local/lib/python3.8/dist-packages/tornado/gen.py:769: in run
    value = future.result()
/usr/local/lib/python3.8/dist-packages/xgboost/dask.py:1010: in _train_async
    results = await map_worker_partitions(
/usr/local/lib/python3.8/dist-packages/xgboost/dask.py:570: in map_worker_partitions
    results = await client.gather(futures)
/usr/local/lib/python3.8/dist-packages/distributed/client.py:2051: in _gather
    raise exception.with_traceback(traceback)
/usr/local/lib/python3.8/dist-packages/xgboost/dask.py:968: in dispatched_train
    Xy = _dmatrix_from_list_of_parts(**train_ref, nthread=n_threads)
/usr/local/lib/python3.8/dist-packages/xgboost/dask.py:844: in _dmatrix_from_list_of_parts
    return _create_device_quantile_dmatrix(**kwargs)
/usr/local/lib/python3.8/dist-packages/xgboost/dask.py:773: in _create_device_quantile_dmatrix
    dmatrix = DeviceQuantileDMatrix(
/usr/local/lib/python3.8/dist-packages/xgboost/core.py:575: in inner_f
    return f(**kwargs)
/usr/local/lib/python3.8/dist-packages/xgboost/core.py:1270: in __init__
    self._init(
/usr/local/lib/python3.8/dist-packages/xgboost/core.py:1321: in _init
    _check_call(ret)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   raise XGBoostError(py_str(_LIB.XGBGetLastError()))
E   xgboost.core.XGBoostError: [11:34:22] ../src/common/device_helpers.cu:64: Check failed: n_uniques == world (1 vs. 2) : Multiple processes within communication group running on same CUDA device is not supported. 9dd69c102a96b338cb25ff8c2e3cd3c3
E   
E   Stack trace:
E     [bt] (0) /usr/local/lib/python3.8/dist-packages/xgboost/lib/libxgboost.so(+0x3afb3d) [0x7f61724abb3d]
E     [bt] (1) /usr/local/lib/python3.8/dist-packages/xgboost/lib/libxgboost.so(+0x3b08f4) [0x7f61724ac8f4]
E     [bt] (2) /usr/local/lib/python3.8/dist-packages/xgboost/lib/libxgboost.so(+0x40c90b) [0x7f617250890b]
E     [bt] (3) /usr/local/lib/python3.8/dist-packages/xgboost/lib/libxgboost.so(+0x40d3ae) [0x7f61725093ae]
E     [bt] (4) /usr/local/lib/python3.8/dist-packages/xgboost/lib/libxgboost.so(+0x43db0b) [0x7f6172539b0b]
E     [bt] (5) /usr/local/lib/python3.8/dist-packages/xgboost/lib/libxgboost.so(+0x18d5ac) [0x7f61722895ac]
E     [bt] (6) /usr/local/lib/python3.8/dist-packages/xgboost/lib/libxgboost.so(XGDeviceQuantileDMatrixCreateFromCallback+0x5a) [0x7f61721c35ba]
E     [bt] (7) /usr/lib/x86_64-linux-gnu/libffi.so.7(+0x6ff5) [0x7f61dcba0ff5]
E     [bt] (8) /usr/lib/x86_64-linux-gnu/libffi.so.7(+0x640a) [0x7f61dcba040a]

/usr/local/lib/python3.8/dist-packages/xgboost/core.py:246: XGBoostError
----------------------------- Captured stderr call -----------------------------
[11:34:22] task [xgboost.dask-1]:tcp://127.0.0.1:41609 got new rank 0
[11:34:22] task [xgboost.dask-4]:tcp://127.0.0.1:45619 got new rank 1
worker tcp://127.0.0.1:41609 has an empty DMatrix.
2022-09-22 11:34:22,472 - distributed.worker - WARNING - Compute Failed
Key:       dispatched_train-3258b644-920c-40c8-9bc1-2bf5f14bec1e
Function:  dispatched_train
args:      ({'tree_method': 'gpu_hist', 'objective': 'reg:logistic'}, [b'DMLC_NUM_WORKER=2', b'DMLC_TRACKER_URI=10.233.68.27', b'DMLC_TRACKER_PORT=47447', b'DMLC_TASK_ID=[xgboost.dask-4]:tcp://127.0.0.1:45619'], 140317825248944, ['valid'], [140315560976976], {'feature_names': None, 'feature_types': None, 'feature_weights': None, 'missing': None, 'enable_categorical': False, 'parts': [{'data':     session_id  item_id  item_category  ...  country  user_age  position
0            5        1              1  ...       19        10        80
1           18        5              2  ...       25        13        51
2           31       15              7  ...       10         5        30
3           15       15              7  ...       13         7        92
4           57      141             67  ...        3         2        50
5          128       21             10  ...        7         4         5
6           48       23             11  ...        7         4        59
7           73       17        
kwargs:    {}
Exception: "XGBoostError('[11:34:22] ../src/common/device_helpers.cu:64: Check failed: n_uniques == world (1 vs. 2) : Multiple processes within communication group running on same CUDA device is not supported. 9dd69c102a96b338cb25ff8c2e3cd3c3\\n\\nStack trace:\\n  [bt] (0) /usr/local/lib/python3.8/dist-packages/xgboost/lib/libxgboost.so(+0x3afb3d) [0x7f61724abb3d]\\n  [bt] (1) /usr/local/lib/python3.8/dist-packages/xgboost/lib/libxgboost.so(+0x3b08f4) [0x7f61724ac8f4]\\n  [bt] (2) /usr/local/lib/python3.8/dist-packages/xgboost/lib/libxgboost.so(+0x40c90b) [0x7f617250890b]\\n  [bt] (3) /usr/local/lib/python3.8/dist-packages/xgboost/lib/libxgboost.so(+0x40d3ae) [0x7f61725093ae]\\n  [bt] (4) /usr/local/lib/python3.8/dist-packages/xgboost/lib/libxgboost.so(+0x43db0b) [0x7f6172539b0b]\\n  [bt] (5) /usr/local/lib/python3.8/dist-packages/xgboost/lib/libxgboost.so(+0x18d5ac) [0x7f61722895ac]\\n  [bt] (6) /usr/local/lib/python3.8/dist-packages/xgboost/lib/libxgboost.so(XGDeviceQuantileDMatrixCreateFromCallback+0x5a) [0x7f61721c35ba]\\n  [bt] (7) /usr/lib/x86_64-linux-gnu/libffi.so.7(+0x6ff5) [0x7f61dcba0ff5]\\n  [bt] (8) /usr/lib/x86_64-linux-gnu/libffi.so.7(+0x640a) [0x7f61dcba040a]\\n\\n')"
```