### PR TITLE
Add LogQ correction support to the new ModelOutput API

### DIFF
--- a/merlin/models/tf/core/prediction.py
+++ b/merlin/models/tf/core/prediction.py
@@ -55,10 +55,13 @@ class PredictionContext(NamedTuple):
 
 
 class Prediction(NamedTuple):
+    """Prediction object returned by `ModelOutput` classes"""
+
     outputs: Dict[str, TensorLike]
     targets: Optional[Union[tf.Tensor, Dict[str, tf.Tensor]]] = None
     sample_weight: Optional[tf.Tensor] = None
     features: Optional[Dict[str, TensorLike]] = None
+    negative_candidate_ids: Optional[tf.Tensor] = None
 
     @property
     def predictions(self):
@@ -66,10 +69,13 @@ class Prediction(NamedTuple):
 
 
 class TopKPrediction(NamedTuple):
+    """Prediction object returned by `TopKOutput` classes"""
+
     scores: tf.Tensor
     identifiers: tf.Tensor
 
     def to_df(self) -> DataFrameType:
+        """Convert Top-k scores and identifiers to a data-frame."""
         score_names = [f"score_{i}" for i in range(self.scores.shape[1])]
         id_names = [f"id_{i}" for i in range(self.identifiers.shape[1])]
 

--- a/merlin/models/tf/prediction_tasks/base.py
+++ b/merlin/models/tf/prediction_tasks/base.py
@@ -216,6 +216,13 @@ class PredictionTask(Layer, ContextMixin):
 
         return metrics
 
+    def compute_output_shape(self, input_shape):
+        if self.task_block:
+            input_shape = self.task_block.compute_output_shape(input_shape)
+        if self.pre:
+            input_shape = self.pre.compute_output_shape(input_shape)
+        return input_shape
+
 
 @tf.keras.utils.register_keras_serializable(package="merlin.models")
 class ParallelPredictionBlock(ParallelBlock):

--- a/merlin/models/tf/prediction_tasks/classification.py
+++ b/merlin/models/tf/prediction_tasks/classification.py
@@ -226,3 +226,6 @@ class MultiClassClassificationTask(PredictionTask):
 
     def call(self, inputs, training=False, **kwargs):
         return inputs
+
+    def compute_output_shape(self, input_shape):
+        self.pre.compute_output_shape(input_shape)

--- a/merlin/models/tf/prediction_tasks/classification.py
+++ b/merlin/models/tf/prediction_tasks/classification.py
@@ -226,6 +226,3 @@ class MultiClassClassificationTask(PredictionTask):
 
     def call(self, inputs, training=False, **kwargs):
         return inputs
-
-    def compute_output_shape(self, input_shape):
-        self.pre.compute_output_shape(input_shape)

--- a/merlin/models/tf/transforms/bias.py
+++ b/merlin/models/tf/transforms/bias.py
@@ -120,9 +120,11 @@ class PopularityLogitsCorrection(Block):
             self.set_schema(schema)
 
         self.reg_factor = reg_factor
-        self.candidate_id_name = self.schema.select_by_tag(candidate_tag_id).first.name
+        self.candidate_tag_id = candidate_tag_id
+        self.candidate_id_name = self.schema.select_by_tag(self.candidate_tag_id).first.name
+        self.item_freq_probs = item_freq_probs
 
-        if item_freq_probs is not None:
+        if self.item_freq_probs is not None:
             self._check_items_cardinality(item_freq_probs)
             candidate_probs = tf_utils.get_candidate_probs(item_freq_probs, is_prob_distribution)
 
@@ -279,6 +281,8 @@ class PopularityLogitsCorrection(Block):
         if self.schema:
             config["schema"] = schema_to_tensorflow_metadata_json(self.schema)
         config["reg_factor"] = self.reg_factor
+        config["candidate_tag_id"] = self.candidate_tag_id.value
+        config["item_freq_probs"] = self.item_freq_probs
 
         return config
 
@@ -287,4 +291,6 @@ class PopularityLogitsCorrection(Block):
         if "schema" in config:
             config["schema"] = schema_utils.tensorflow_metadata_json_to_schema(config["schema"])
 
-        return super().from_config(config)
+        config["candidate_tag_id"] = Tags(config["candidate_tag_id"])
+
+        return cls(**config)

