### PR TITLE
Change output format of ToTarget to tuple

### DIFF
--- a/merlin/models/tf/transforms/features.py
+++ b/merlin/models/tf/transforms/features.py
@@ -15,7 +15,7 @@
 #
 import warnings
 from itertools import combinations
-from typing import Dict, Optional, Sequence, Union
+from typing import Dict, Optional, Sequence, Tuple, Union
 
 import tensorflow as tf
 from keras.layers.preprocessing import preprocessing_utils as p_utils
@@ -738,11 +738,8 @@ class ToTarget(Block):
         return target_columns
 
     def call(
-        self, inputs: TabularData, targets=None, testing=False, **kwargs
-    ) -> "PredictionOutput":
-        if testing:
-            return inputs, targets
-
+        self, inputs: TabularData, targets=None, **kwargs
+    ) -> Tuple[TabularData, Union[TabularData, tf.Tensor, None]]:
         target_columns = self._target_column_schemas()
 
         outputs = {}

--- a/merlin/models/tf/transforms/features.py
+++ b/merlin/models/tf/transforms/features.py
@@ -741,10 +741,7 @@ class ToTarget(Block):
         self, inputs: TabularData, targets=None, testing=False, **kwargs
     ) -> "PredictionOutput":
         if testing:
-            return PredictionOutput(predictions=inputs, targets=targets)
-
-        if targets is None:
-            targets = {}
+            return inputs, targets
 
         target_columns = self._target_column_schemas()
 
@@ -758,7 +755,7 @@ class ToTarget(Block):
             else:
                 targets = inputs[name]
 
-        return PredictionOutput(predictions=outputs, targets=targets or None)
+        return outputs, targets
 
     def compute_output_shape(self, input_shape):
         return input_shape

--- a/tests/unit/tf/core/test_encoder.py
+++ b/tests/unit/tf/core/test_encoder.py
@@ -66,11 +66,9 @@ def test_topk_encoder(music_streaming_data: Dataset):
     _candidate_embeddings = tf.random.uniform(shape=(NUM_CANDIDATES, 4), dtype=tf.float32)
 
     # 3. Set data-loader for top-k recommendation
-    def _item_id_as_target(inputs, targets):
-        targets = tf.squeeze(inputs["item_id"])
-        return inputs, targets
-
-    loader = mm.Loader(music_streaming_data, batch_size=32, transform=_item_id_as_target)
+    loader = mm.Loader(
+        music_streaming_data, batch_size=32, transform=mm.ToTarget(schema, "item_id")
+    )
     batch = next(iter(loader))
 
     # 4. Define the top-k encoder

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -675,12 +675,9 @@ def test_retrieval_model_query(ecommerce_data: Dataset, run_eagerly=True):
     query = ecommerce_data.schema.select_by_tag(Tags.USER_ID)
     candidate = ecommerce_data.schema.select_by_tag(Tags.ITEM_ID)
 
-    def item_id_as_target(features, targets):
-        targets[candidate.first.name] = features.pop(candidate.first.name)
-
-        return features, targets
-
-    loader = mm.Loader(ecommerce_data, batch_size=50, transform=item_id_as_target)
+    loader = mm.Loader(
+        ecommerce_data, batch_size=50, transform=mm.ToTarget(ecommerce_data.schema, Tags.ITEM_ID)
+    )
 
     model = mm.RetrievalModelV2(
         query=mm.EmbeddingEncoder(query, dim=8),

--- a/tests/unit/tf/transforms/test_features.py
+++ b/tests/unit/tf/transforms/test_features.py
@@ -924,38 +924,34 @@ def test_to_target_loader():
 
     # target is passed as a string.
     loader0 = mm.Loader(dataset, batch_size=10, transform=mm.ToTarget(schema, "c"))
-    batch0 = next(iter(loader0))
-    assert sorted(batch0.predictions.keys()) == ["a", "b"]
-    assert sorted(batch0.targets.keys()) == ["c"]
-    assert batch0.targets["c"].numpy().tolist() == [[3], [6]]
+    inputs0, targets0 = next(iter(loader0))
+    assert sorted(inputs0.keys()) == ["a", "b"]
+    assert targets0.numpy().tolist() == [[3], [6]]
     assert loader0.output_schema.select_by_tag(Tags.TARGET).column_names == ["c"]
 
     # target is passed as a ColumnSchema
     target_column_schema = ColumnSchema("c", tags=[Tags.CATEGORICAL])
     assert Tags.TARGET not in target_column_schema.tags
     loader1 = mm.Loader(dataset, batch_size=10, transform=mm.ToTarget(schema, target_column_schema))
-    batch1 = next(iter(loader1))
-    assert sorted(batch1.predictions.keys()) == ["a", "b"]
-    assert sorted(batch1.targets.keys()) == ["c"]
-    assert batch1.targets["c"].numpy().tolist() == [[3], [6]]
+    inputs1, targets1 = next(iter(loader1))
+    assert sorted(inputs1.keys()) == ["a", "b"]
+    assert targets1.numpy().tolist() == [[3], [6]]
     assert loader1.output_schema.select_by_tag(Tags.TARGET).column_names == ["c"]
 
     # target is passed as a Schema
     target_schema = schema.select_by_name("c")
     assert not target_schema.select_by_tag(Tags.TARGET)
     loader2 = mm.Loader(dataset, batch_size=10, transform=mm.ToTarget(schema, target_schema))
-    batch2 = next(iter(loader2))
-    assert sorted(batch2.predictions.keys()) == ["a", "b"]
-    assert sorted(batch2.targets.keys()) == ["c"]
-    assert batch2.targets["c"].numpy().tolist() == [[3], [6]]
+    inputs2, targets2 = next(iter(loader2))
+    assert sorted(inputs2.keys()) == ["a", "b"]
+    assert targets2.numpy().tolist() == [[3], [6]]
     assert loader2.output_schema.select_by_tag(Tags.TARGET).column_names == ["c"]
 
     # target is passed as a Tag
     loader3 = mm.Loader(dataset, batch_size=10, transform=mm.ToTarget(schema, Tags.ITEM))
-    batch3 = next(iter(loader3))
-    assert sorted(batch3.predictions.keys()) == ["a", "b"]
-    assert sorted(batch3.targets.keys()) == ["c"]
-    assert batch3.targets["c"].numpy().tolist() == [[3], [6]]
+    inputs3, targets3 = next(iter(loader3))
+    assert sorted(inputs3.keys()) == ["a", "b"]
+    assert targets3.numpy().tolist() == [[3], [6]]
     assert loader3.output_schema.select_by_tag(Tags.TARGET).column_names == ["c"]
 
 


### PR DESCRIPTION
Follow-up to #740 

### Goals :soccer:
This PR changes the output format of `ToTarget` from `PredictionsOutput` to a tuple `(x, y)`.

### Implementation Details :construction:
Since `ToTarget` was intended as a transformation operation (to be mainly used in `Loader(transform=ToTarget(...))`) that transforms the schema and the input *before* feeding the input to a keras model, the output should be something that keras recognizes (i.e., tuple). When the output format is `PredictionsOutput`, keras throws an error:
```
ValueError: Data is expected to be in format `x`, `(x,)`, `(x, y)`, or `(x, y, sample_weight)`, found: PredictionOutput...
```

### Testing Details :mag:
Two existing unit tests in `core/test_encoder.py` and `models/test_base.py` that were using a custom function to transform inputs without a target were modified to use `ToTarget`.