### PR TITLE
Add L2-batch regularization to EmbeddingTable

### DIFF
--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -533,9 +533,12 @@ def Embeddings(
         Transformation block to apply after the embeddings lookup, by default None
     aggregation: Optional[TabularAggregationType], optional
         Transformation block to apply for aggregating the inputs, by default None
-    block_name: Optional[float, Dict[str, float]] = 0.0
+    block_name: str, optional
         Name of the block, by default "embeddings"
-
+    l2_batch_regularization_factor: Optional[float, Dict[str, float]] = 0.0
+        Factor for L2 regularization of the embeddings vectors (from the current batch only)
+        If a dictionary is provided, the keys are feature names and the values are
+        regularization factors
     Returns
     -------
     ParallelBlock

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -385,14 +385,6 @@ class EmbeddingTable(EmbeddingTableBase):
         else:
             out = self._call_table(inputs, **kwargs)
 
-        if self.l2_batch_regularization_factor > 0:
-            if isinstance(out, dict):
-                self.add_loss(
-                    self.l2_batch_regularization_factor
-                    * tf.reduce_sum(tf.square(out[feature_name]))
-                )
-            else:
-                self.add_loss(self.l2_batch_regularization_factor * tf.reduce_sum(tf.square(out)))
         return out
 
     def _call_table(self, inputs, **kwargs):
@@ -422,6 +414,9 @@ class EmbeddingTable(EmbeddingTableBase):
                     out = call_layer(self.sequence_combiner, out, **kwargs)
         else:
             out = call_layer(self.table, inputs, **kwargs)
+
+        if self.l2_batch_regularization_factor > 0:
+            self.add_loss(self.l2_batch_regularization_factor * tf.reduce_sum(tf.square(out)))
 
         if self._dtype_policy.compute_dtype != self._dtype_policy.variable_dtype:
             # Instead of casting the variable as in most layers, cast the output, as
@@ -496,7 +491,7 @@ def Embeddings(
     post: Optional[BlockType] = None,
     aggregation: Optional[TabularAggregationType] = None,
     block_name: str = "embeddings",
-    l2_batch_regularization_factor: float = 0.0,
+    l2_batch_regularization_factor: Optional[Union[float, Dict[str, float]]] = 0.0,
     **kwargs,
 ) -> ParallelBlock:
     """Creates a ParallelBlock with an EmbeddingTable for each categorical feature
@@ -538,7 +533,7 @@ def Embeddings(
         Transformation block to apply after the embeddings lookup, by default None
     aggregation: Optional[TabularAggregationType], optional
         Transformation block to apply for aggregating the inputs, by default None
-    block_name: str, optional
+    block_name: Optional[float, Dict[str, float]] = 0.0
         Name of the block, by default "embeddings"
 
     Returns
@@ -556,6 +551,8 @@ def Embeddings(
         kwargs["activity_regularizer"] = activity_regularizer
     if sequence_combiner:
         kwargs["sequence_combiner"] = sequence_combiner
+    if l2_batch_regularization_factor:
+        kwargs["l2_batch_regularization_factor"] = l2_batch_regularization_factor
 
     tables = {}
 
@@ -569,7 +566,6 @@ def Embeddings(
                 _get_dim(col, dim, infer_dim_fn),
                 col,
                 name=table_name,
-                l2_batch_regularization_factor=l2_batch_regularization_factor,
                 **table_kwargs,
             )
 

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -455,6 +455,25 @@ def test_embedding_features_l2_reg(testing_data: Dataset):
         assert reg_loss > 0.0
 
 
+def test_embeddings_with_regularization(testing_data: Dataset):
+    schema = testing_data.schema.select_by_tag(Tags.ITEM_ID)
+    dim = 16
+    embeddings_wo_reg = mm.Embeddings(schema, dim=dim)
+    embeddings_batch_reg = mm.Embeddings(schema, dim=dim, l2_batch_regularization_factor=0.2)
+    embeddings_table_reg = mm.Embeddings(
+        schema, dim=dim, embeddings_regularizer=tf.keras.regularizers.L2(0.2)
+    )
+
+    inputs = mm.sample_batch(testing_data, batch_size=100, include_targets=False)
+    _ = embeddings_wo_reg(inputs)
+    _ = embeddings_batch_reg(inputs)
+    _ = embeddings_table_reg(inputs)
+
+    assert not embeddings_wo_reg.losses
+    assert embeddings_batch_reg.losses[0] > 0
+    tf.debugging.assert_greater(embeddings_table_reg.losses[0], embeddings_batch_reg.losses[0])
+
+
 def test_embedding_features_yoochoose_infer_embedding_sizes(testing_data: Dataset):
     schema = testing_data.schema.select_by_tag(Tags.CATEGORICAL)
 


### PR DESCRIPTION
### Goals :soccer:
We observed an accuracy drop when running the retrieval research script with the new API defined in https://github.com/NVIDIA-Merlin/models/pull/790. This figure shows that the regularization loss of the new API was higher during the first iterations, compared to the regularization loss of the old API. Which prevents the model from learning useful information.  

<img width="896" alt="image" src="https://user-images.githubusercontent.com/17721108/196542868-ccc23a2e-9b60-4232-ac69-4342873b2d81.png">

After some investigation, it seems the issue was related to the embedding table regularization.  In fact, in the old API, the l2 regularization was computed only for the embeddings in the current batch using this custom [code](https://github.com/NVIDIA-Merlin/models/blob/093cf2bc2942e54b8e56b1709af0ea17ca476676/merlin/models/tf/inputs/embedding.py#L852). While  the new Embeddings API uses base Keras regularizers ([here](https://github.com/NVIDIA-Merlin/models/blob/093cf2bc2942e54b8e56b1709af0ea17ca476676/merlin/models/tf/inputs/embedding.py#L168)) that computes the regularization loss using the whole embeddings table weights. 

### Implementation Details :construction:
- Add the support of embeddings l2 regularization using only the current batch weights. 

### Testing Details :mag:
- Add a unit test to `embeddings.py` that compares the three scenarios: no regularization, batch regularization and embedding table regularization. 
