### PR TITLE
Add support for LogitsTemperatureScaler in the new ModelOutput API

### DIFF
--- a/merlin/models/tf/core/prediction.py
+++ b/merlin/models/tf/core/prediction.py
@@ -67,6 +67,24 @@ class Prediction(NamedTuple):
     def predictions(self):
         return self.outputs
 
+    def copy_with_updates(
+        self,
+        outputs=None,
+        targets=None,
+        sample_weight=None,
+        features=None,
+        negative_candidate_ids=None,
+    ) -> "Prediction":
+        return Prediction(
+            outputs if outputs is not None else self.outputs,
+            targets if targets is not None else self.targets,
+            sample_weight if sample_weight is not None else self.sample_weight,
+            features if features is not None else self.features,
+            negative_candidate_ids
+            if negative_candidate_ids is not None
+            else self.negative_candidate_ids,
+        )
+
 
 class TopKPrediction(NamedTuple):
     """Prediction object returned by `TopKOutput` classes"""

--- a/merlin/models/tf/outputs/base.py
+++ b/merlin/models/tf/outputs/base.py
@@ -139,11 +139,9 @@ class ModelOutput(Layer):
             outputs = tf_utils.call_layer(self.post, outputs, **kwargs)
 
         if getattr(self, "logits_scaler", None):
-            if isinstance(outputs, Prediction):
-                scaled_outputs = self.logits_scaler(outputs.outputs)
-                outputs = Prediction(scaled_outputs, outputs.targets)
-            else:
-                outputs = self.logits_scaler(outputs)
+            if isinstance(outputs, tf.Tensor):
+                outputs = Prediction(outputs)
+            outputs = self.logits_scaler(outputs)
 
         return outputs
 

--- a/tests/unit/tf/outputs/test_base.py
+++ b/tests/unit/tf/outputs/test_base.py
@@ -61,6 +61,27 @@ def test_logits_scaler(ecommerce_data: Dataset):
     assert np.allclose(prediction_1.numpy(), prediction_2.numpy())
 
 
+def test_logits_scaler_v2(ecommerce_data: Dataset):
+    import numpy as np
+    from tensorflow.keras.utils import set_random_seed
+
+    set_random_seed(42)
+    logits_temperature = 0.5
+    model = mm.Model(
+        mm.InputBlockV2(ecommerce_data.schema),
+        mm.MLPBlock([8]),
+        mm.BinaryOutput("click", logits_temperature=logits_temperature),
+    )
+
+    inputs = mm.sample_batch(ecommerce_data, batch_size=10, include_targets=False)
+    prediction_1 = model(inputs)
+
+    model.last.logits_scaler = LogitsTemperatureScaler(temperature=1)
+    prediction_2 = model(inputs)
+
+    assert np.allclose(prediction_1.numpy(), prediction_2.numpy() / 0.5)
+
+
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_parallel_outputs(ecommerce_data: Dataset, run_eagerly):
     model = mm.Model(


### PR DESCRIPTION
### Goals: 
- As a follow-up to the fixes needed to reproduce the research scripts with the new API (see #812 and #811), I defined integration tests for TwoTower and MatrixFactorization. I observed that TwoTower is still returning a smaller validation performance compared to the old API.

-  After debugging, the issue is now related to `LogitsTemperatureScaler` not including the logic of scaling the logits if the class variable `apply_on_call_outputs`  is set to True (which is the default). 

- In fact, the logits scaler in ModelOutput is set [here](https://github.com/NVIDIA-Merlin/models/blob/969c9a0af4255aa3b6770444e60b5e2eadc2ddfe/merlin/models/tf/outputs/base.py#L91) with the default value True, so the logits are never scaled with the provided temperature.

- `apply_on_call_outputs` is specific to Merlin supporting two versions of the API so I believe we should not expose this argument to the user. It might be confusing for the user to understand when to set `apply_on_call_outputs` to True or False. 

- So I refactored `LogitsTemperatureScaler` to have similar logic we have in `PopularityLogitsCorrection` 

- Figures below show the 3 runs of integration tests:  Old API, New API, New API with logit scaler fix 

<img width="1010" alt="Screen Shot 2022-10-20 at 12 29 55 PM" src="https://user-images.githubusercontent.com/17721108/197027102-4a8f0256-1066-4ec4-aafe-f97c629849be.png">
<img width="1005" alt="image" src="https://user-images.githubusercontent.com/17721108/197028024-29000101-1140-4467-ad99-02f4d8045921.png">

### Implementation Details :construction:

- Add a `copy_with_updates` to the Prediction NamedTuple class to update only necessary tensors in the post transforms blocks. 
- Make sure the ModelOutputBase is always returning a Prediction object. 
- Add applying logits-temperature inside the call method of the `LogitsTemperatureScaler` block. 
- Add `get_config` method to `LogitsTemperatureScaler` to store the value `temperature` when saving the model. 


### Testing Details 🔍
- Add test of logit scaler with different temperatures in outputs/test_base.py`