--- a/merlin/models/tf/transforms/bias.py
+++ b/merlin/models/tf/transforms/bias.py
@@ -209,6 +209,7 @@ class PopularityLogitsCorrection(Block):
         """
         self._check_items_cardinality(item_freq_probs)
         candidate_probs = tf_utils.get_candidate_probs(item_freq_probs, is_prob_distribution)
+        self.item_freq_probs = item_freq_probs
         self.candidate_probs.assign(candidate_probs)
 
     def compute_output_shape(self, input_shape):
@@ -282,7 +283,7 @@ class PopularityLogitsCorrection(Block):
             config["schema"] = schema_to_tensorflow_metadata_json(self.schema)
         config["reg_factor"] = self.reg_factor
         config["candidate_tag_id"] = self.candidate_tag_id.value
-        config["item_freq_probs"] = self.item_freq_probs
+        config["item_freq_probs"] = self.item_freq_probs.numpy()
 
         return config
 
@@ -292,5 +293,6 @@ class PopularityLogitsCorrection(Block):
             config["schema"] = schema_utils.tensorflow_metadata_json_to_schema(config["schema"])
 
         config["candidate_tag_id"] = Tags(config["candidate_tag_id"])
+        config["item_freq_probs"] = tf.convert_to_tensor(config["item_freq_probs"])
 
         return cls(**config)

--- a/tests/unit/tf/outputs/test_contrastive.py
+++ b/tests/unit/tf/outputs/test_contrastive.py
@@ -71,6 +71,36 @@ def test_two_tower_constrastive(ecommerce_data: Dataset):
     testing_utils.model_test(model, ecommerce_data)
 
 
+def test_two_tower_constrastive_with_logq_correction(ecommerce_data: Dataset):
+    from merlin.models.tf.transforms.bias import PopularityLogitsCorrection
+    from merlin.models.utils import schema_utils
+
+    cardinalities = schema_utils.categorical_cardinalities(ecommerce_data.schema)
+    item_id_cardinalities = cardinalities[
+        ecommerce_data.schema.select_by_tag(Tags.ITEM_ID).column_names[0]
+    ]
+    items_frequencies = tf.sort(
+        tf.random.uniform((item_id_cardinalities,), minval=0, maxval=1000, dtype=tf.int32)
+    )
+    post_logits = PopularityLogitsCorrection(
+        items_frequencies,
+        schema=ecommerce_data.schema,
+    )
+
+    model = mm.RetrievalModel(
+        mm.TwoTowerBlock(ecommerce_data.schema, query_tower=mm.MLPBlock([8])),
+        mm.ContrastiveOutput(
+            ecommerce_data.schema.select_by_tag(Tags.ITEM_ID),
+            negative_samplers="in-batch",
+            candidate_name="item",
+            store_negative_ids=True,
+            post=post_logits,
+        ),
+    )
+
+    testing_utils.model_test(model, ecommerce_data, reload_model=True)
+
+
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_contrastive_output(ecommerce_data: Dataset, run_eagerly):
     schema = ecommerce_data.schema

--- a/tests/unit/tf/outputs/test_contrastive.py
+++ b/tests/unit/tf/outputs/test_contrastive.py
@@ -19,8 +19,10 @@ import tensorflow as tf
 import merlin.models.tf as mm
 from merlin.io import Dataset
 from merlin.models.tf.outputs.sampling.popularity import PopularityBasedSamplerV2
+from merlin.models.tf.transforms.bias import PopularityLogitsCorrection
 from merlin.models.tf.transforms.features import Rename
 from merlin.models.tf.utils import testing_utils
+from merlin.models.utils import schema_utils
 from merlin.schema import Tags
 
 
@@ -72,9 +74,6 @@ def test_two_tower_constrastive(ecommerce_data: Dataset):
 
 
 def test_two_tower_constrastive_with_logq_correction(ecommerce_data: Dataset):
-    from merlin.models.tf.transforms.bias import PopularityLogitsCorrection
-    from merlin.models.utils import schema_utils
-
     cardinalities = schema_utils.categorical_cardinalities(ecommerce_data.schema)
     item_id_cardinalities = cardinalities[
         ecommerce_data.schema.select_by_tag(Tags.ITEM_ID).column_names[0]

--- a/tests/unit/tf/transforms/test_bias.py
+++ b/tests/unit/tf/transforms/test_bias.py
@@ -65,8 +65,8 @@ def test_popularity_logits_correct():
         outputs=inputs_v2, features={"item_feature": positive_item_ids}, training=True
     )
 
-    tf.debugging.assert_less_equal(logits, corrected_logits.predictions)
-    tf.debugging.assert_less_equal(logits, corrected_logits_v2.outputs)
+    tf.debugging.assert_less(logits, corrected_logits.predictions)
+    tf.debugging.assert_less(logits, corrected_logits_v2.outputs)
 
     _ = testing_utils.assert_serialization(log_q_correction)
 

--- a/tests/unit/tf/transforms/test_bias.py
+++ b/tests/unit/tf/transforms/test_bias.py
@@ -68,7 +68,8 @@ def test_popularity_logits_correct():
     tf.debugging.assert_less(logits, corrected_logits.predictions)
     tf.debugging.assert_less(logits, corrected_logits_v2.outputs)
 
-    _ = testing_utils.assert_serialization(log_q_correction)
+    copy_layer = testing_utils.assert_serialization(log_q_correction)
+    tf.debugging.assert_equal(copy_layer.candidate_probs, log_q_correction.candidate_probs)
 
 
 def test_popularity_logits_correct_from_parquet():

--- a/tests/unit/tf/transforms/test_bias.py
+++ b/tests/unit/tf/transforms/test_bias.py
@@ -17,12 +17,14 @@ import tempfile
 
 import tensorflow as tf
 
+from merlin.models.tf.utils import testing_utils
 from merlin.models.utils.schema_utils import create_categorical_column
 from merlin.schema import Schema, Tags
 
 
 def test_popularity_logits_correct():
     from merlin.models.tf.core.base import PredictionOutput
+    from merlin.models.tf.core.prediction import Prediction
     from merlin.models.tf.transforms.bias import PopularityLogitsCorrection
 
     schema = Schema(
@@ -44,18 +46,29 @@ def test_popularity_logits_correct():
     positive_item_ids = tf.random.uniform((NUM_ROWS,), minval=1, maxval=NUM_ITEMS, dtype=tf.int32)
     item_frequency = tf.sort(tf.random.uniform((NUM_ITEMS,), minval=0, maxval=1000, dtype=tf.int32))
 
+    log_q_correction = PopularityLogitsCorrection(item_frequency, reg_factor=0.5, schema=schema)
+
     inputs = PredictionOutput(
         predictions=logits,
         targets=[],
         positive_item_ids=positive_item_ids,
         negative_item_ids=negative_item_ids,
     )
+    corrected_logits = log_q_correction.call_outputs(outputs=inputs)
 
-    corrected_logits = PopularityLogitsCorrection(
-        item_frequency, reg_factor=0.5, schema=schema
-    ).call_outputs(outputs=inputs)
+    inputs_v2 = Prediction(
+        outputs=logits,
+        targets=[],
+        negative_candidate_ids=negative_item_ids,
+    )
+    corrected_logits_v2 = log_q_correction(
+        outputs=inputs_v2, features={"item_feature": positive_item_ids}, training=True
+    )
 
     tf.debugging.assert_less_equal(logits, corrected_logits.predictions)
+    tf.debugging.assert_less_equal(logits, corrected_logits_v2.outputs)
+
+    _ = testing_utils.assert_serialization(log_q_correction)
 
 
 def test_popularity_logits_correct_from_parquet():


### PR DESCRIPTION
### Context
- We observed an accuracy drop when running the retrieval research script with the new API defined in #790. One of the main issues was that the logic of log-Q correction is defined inside the `call_outputs` method, which is not used in the new ModelOutput API. 

- The serialization of logQ is also not working because we missed `get_config`/`from_config` methods to serialize the required schema object. After adding the methods to the class, a new issue was raised: 

    ==>  If loading the class as a standalone using get_config/from_config  methods, the  tf Variable `candidate_probs`  defined [here](https://github.com/NVIDIA-Merlin/models/blob/8f1a73a07fc4586a374d9d7c793111946726517b/merlin/models/tf/transforms/bias.py#L129) is not loaded:  
             **Note:** This was fixed by adding `candidate_tag_id` and `item_freq_probs` to the config as recommended by @oliverholworthy 

    ==>  Loading a whole model containing logQ block using `tf.keras.load()` is correctly loading the variable `candidate_probs` .
             **Note:** I needed to save `item_freq_probs` as a NumPy array to avoid the serialization error raised by tf.Keras.save_model 


### Goals :soccer:

- [x] Add the logic of log-q correction to the `call` method
- [x] Fix the serialization of LogQ correction

### Testing Details :mag:
- Update tests in `test_bias.py` to ensure logq correction is applied in the new ModelOutputAPI.
- Add a test in `test_contrastive.py` to test ContrastiveOutput with the logq correction as a post block.  
