### PR TITLE
Remove `cluster_type` from `dask_client` test fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,7 @@ def testing_data() -> Dataset:
 
 @pytest.fixture(scope="module")
 def dask_client() -> distributed.Client:
-    with Distributed(cluster_type="cpu") as dist:
+    with Distributed() as dist:
         yield dist.client
 
 


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Removes `cluster_type` from `dask_client` test fixture.

This was initially set to be CPU only because the tests would not work in a CPU-only environment due to the way the cpu checks were working in the merlin core module (context [here](https://github.com/NVIDIA-Merlin/models/pull/466#discussion_r883895804) ).

This  is no longer required, and may be causing issues with the GPU version of the tests when  `tree_method="gpu_hist"` (see: #762)
