### PR TITLE
Adding transformers as backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ markers = [
     "lightfm",
     "implicit",
     "xgboost",
+    "transformers",
     "example",
     "integration",
     "unit",

--- a/requirements/transformers.txt
+++ b/requirements/transformers.txt
@@ -1,0 +1,1 @@
+transformers

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ def read_requirements(filename):
 _dev = read_requirements("requirements/dev.txt")
 _docs = read_requirements("requirements/docs.txt")
 _nvt = read_requirements("requirements/nvtabular.txt")
+_transformers = read_requirements("requirements/transformers.txt")
 
 requirements = {
     "base": read_requirements("requirements/base.txt"),
@@ -49,12 +50,13 @@ requirements = {
     "lightfm": read_requirements("requirements/lightfm.txt"),
     "implicit": read_requirements("requirements/implicit.txt"),
     "xgboost": read_requirements("requirements/xgboost.txt"),
+    "transformers": _transformers,
     "nvtabular": _nvt,
     "dev": _dev,
     "docs": _docs,
 }
 dev_requirements = {
-    "tensorflow-dev": requirements["tensorflow"] + _dev + _nvt,
+    "tensorflow-dev": requirements["tensorflow"] + _transformers + _dev + _nvt,
     "pytorch-dev": requirements["pytorch"] + _dev + _nvt,
     "implicit-dev": requirements["implicit"] + _dev + _nvt,
     "lightfm-dev": requirements["lightfm"] + _dev + _nvt,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,3 +104,5 @@ def pytest_collection_modifyitems(items):
             item.add_marker(pytest.mark.xgboost)
         if "/datasets/" in path:
             item.add_marker(pytest.mark.datasets)
+        if "/transformers/" in path:
+            item.add_marker(pytest.mark.transformers)

--- a/tests/unit/tf/transformers/__init__.py
+++ b/tests/unit/tf/transformers/__init__.py
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+
+pytest.importorskip("transformers")

--- a/tests/unit/tf/transformers/test_block.py
+++ b/tests/unit/tf/transformers/test_block.py
@@ -1,0 +1,4 @@
+def test_import():
+    import transformers
+
+    assert transformers is not None


### PR DESCRIPTION
### Goals :soccer:
This PR adds Huggingface transformers as a optional backend.

### Implementation Details :construction:
Also adds test-markers to give users the ability to only run the huggingface-related tests.