### PR TITLE
Add TensorFlow 2.10 to versions in test matrix

### DIFF
--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         python-version: [3.9.7]
         os: [ubuntu-latest]
-        tensorflow-version: ["~=2.8.0", "~=2.9.0"]
+        tensorflow-version: ["~=2.8.0", "~=2.9.0", "~=2.10.0"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Supports #746

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Test TensorFlow version 2.10 with our code to check compatibility

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

Adds TensorFlow `~=2.10.0` to our GitHub Actions workflow running on CPU

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Relying on existing tests for coverage.