### PR TITLE
Adding pre to model.fit, model.evaluate & model.predict

### DIFF
--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -579,7 +579,7 @@ class BaseModel(tf.keras.Model):
         with tf.GradientTape() as tape:
             x, y, sample_weight = unpack_x_y_sample_weight(data)
 
-            if getattr(self, "train_pre"):
+            if getattr(self, "train_pre", None):
                 out = call_layer(self.train_pre, x, targets=y, features=x, training=True)
                 if isinstance(out, Prediction):
                     x, y = out.outputs, out.targets
@@ -606,7 +606,7 @@ class BaseModel(tf.keras.Model):
 
         x, y, sample_weight = unpack_x_y_sample_weight(data)
 
-        if getattr(self, "test_pre"):
+        if getattr(self, "test_pre", None):
             out = call_layer(self.test_pre, x, targets=y, features=x, training=True)
             if isinstance(out, Prediction):
                 x, y = out.outputs, out.targets
@@ -632,7 +632,7 @@ class BaseModel(tf.keras.Model):
     def predict_step(self, data):
         x, _, _ = unpack_x_y_sample_weight(data)
 
-        if getattr(self, "predict_pre"):
+        if getattr(self, "predict_pre", None):
             out = call_layer(self.predict_pr, x, features=x, training=False)
             if isinstance(out, Prediction):
                 x = out.outputs

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -487,7 +487,8 @@ class BaseModel(tf.keras.Model):
         **kwargs,
     ) -> Union[Prediction, PredictionOutput]:
         """Apply the model's call method during Train or Test modes and prepare
-        Prediction (v2) or PredictionOutput (v1 - depreciated) objects
+        Prediction (v2) or PredictionOutput (v1 -
+        depreciated) objects
 
         Parameters
         ----------
@@ -746,7 +747,7 @@ class BaseModel(tf.keras.Model):
         fit_kwargs = {
             k: v
             for k, v in locals().items()
-            if k not in ["self", "kwargs", "train_metrics_steps"] or not k.startswith("__")
+            if k not in ["self", "kwargs", "train_metrics_steps", "pre"] and not k.startswith("__")
         }
 
         if pre:

--- a/merlin/models/tf/utils/testing_utils.py
+++ b/merlin/models/tf/utils/testing_utils.py
@@ -81,12 +81,14 @@ def model_test(
     optimizer="adam",
     epochs: int = 1,
     reload_model: bool = False,
+    fit_kwargs=None,
     **kwargs,
 ) -> Tuple[Model, Any]:
     """Generic model test. It will compile & fit the model and make sure it can be re-trained."""
 
     model.compile(run_eagerly=run_eagerly, optimizer=optimizer, **kwargs)
-    losses = model.fit(dataset, batch_size=50, epochs=epochs, steps_per_epoch=1)
+    fit_kwargs = fit_kwargs or {}
+    losses = model.fit(dataset, batch_size=50, epochs=epochs, steps_per_epoch=1, **fit_kwargs)
 
     batch = sample_batch(dataset, batch_size=50, to_ragged=reload_model)
 

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -741,19 +741,19 @@ def test_model_fit_pre(ecommerce_data: Dataset, run_eagerly):
     )
 
     @tf.keras.utils.register_keras_serializable(package="merlin_=.models")
-    class NoOpLayer(tf.keras.layers.Layer):
+    class _NoOpLayer(tf.keras.layers.Layer):
         def call(self, inputs):
             self._has_run = True
 
             return inputs
 
-    no_op_fit = NoOpLayer()
+    no_op_fit = _NoOpLayer()
     testing_utils.model_test(
         model, ecommerce_data, run_eagerly=run_eagerly, fit_kwargs=dict(pre=no_op_fit)
     )
 
     assert no_op_fit._has_run
 
-    no_op_eval = NoOpLayer()
+    no_op_eval = _NoOpLayer()
     model.evaluate(ecommerce_data, batch_size=10, pre=no_op_eval)
     assert no_op_eval._has_run

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -740,13 +740,6 @@ def test_model_fit_pre(ecommerce_data: Dataset, run_eagerly):
         mm.BinaryClassificationTask("click"),
     )
 
-    @tf.keras.utils.register_keras_serializable(package="merlin_=.models")
-    class _NoOpLayer(tf.keras.layers.Layer):
-        def call(self, inputs):
-            self._has_run = True
-
-            return inputs
-
     no_op_fit = _NoOpLayer()
     testing_utils.model_test(
         model, ecommerce_data, run_eagerly=run_eagerly, fit_kwargs=dict(pre=no_op_fit)
@@ -757,3 +750,11 @@ def test_model_fit_pre(ecommerce_data: Dataset, run_eagerly):
     no_op_eval = _NoOpLayer()
     model.evaluate(ecommerce_data, batch_size=10, pre=no_op_eval)
     assert no_op_eval._has_run
+
+
+@tf.keras.utils.register_keras_serializable(package="merlin.models")
+class _NoOpLayer(tf.keras.layers.Layer):
+    def call(self, inputs):
+        self._has_run = True
+
+        return inputs


### PR DESCRIPTION
### Goals :soccer:
We support `pre` as an argument in a large amount of blocks in Merlin Models. This PR adds it to `model.fit`, `model.evaluate` & `model.predict`. This is useful in instances where you want to run a layer as part of each step, without making it part of the model. Right now, we offer the ability to use layers to transform each batch in the data-loader but this is not always enough. The big use-case where that’s enough right now is masking, since we loose the masking information when passing the data from the data-loader to the model.

This PR allows for the following API:

```python
model = ...

model.fit(
	dataset, 
	batch_size=1000, 
	pre=SequenceMaskRandom(sequence_schema, Tags.ITEM_ID)
)

model.evaluate(
	dataset, 
	batch_size=1000,
	pre=SequenceMaskLast(sequence_schema, Tags.ITEM_ID)
)
```

### Implementation Details :construction:
In Keras, there’s the following code-path for these methods:
- `model.fit` will call `train_step` for each batch, this is where the `pre` would be called.
- `model.evaluate` will call `test_step` for each batch, this is where the `pre` would be called.
- `model.predict` will call `predict_step` for each batch, this is where the `pre` would be called.

### Testing Details :mag:
Added a unit-test asserting that the the layer provided in `model.fit(pre=…)` & evaluate is actually being run.
