### PR TITLE
Fix the rank of predictions returned by ContrastiveOutout

### DIFF
--- a/merlin/models/tf/losses/pairwise.py
+++ b/merlin/models/tf/losses/pairwise.py
@@ -72,6 +72,10 @@ class PairwiseLoss(Loss, LossRegistryMixin):
         tf.Tensor
             Loss per example
         """
+        tf.assert_equal(tf.rank(y_true), 2, f"Targets must be 2-D tensor (got {y_true.shape})")
+
+        tf.assert_equal(tf.rank(y_pred), 2, f"Predictions must be 2-D tensor (got {y_pred.shape})")
+
         (
             positives_scores,
             negatives_scores,

--- a/merlin/models/tf/outputs/contrastive.py
+++ b/merlin/models/tf/outputs/contrastive.py
@@ -226,7 +226,6 @@ class ContrastiveOutput(ModelOutput):
         # To ensure that the output is always fp32, avoiding numerical
         # instabilities with mixed_float16 policy
         outputs = tf.cast(outputs, tf.float32)
-        outputs = tf.squeeze(outputs)
 
         targets = tf.concat(
             [


### PR DESCRIPTION
Fixes #799

### Goals :soccer:
- Make sure ContrastiveOutput is returning a 2-D predictions tensor in graph mode. 


### Implementation Details :construction:
This PR removes the [line](https://github.com/NVIDIA-Merlin/models/blob/abab6e1a63bea64031e6f6a232a9112d6b14dcd7/merlin/models/tf/outputs/contrastive.py#L229) from ContrastiveOutput. 

--> The squeeze could be needed when the last dim is equal to `1`. In the case of ContrastiveOutput, this means that the number of negatives is equal to zero. This will never be the case as `outputs` is called inside the `call_contrastive` method where negatives are always sampled. 


### Testing Details :mag:
- Add a test of training a ContrastiveOutput with `bpr-max` loss. 
