### PR TITLE
Support Compiling Model More than Once

### DIFF
--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -589,8 +589,6 @@ class BaseModel(tf.keras.Model):
             lambda: self.metrics_results(),
         )
 
-        metrics = self.compute_metrics(outputs)
-
         # Adding regularization loss to metrics
         metrics["regularization_loss"] = tf.reduce_sum(cast_losses_to_common_dtype(self.losses))
 

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -42,7 +42,7 @@ def test_simple_model(ecommerce_data: Dataset, run_eagerly):
     testing_utils.test_model_signature(loaded_model, features, ["click/binary_classification_task"])
 
 
-def test_fit_twice():
+def test_fit_compile_twice():
     dataset = Dataset(pd.DataFrame({"feature": [1, 2, 3, 4, 5, 6], "target": [1, 0, 0, 1, 1, 0]}))
     dataset.schema = Schema(
         [
@@ -56,8 +56,9 @@ def test_fit_twice():
         tf.keras.layers.Dense(1),
         mm.BinaryClassificationTask("target"),
     )
-    model.compile(run_eagerly=True, optimizer="adam")
+    model.compile()
     model.fit(loader, epochs=2)
+    model.compile()
     model.fit(loader, epochs=2)
 
 


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of th e automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Aims to fix #647

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

When trying compile and fit a model more than once in non-eager mode (the default). We get the following error raised from the call to `compute_metrics`

```
AssertionError: Called a function referencing variables which have been deleted. This likely means that function-local variables were created and not referenced elsewhere in the program. This is generally a mistake; consider storing variables in an object attribute on first call.
```

~The variable that has been 'deleted' appears to be `should_compute_train_metrics_for_batch` which is assigned to `self._should_compute_train_metrics_for_batch` in the compile method.~

The function from the error is referring to our custom `compute_metrics` method. And the variable that has been deleted is the `self.compiled_metrics`. This seems to be because `compiled_metrics` is re-assigned during the `model.compile()`. 

This PR attempts to address this by passing the metrics container `self.compiled_metrics` through to to compute_metrics (which is wrapped in a `tf.function` to make the check of the tensorflow variable controlling how often we should re-compute metrics) work correctly.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Extending `test_fit_twice` to also compile (in non-eager mode) and renaming it to `test_fit_compile_twice`