### PR TITLE
Introduce TopKEncoder for retrieval

### DIFF
--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -75,7 +75,7 @@ from merlin.models.tf.core.combinators import (
     ResidualBlock,
     SequentialBlock,
 )
-from merlin.models.tf.core.encoder import EncoderBlock
+from merlin.models.tf.core.encoder import EncoderBlock, TopKEncoder
 from merlin.models.tf.inputs.base import InputBlock, InputBlockV2
 from merlin.models.tf.inputs.continuous import Continuous, ContinuousFeatures, ContinuousProjection
 from merlin.models.tf.inputs.embedding import (
@@ -114,6 +114,7 @@ from merlin.models.tf.outputs.regression import RegressionOutput
 from merlin.models.tf.outputs.sampling.base import Candidate, CandidateSampler
 from merlin.models.tf.outputs.sampling.in_batch import InBatchSamplerV2
 from merlin.models.tf.outputs.sampling.popularity import PopularityBasedSamplerV2
+from merlin.models.tf.outputs.topk import TopKOutput
 from merlin.models.tf.prediction_tasks.base import ParallelPredictionBlock, PredictionTask
 from merlin.models.tf.prediction_tasks.classification import (
     BinaryClassificationTask,
@@ -179,6 +180,7 @@ __all__ = [
     "ResidualBlock",
     "DualEncoderBlock",
     "EncoderBlock",
+    "TopKEncoder",
     "CrossBlock",
     "DLRMBlock",
     "MLPBlock",

--- a/merlin/models/tf/core/encoder.py
+++ b/merlin/models/tf/core/encoder.py
@@ -5,6 +5,7 @@ from packaging import version
 
 import merlin.io
 from merlin.models.tf.core import combinators
+from merlin.models.tf.core.prediction import TopKPrediction
 from merlin.models.tf.inputs.base import InputBlockV2
 from merlin.models.tf.models.base import BaseModel
 from merlin.models.tf.outputs.topk import TopKOutput
@@ -198,6 +199,7 @@ class TopKEncoder(EncoderBlock, BaseModel):
             topk_output = topk_layer
         else:
             topk_output = TopKOutput(to_call=topk_layer, candidates=candidates, k=k, **kwargs)
+        self.k = k
 
         EncoderBlock.__init__(self, query_encoder, topk_output, pre=pre, post=post, **kwargs)
         # The base model is required for the evaluation step:
@@ -315,7 +317,10 @@ class TopKEncoder(EncoderBlock, BaseModel):
         from merlin.models.tf.utils.batch_utils import TFModelEncode
 
         model_encode = TFModelEncode(
-            model=self, batch_size=batch_size, output_names=["top_scores", "top_ids"], **kwargs
+            model=self,
+            batch_size=batch_size,
+            output_names=TopKPrediction.output_names(self.k),
+            **kwargs,
         )
 
         dataset = dataset.to_ddf()

--- a/merlin/models/tf/core/encoder.py
+++ b/merlin/models/tf/core/encoder.py
@@ -145,3 +145,42 @@ class EncoderBlock(tf.keras.Model):
             config[i] = tf.keras.utils.serialize_keras_object(layer)
 
         return config
+
+
+@tf.keras.utils.register_keras_serializable(package="merlin.models")
+class TopKEncoder(EncoderBlock):
+    """Block that can be used for top-k prediction & evaluation from a trained
+    retrieval model
+
+    Parameters
+    ----------
+    inputs: Union[Schema, tf.keras.layers.Layer]
+        The input block or schema.
+        When a schema is provided, a default input block will be created.
+    *blocks: tf.keras.layers.Layer
+        The blocks to use for encoding.
+    pre: Optional[tf.keras.layers.Layer]
+        A block to use before the main blocks
+    post: Optional[tf.keras.layers.Layer]
+        A block to use after the main blocks
+    """
+
+    def __init__(
+        self,
+        query_encoder: tf.keras.layers.Layer,
+        strategy: Union[str, tf.keras.layers.Layer] = "brute-force-topk",
+        candidate_encoder: Optional[Union[tf.Tensor, tf.keras.layers.Layer]] = None,
+        pre: Optional[tf.keras.layers.Layer] = None,
+        post: Optional[tf.keras.layers.Layer] = None,
+        **kwargs,
+    ):
+        pass
+
+    @classmethod
+    def from_candidate_dataset(
+        cls,
+        query_encoder,
+        candidate_encoder,
+        canidates_dataset,
+    ):
+        pass

--- a/merlin/models/tf/core/encoder.py
+++ b/merlin/models/tf/core/encoder.py
@@ -152,8 +152,8 @@ class EncoderBlock(tf.keras.Model):
 
 @tf.keras.utils.register_keras_serializable(package="merlin.models")
 class TopKEncoder(EncoderBlock, BaseModel):
-    """Block that can be used for top-k prediction & evaluation from a trained
-    retrieval model
+    """Block that can be used for top-k prediction & evaluation, initialized
+    from a trained retrieval model
 
     Parameters
     ----------
@@ -173,9 +173,8 @@ class TopKEncoder(EncoderBlock, BaseModel):
         By default None
     candidate_encoder:  Union[EncoderBlock, tf.keras.layers.Layer],
         The layer to use for encoding the item features
-    k: int
-        The threshold to use for top-k retrieval
-        By default 10
+    k: int, Optional
+        Number of candidates to return, by default 10
     pre: Optional[tf.keras.layers.Layer]
         A block to use before encoding the input query
         By default None
@@ -207,39 +206,127 @@ class TopKEncoder(EncoderBlock, BaseModel):
     @classmethod
     def from_candidate_dataset(
         cls,
-        query_encoder,
-        canidates_features,
-        candidate_encoder,
-        k=10,
-        index: Optional[Union[str, ColumnSchema, Schema, Tags]] = None,
+        query_encoder: Union[EncoderBlock, tf.keras.layers.Layer],
+        candidate_encoder: Union[EncoderBlock, tf.keras.layers.Layer],
+        dataset: merlin.io.Dataset,
+        top_k: int = 10,
+        index_column: Optional[Union[str, ColumnSchema, Schema, Tags]] = None,
         **kwargs,
     ):
+        """Class method to initialize a TopKEncoder from a dataset of
+        raw candidates features.
+
+        Parameters
+        ----------
+        query_encoder : Union[EncoderBlock, tf.keras.layers.Layer]
+            The encoder layer to use for computing the query embeddings.
+        candidate_encoder : Union[EncoderBlock, tf.keras.layers.Layer]
+            The encoder layer to use for computing the candidates embeddings.
+        dataset : merlin.io.Dataset
+            Raw candidate features dataset
+        index_column : Union[str, ColumnSchema, Schema, Tags], optional
+            The column to use as candidates identifiers, this will be used
+            for returning the topk ids of candidates with the highest scores.
+            If not specified, the candidates indices will be used instead.
+            by default None
+        top_k : int, optional
+            Number of candidates to return, by default 10
+
+        Returns
+        -------
+        TopKEncoder
+            a `TopKEncoder` indexed by the pre-trained embeddings of the candidates
+            in the specified `dataset`
+        """
         # TODO: Add related unit-test after RetrievalModelV2 is merged
-        candidates = cls.encode_candidates(canidates_features, candidate_encoder)
-        topk_output = TopKOutput(to_call="topk_layer", candidate_dataset=candidates, k=k, **kwargs)
+        candidates = cls.encode_candidates(dataset, candidate_encoder)
+        topk_output = TopKOutput(
+            to_call="topk_layer", candidate_dataset=candidates, k=top_k, **kwargs
+        )
         return cls(query_encoder, topk_output, **kwargs)
+
+    @property
+    def topk_layer(self):
+        return self.blocks[-1].to_call
+
+    def index_candidates(self, candidates, identifiers=None):
+        self.topk_layer.index(candidates, identifiers=identifiers)
+        return self
 
     def encode_candidates(
         self,
-        candidates_features,
-        index: Optional[Union[str, ColumnSchema, Schema, Tags]] = None,
-        candidate_encoder=None,
+        dataset: merlin.io.Dataset,
+        index_column: Optional[Union[str, ColumnSchema, Schema, Tags]] = None,
+        candidate_encoder: Optional[Union[EncoderBlock, tf.keras.layers.Layer]] = None,
         **kwargs,
     ) -> merlin.io.Dataset:
+        """Method to generate candidates embeddings
+
+        Parameters
+        ----------
+        dataset : merlin.io.Dataset
+            Raw candidate features dataset
+        index_column  : Union[str, ColumnSchema, Schema, Tags], optional
+            The column to use as candidates identifiers, this will be used
+            for returning the topk ids of candidates with the highest scores.
+            If not specified, the candidates indices will be used instead.
+            by default None
+        candidate_encoder : Union[EncoderBlock, tf.keras.layers.Layer], optional
+            The encoder layer to use for computing the candidates embeddings.
+            If not specified, the candidate_encoder set in the class constructor
+            will be used instead.
+            by default None
+        Returns
+        -------
+        merlin.io.Dataset
+            A merlin dataset of candidates embeddings, indexed by index_column.
+        """
         # TODO: Add related unit-test after RetrievalModelV2 is merged
         if not candidate_encoder:
             candidate_encoder = self.candidate_encoder
         assert candidate_encoder is not None, ValueError(
             "You should provide a `candidate_encoder` to compute candidates embeddings"
         )
-        return candidate_encoder.encode(dataset=candidates_features, index=index, **kwargs)
+        return candidate_encoder.encode(dataset=dataset, index=index_column, **kwargs)
 
-    def index_candidates(self, candidates, identifiers=None):
-        self.blocks[-1].to_call.index(candidates, identifiers=identifiers)
-        return self
+    def batch_predict(
+        self,
+        dataset: merlin.io.Dataset,
+        batch_size: int,
+        output_schema: Optional[Schema] = None,
+        **kwargs,
+    ) -> merlin.io.Dataset:
+        """Batched top-k prediction using Dask.
 
-    def to_dataset(query_features):
-        raise NotImplementedError("TODO")
+        Parameters
+        ----------
+        dataset : merlin.io.Dataset
+            Raw queries features dataset
+        batch_size : int
+            The number of queries to process at each prediction step
+        output_schema: Schema, optional
+            The columns to output from the input dataset
+        Returns
+        -------
+        merlin.io.Dataset
+            A merlin dataset with the top-k predictions, the
+            candidates identifiers and related scores.
+        """
+        from merlin.models.tf.utils.batch_utils import TFModelEncode
+
+        model_encode = TFModelEncode(
+            model=self, batch_size=batch_size, output_names=["top_scores", "top_ids"], **kwargs
+        )
+
+        dataset = dataset.to_ddf()
+
+        encode_kwargs = {}
+        if output_schema:
+            encode_kwargs["filter_input_columns"] = output_schema.column_names
+
+        predictions = dataset.map_partitions(model_encode, **encode_kwargs)
+
+        return merlin.io.Dataset(predictions)
 
     def fit(self, *args, **kwargs):
         """Fit model"""

--- a/merlin/models/tf/core/encoder.py
+++ b/merlin/models/tf/core/encoder.py
@@ -273,7 +273,7 @@ class TopKEncoder(EncoderBlock, BaseModel):
             by default None
         candidate_encoder : Union[EncoderBlock, tf.keras.layers.Layer], optional
             The encoder layer to use for computing the candidates embeddings.
-            If not specified, the candidate_encoder set in the class constructor
+            If not specified, the candidate_encoder set in the constructor
             will be used instead.
             by default None
         Returns

--- a/merlin/models/tf/core/prediction.py
+++ b/merlin/models/tf/core/prediction.py
@@ -61,3 +61,8 @@ class Prediction(NamedTuple):
     @property
     def predictions(self):
         return self.outputs
+
+
+class TopKPrediction(NamedTuple):
+    scores: tf.Tensor
+    identifiers: tf.Tensor

--- a/merlin/models/tf/outputs/topk.py
+++ b/merlin/models/tf/outputs/topk.py
@@ -1,0 +1,233 @@
+from typing import Optional, Tuple, Union
+
+import tensorflow as tf
+from tensorflow.keras.layers import Layer
+
+import merlin.io
+from merlin.core.dispatch import DataFrameType
+from merlin.models.tf.blocks.core import Block, block_registry
+from merlin.models.tf.core.prediction import Prediction
+from merlin.models.tf.outputs.base import MetricsFn, ModelOutput
+from merlin.models.tf.outputs.classification import default_categorical_prediction_metrics
+from merlin.models.tf.utils import tf_utils
+from merlin.schema import Schema
+
+
+@tf.keras.utils.register_keras_serializable(package="merlin.models")
+class TopKLayer(Layer):
+    """Top-K index to retrieve top-k scores and indices from an item block.
+
+    Parameters:
+    -----------
+    k: int
+        The cut-off for top-k retrieval
+    """
+
+    def __init__(self, k: int, **kwargs) -> None:
+        """Initializes the base class."""
+        super().__init__(**kwargs)
+        self._k = k
+
+    def index(self, candidates: tf.Tensor, identifiers: Optional[tf.Tensor] = None) -> "TopKLayer":
+        """Set the index used for retrieving the top-k candidates.
+        When called multiple times the existing index will be dropped and a new one
+        created.
+        Parameters:
+        -----------
+            candidates: tensor of candidate embeddings.
+            identifiers: Optional tensor of candidate identifiers. If
+                given, these will be used as identifiers of top candidates returned
+                when performing searches. If not given, indices into the candidates
+                tensor will be returned instead.
+
+        """
+        raise NotImplementedError()
+
+    def index_from_dataset(
+        self, data: merlin.io.Dataset, check_unique_ids: bool = True
+    ) -> "TopKLayer":
+        """Builds the top-k retrieval index from a merlin dataset.
+        Parameters
+        ----------
+        data : merlin.io.Dataset
+            The dataset with the pre-trained item embeddings
+        check_unique_ids : bool, optional
+            Whether to check if `data` has unique indices, by default True
+        Returns
+        -------
+        TopKLayer
+            return the class with retrieval index
+        """
+        ids, values = self.extract_ids_embeddings(data, check_unique_ids)
+        return self.index(candidates=values, identifiers=ids)
+
+    @staticmethod
+    def _check_unique_ids(data: DataFrameType):
+        if data.index.to_series().nunique() != data.shape[0]:
+            raise ValueError("Please make sure that `data` contains unique indices")
+
+    def extract_ids_embeddings(self, data: merlin.io.Dataset, check_unique_ids: bool = True):
+        """Extract tensors of candidates and indices from the merlin dataset
+        Parameters
+        ----------
+        data : merlin.io.Dataset
+            The dataset with the pre-trained candidates embeddings,
+            indexed by the candidate's id column
+        check_unique_ids : bool, optional
+            Whether to check if `data` has unique indices, by default True
+        """
+        if hasattr(data, "to_ddf"):
+            data = data.to_ddf()
+        if check_unique_ids:
+            self._check_unique_ids(data=data)
+        values = tf_utils.df_to_tensor(data)
+        ids = tf_utils.df_to_tensor(data.index)
+
+        if len(ids.shape) == 2:
+            ids = tf.squeeze(ids)
+        return ids, values
+
+    def call(self, inputs: tf.Tensor, **kwargs) -> tf.Tensor:
+        """Method to return the tuple of top-k (ids, scores)"""
+        raise NotImplementedError()
+
+    def _score(self, queries: tf.Tensor, candidates: tf.Tensor) -> tf.Tensor:
+        """Computes the standard dot product score from queries and candidates."""
+        return tf.matmul(queries, candidates, transpose_b=True)
+
+
+@Block.registry.register("brute-force-topk")
+@tf.keras.utils.register_keras_serializable(package="merlin.models")
+class BruteForce(TopKLayer):
+    """Top-k layer that performs Brute force search over the candidates index."""
+
+    def __init__(self, k: int = 10, name: Optional[str] = None):
+        """Initializes the layer.
+
+        Parameters:
+        -----------
+        k: int
+            Default threshold for top-k retrieval. By default 10
+        name: Optional[str]
+            Name of the layer. By default None
+        """
+
+        super().__init__(k=k, name=name)
+
+    def index(self, candidates: tf.Tensor, identifiers: Optional[tf.Tensor]) -> "BruteForce":
+
+        self._ids = self.add_weight(
+            name="ids",
+            dtype=tf.int32,
+            shape=identifiers.shape,
+            initializer=tf.keras.initializers.Constant(value=tf.cast(identifiers, tf.int32)),
+            trainable=False,
+        )
+
+        self._candidates = self.add_weight(
+            name="candidates",
+            dtype=tf.float32,
+            shape=candidates.shape,
+            initializer=tf.keras.initializers.Zeros(),
+            trainable=False,
+        )
+
+        self._ids.assign(tf.cast(identifiers, tf.int32))
+        self._candidates.assign(tf.cast(candidates, tf.float32))
+        return self
+
+    def call(
+        self, inputs, targets=None, k=None, testing=False
+    ) -> Union[Prediction, Tuple[tf.Tensor, tf.Tensor]]:
+        """Compute the scores between the query inputs and all indexed candidates,
+        then retrieve the top-k candidates with the highest scores.
+
+        Parameters
+        ----------
+        inputs : tf.Tensor
+            The query embeddings representation
+        targets: tf.Tensor
+            The tensor of positive candidates
+        k : int, optional
+            The threshold for top-k retrieval, by default None
+        testing: bool
+        """
+        if not k:
+            k = self._k
+        scores = self._score(inputs, self._candidates)
+        top_scores, top_ids = tf.math.top_k(scores, k=k)
+        if testing:
+            assert targets is not None, ValueError(
+                "Targets should be provided during evaluation mode"
+            )
+            targets = tf.cast(tf.squeeze(targets), tf.int32)
+            targets = tf.cast(tf.expand_dims(targets, -1) == top_ids, tf.float32)
+            targets = tf.reshape(targets, tf.shape(top_scores))
+            return Prediction(top_scores, targets)
+        return top_scores, top_ids
+
+
+@tf.keras.utils.register_keras_serializable(package="merlin.models")
+class TopKOutput(ModelOutput):
+    """Prediction block for top-k evaluation
+    Parameters
+    ----------
+    to_call:  Union[str, tf.keras.layers.Layer, TopKLayer]
+       The top-k layer to use for retrieving top-k candidates ids and scores
+    item_dataset:  merlin.io.Dataset,
+        Dataset of the pretrained candidates embeddings to use for the top-k index.
+    target: Union[str, Schema], optional
+        The name of the target. If a Schema is provided, the target is inferred from the schema.
+    pre: Optional[Block], optional
+        Optional block to transform predictions before computing the binary logits,
+        by default None
+    post: Optional[Block], optional
+        Optional block to transform the binary logits,
+        by default None
+    name: str, optional
+        The name of the task.
+    logits_temperature: float, optional
+        Parameter used to reduce model overconfidence, so that logits / T.
+        by default 1.
+    default_loss: Union[str, tf.keras.losses.Loss], optional
+        Default loss to use for binary-classification
+        by 'categorical_crossentropy'
+    default_metrics_fn: Callable
+        A function returning the list of default metrics
+        to use for ranking evaluation
+    """
+
+    def __init__(
+        self,
+        to_call: Union[str, TopKLayer],
+        candidate_dataset: merlin.io.Dataset = None,
+        k: int = 10,
+        target: Optional[str, Schema] = None,
+        pre: Optional[Layer] = None,
+        post: Optional[Layer] = None,
+        logits_temperature: float = 1.0,
+        name: Optional[str] = None,
+        default_loss: Union[str, tf.keras.losses.Loss] = "categorical_crossentropy",
+        default_metrics_fn: MetricsFn = default_categorical_prediction_metrics,
+        **kwargs,
+    ):
+
+        if isinstance(to_call, str):
+            if candidate_dataset is None:
+                raise ValueError(
+                    "You should provide the dataset of pre-trained embeddings"
+                    " when `to_call` is the string name of the top-k strategy "
+                )
+                to_call = block_registry.parse(to_call).index_from_dataset(candidate_dataset)
+
+        super().__init__(
+            to_call=to_call,
+            default_loss=default_loss,
+            default_metrics_fn=default_metrics_fn,
+            name=name,
+            target=target,
+            pre=pre,
+            post=post,
+            logits_temperature=logits_temperature,
+            **kwargs,
+        )

--- a/merlin/models/tf/utils/batch_utils.py
+++ b/merlin/models/tf/utils/batch_utils.py
@@ -6,6 +6,7 @@ import tensorflow as tf
 
 from merlin.core.dispatch import DataFrameType, concat_columns, get_lib
 from merlin.models.tf.core.base import Block
+from merlin.models.tf.core.prediction import TopKPrediction
 from merlin.models.tf.loader import Loader
 from merlin.models.tf.models.base import Model, RetrievalModel
 from merlin.models.utils.schema_utils import select_targets
@@ -157,6 +158,15 @@ def model_encode(model, batch):
     if isinstance(model_outputs, dict):
         return get_lib().DataFrame({key: encode_output(val) for key, val in model_outputs.items()})
 
+    if isinstance(model_outputs, TopKPrediction):
+        return get_lib().DataFrame(
+            [
+                {
+                    "top_scores": encode_output(model_outputs.scores),
+                    "top_ids": encode_output(model_outputs.identifiers),
+                }
+            ]
+        )
     return encode_output(model_outputs)
 
 

--- a/tests/unit/tf/core/test_encoder.py
+++ b/tests/unit/tf/core/test_encoder.py
@@ -48,22 +48,25 @@ def test_topk_encoder(music_streaming_data: Dataset):
     TOP_K = 50
     NUM_CANDIDATES = 100
     music_streaming_data.schema = music_streaming_data.schema.select_by_name(
-        ["user_id", "item_id", "user_genres"]
+        ["user_id", "item_id", "country", "user_age"]
     )
 
+    # 1. Train a retrieval model
     schema = music_streaming_data.schema
-    user_schema = schema.select_by_name(["user_id", "user_genres"])
+    user_schema = schema.select_by_name(["user_id", "country", "user_age"])
     user_encoder = mm.EncoderBlock(user_schema, mm.MLPBlock([4]), name="query")
     item_schema = schema.select_by_name(["item_id"])
     item_encoder = mm.EncoderBlock(item_schema, mm.MLPBlock([4]), name="candidate")
-    model = mm.Model(
+    retrieval_model = mm.Model(
         mm.ParallelBlock(user_encoder, item_encoder),
         mm.ContrastiveOutput(item_schema, "in-batch"),
     )
-    testing_utils.model_test(model, music_streaming_data)
+    testing_utils.model_test(retrieval_model, music_streaming_data)
 
+    # 2. Get candidates embeddings for the top-k encoder
     _candidate_embeddings = tf.random.uniform(shape=(NUM_CANDIDATES, 4), dtype=tf.float32)
 
+    # 3. Set data-loader for top-k recommendation
     def _item_id_as_target(inputs, targets):
         targets = tf.squeeze(inputs["item_id"])
         return inputs, targets
@@ -71,15 +74,17 @@ def test_topk_encoder(music_streaming_data: Dataset):
     loader = mm.Loader(music_streaming_data, batch_size=32, transform=_item_id_as_target)
     batch = next(iter(loader))
 
+    # 4. Define the top-k encoder
     topk_encoder = TopKEncoder(
-        query_encoder=model.blocks[0]["query"], candidates=_candidate_embeddings, k=TOP_K
+        query_encoder=retrieval_model.blocks[0]["query"], candidates=_candidate_embeddings, k=TOP_K
     )
+    # 5. Get top-k predictions
     batch_output = topk_encoder(batch[0])
     predict_output = topk_encoder.predict(loader)
-    assert isinstance(batch_output, tuple)
-    assert list(batch_output[0].shape) == [32, TOP_K]
-    assert list(predict_output[0].shape) == [100, TOP_K]
+    assert list(batch_output.scores.shape) == [32, TOP_K]
+    assert list(predict_output.scores.shape) == [100, TOP_K]
 
+    # 6. Compute top-k evaluation metrics
     topk_encoder.compile()
     topk_evaluation_metrics = topk_encoder.evaluate(loader, return_dict=True)
     assert set(topk_evaluation_metrics.keys()) == set(
@@ -94,12 +99,22 @@ def test_topk_encoder(music_streaming_data: Dataset):
         ]
     )
 
+    # 7. Top-k batch predict: get dataframe with top-k scores and ids
+    topk_dataset = topk_encoder.batch_predict(
+        dataset=music_streaming_data,
+        batch_size=32,
+        output_schema=music_streaming_data.schema.select_by_name("user_id"),
+    )
+    assert set(topk_dataset.head().columns) == set(["user_id", "top_ids", "top_scores"])
+
+    # 8. Save and load a top-k encoder
     with tempfile.TemporaryDirectory() as tmpdir:
         topk_encoder.save(tmpdir)
         loaded_topk_encoder = tf.keras.models.load_model(tmpdir)
     batch_output = loaded_topk_encoder(batch[0])
     assert isinstance(batch_output, tuple)
     tf.assert_equal(
-        topk_encoder.layers[-1].to_call._candidates,
-        loaded_topk_encoder.layers[-1].to_call._candidates,
+        topk_encoder.topk_layer._candidates,
+        loaded_topk_encoder.topk_layer._candidates,
     )
+    assert not loaded_topk_encoder.topk_layer._candidates.trainable

--- a/tests/unit/tf/core/test_encoder.py
+++ b/tests/unit/tf/core/test_encoder.py
@@ -103,8 +103,8 @@ def test_topk_encoder(music_streaming_data: Dataset):
         dataset=music_streaming_data,
         batch_size=32,
         output_schema=music_streaming_data.schema.select_by_name("user_id"),
-    )
-    assert set(topk_dataset.head().columns) == set(["user_id", "top_ids", "top_scores"])
+    ).compute()
+    assert len(topk_dataset.head().columns) == 1 + (TOP_K * 2)
 
     # 8. Save and load the top-k encoder
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/unit/tf/outputs/test_topk.py
+++ b/tests/unit/tf/outputs/test_topk.py
@@ -1,0 +1,70 @@
+#
+# Copyright (c) 2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+import tensorflow as tf
+
+
+def test_brute_force_layer():
+    from merlin.models.tf.core.prediction import TopKPrediction
+    from merlin.models.tf.outputs.topk import BruteForce
+
+    num_candidates = 1000
+    num_queries = 100
+    top_k = 5
+
+    candidates = tf.random.uniform(shape=(num_candidates, 4), dtype=tf.float32)
+    query = tf.random.uniform(shape=(num_queries, 4), dtype=tf.float32)
+
+    wrong_candidates_rank = tf.random.uniform(shape=(num_candidates,), dtype=tf.float32)
+    wrong_query_dim = tf.random.uniform(shape=(num_queries, 8), dtype=tf.float32)
+    wrong_identifiers_shape = tf.range(num_candidates + 1, dtype=tf.int32)
+
+    brute_force = BruteForce(k=top_k)
+
+    with pytest.raises(Exception) as excinfo:
+        brute_force.index(candidates=candidates, identifiers=wrong_identifiers_shape)
+    assert "The candidates and identifiers tensors must have the same number of rows " in str(
+        excinfo.value
+    )
+
+    with pytest.raises(Exception) as excinfo:
+        brute_force.index(wrong_candidates_rank)
+    assert "candidates must be 2-D tensor (got (1000,))" in str(excinfo.value)
+
+    with pytest.raises(Exception) as excinfo:
+        brute_force(query)
+    assert "You should call the `index` method first to set the _candidates index." in str(
+        excinfo.value
+    )
+
+    brute_force.index(candidates=candidates)
+
+    with pytest.raises(Exception) as excinfo:
+        brute_force(wrong_query_dim)
+    assert "Query and candidates vectors must have the same embedding size" in str(excinfo.value)
+
+    topk_output = brute_force(query)
+    assert list(topk_output.scores.shape) == [num_queries, top_k]
+    assert list(topk_output.identifiers.shape) == [num_queries, top_k]
+    assert isinstance(topk_output, TopKPrediction)
+
+    with pytest.raises(Exception) as excinfo:
+        brute_force(query, targets=None, testing=True)
+    assert "Targets should be provided during the evaluation mode" in str(excinfo.value)
+
+    new_candidates = tf.random.uniform(shape=(num_candidates, 4), dtype=tf.float32)
+    brute_force.index(candidates=new_candidates)
+    tf.debugging.assert_none_equal(brute_force._candidates, candidates)


### PR DESCRIPTION
Fixes #499 
Fixes #718 

### Goals :soccer:
The main objective is to decouple top-k evaluation and prediction from the retrieval model.  The typical steps would be: 

1. Training and evaluating the retrieval model using negative sampling. 
2. Defining the TopKEncoder from the candidates/query encoders of the trained retrieval model. 
3. Apply the top-k evaluation to a specified set of candidates. 
4. Prepare top-k predictions for every query: 
         - using .predict() to get a TopKPrediction with tensors of top-k scores and candidates' ids.
         - using batch_predict() to get a merlin dataset with the list columns: top_scores and top_ids.

6. If needed, save the top-k encoder and load it back to apply it to a new set of queries. 

There are more details about the scope of this work in #718. 

### Implementation Details :construction:

This PR introduces a `TopKEncoder` class that takes as a parameter the query encoder and a top-k retrieval strategy. The output of this class is the top-k scores and the related candidates' ids for a given input query. 


- [x] **Add TopK layer**: a Keras layer that supports indexing candidates' pre-trained embeddings. The `call` method returns the top-k scores of the input query and the indexed candidates. This base class can be extended to different top-k strategies (ANN, Streaming..) the supported class in this first work is the `brute-force-topk` 

- [x] **Add TopKOutput**: the output class to calculate the ranking metrics and loss, needed for the top-k evaluation. 

- [x] **Add TopKencoder:** a subclass of the Merlin `BaseModel` and `EncoderBlock` classes. It accepts a query-encoder and a TopKOutput as key arguments. The class supports the Keras methods: .predict, .evaluate, .save, and .load. Additionally, it should support the batch-predict method `to_dataset` that builds a data frame with the top-k predictions for a given input of queries.

### Testing Details :mag:
- Add a first unit test of the TopKEncoder showing the five steps defined in the Goals section. 

### WIP: 
- Update unit tests and the TopKEncoder class after RetrievalModelV2 (#761) is merged. 
