### PR TITLE
Fix `EmbeddingFeatures` serialization/deserialization when a feature is named 'name'

### DIFF
--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -1030,24 +1030,19 @@ class EmbeddingFeatures(TabularBlock):
             feature_configs[key] = feature_config_dict
 
         config["feature_config"] = feature_configs
+        config["l2_reg"] = self.l2_reg
 
         return config
 
     @classmethod
     def from_config(cls, config):
         # Deserialize feature_config
-        feature_configs, table_configs = {}, {}
+        feature_configs = {}
         for key, val in config["feature_config"].items():
-            feature_params = deepcopy(val)
-            table_params = feature_params["table"]
-            if "name" in table_configs:
-                feature_params["table"] = table_configs["name"]
-            else:
-                table = deserialize_table_config(table_params)
-                if table.name:
-                    table_configs[table.name] = table
-                feature_params["table"] = table
-            feature_configs[key] = FeatureConfig(**feature_params)
+            table = deserialize_table_config(val["table"])
+            feature_config_params = {**val, "table": table}
+            feature_configs[key] = FeatureConfig(**feature_config_params)
+
         config["feature_config"] = feature_configs
 
         # Set `add_default_pre to False` since pre will be provided from the config

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -648,6 +648,57 @@ def test_embedding_features_yoochoose_pretrained_initializer(testing_data: Datas
     )
 
 
+def test_embedding_features_from_config():
+    schema = Schema(
+        [
+            ColumnSchema(
+                "name",
+                tags=[Tags.USER, Tags.CATEGORICAL],
+                is_list=False,
+                is_ragged=False,
+                dtype=np.int32,
+                properties={
+                    "num_buckets": None,
+                    "freq_threshold": 0,
+                    "max_size": 0,
+                    "start_index": 0,
+                    "cat_path": ".//categories/unique.name.parquet",
+                    "domain": {"min": 0, "max": 5936, "name": "name"},
+                    "embedding_sizes": {"cardinality": 5937, "dimension": 208},
+                },
+            ),
+            ColumnSchema(
+                "feature",
+                tags=[Tags.USER, Tags.CATEGORICAL],
+                is_list=False,
+                is_ragged=False,
+                dtype=np.int32,
+                properties={
+                    "num_buckets": None,
+                    "freq_threshold": 0,
+                    "max_size": 0,
+                    "start_index": 0,
+                    "cat_path": ".//categories/unique.feature.parquet",
+                    "domain": {"min": 0, "max": 2, "name": "feature"},
+                    "embedding_sizes": {"cardinality": 3, "dimension": 16},
+                },
+            ),
+        ]
+    )
+
+    embedding_features = mm.EmbeddingFeatures.from_schema(
+        schema,
+        tags=(Tags.CATEGORICAL,),
+        embedding_options=mm.EmbeddingOptions(infer_embedding_sizes=True),
+    )
+    config = embedding_features.get_config()
+    reloaded_embedding_features = mm.EmbeddingFeatures.from_config(config)
+
+    assert set(embedding_features.embedding_tables.keys()) == set(
+        reloaded_embedding_features.embedding_tables.keys()
+    )
+
+
 def test_embedding_features_exporting_and_loading_pretrained_initializer(testing_data: Dataset):
     schema = testing_data.schema.select_by_tag(Tags.CATEGORICAL)
     emb_module = mm.EmbeddingFeatures.from_schema(schema)


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->


### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

- Fix bug in `EmbeddingFeatures` serialization when a features with the name `name` is included.
  - When a feature with the name `"name"` is included alongside others. Those that get processed after will be assigned to share the same embedding table. 
    - In the case where the embedding sizes of these features are the same, this wouldn't result in an exception, but would silently produce different results when a model is re-loaded. 
    - If the embeddings were of different sizes, then an exception would be raised along the lines of `Input layer "dense_X" is incompatible: expected axis -1 of input shape to have value 212, but received input with shape (2, 158)`


### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

  - If a feature with `name` is included, then when the class is deserialized, it will ignore and features that are loaded after `name`. Which means the model re-load will not result in the same embedding tables. Resulting in errors when trying to run inference on a reloaded model.
  - Updates and simplifies `from_config` method of `EmbeddingFeatures` to remove the line that caused this error
### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

- added a  test for `EmbeddingFeatures` serialization using `get_config`/`from_config`