### PR TITLE
[WIP] Add initial draft of example notebook using horovod

### DIFF
--- a/examples/usecases/multi-gpu-training.ipynb
+++ b/examples/usecases/multi-gpu-training.ipynb
@@ -1,0 +1,392 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a04a14a4-de2e-4edc-b155-cc6bd1c6a619",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright 2022 NVIDIA Corporation. All Rights Reserved.\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     http://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License.\n",
+    "# ================================"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4a53b0c3-7e92-4309-b70c-90025f801063",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-10-20 07:45:04.202902: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+      "/usr/lib/python3/dist-packages/requests/__init__.py:89: RequestsDependencyWarning: urllib3 (1.26.12) or chardet (3.0.4) doesn't match a supported version!\n",
+      "  warnings.warn(\"urllib3 ({}) or chardet ({}) doesn't match a supported \"\n",
+      "2022-10-20 07:45:05.609926: I tensorflow/core/platform/cpu_feature_guard.cc:194] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "2022-10-20 07:45:07.669736: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1532] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 14742 MB memory:  -> device: 0, name: NVIDIA RTX A6000, pci bus id: 0000:17:00.0, compute capability: 8.6\n",
+      "2022-10-20 07:45:07.670334: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1532] Created device /job:localhost/replica:0/task:0/device:GPU:1 with 46149 MB memory:  -> device: 1, name: NVIDIA RTX A6000, pci bus id: 0000:b3:00.0, compute capability: 8.6\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "\n",
+    "# we can control how much memory to give tensorflow with this environment variable\n",
+    "# IMPORTANT: make sure you do this before you initialize TF's runtime, otherwise\n",
+    "# TF will have claimed all free GPU memory\n",
+    "os.environ[\"TF_MEMORY_ALLOCATION\"] = \"0.3\"  # fraction of free memory\n",
+    "\n",
+    "from nvtabular.loader.tf_utils import configure_tensorflow\n",
+    "\n",
+    "configure_tensorflow()\n",
+    "\n",
+    "import nvtabular as nvt\n",
+    "from nvtabular.ops import *\n",
+    "from merlin.models.utils.example_utils import workflow_fit_transform, save_results\n",
+    "\n",
+    "from merlin.schema.tags import Tags\n",
+    "\n",
+    "import merlin.models.tf as mm\n",
+    "from merlin.io.dataset import Dataset\n",
+    "\n",
+    "import tensorflow as tf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d0c41074-32ef-4753-adf4-13d7b04b39f6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.8/dist-packages/merlin/schema/tags.py:148: UserWarning: Compound tags like Tags.USER_ID have been deprecated and will be removed in a future version. Please use the atomic versions of these tags, like [<Tags.USER: 'user'>, <Tags.ID: 'id'>].\n",
+      "  warnings.warn(\n",
+      "/usr/local/lib/python3.8/dist-packages/merlin/schema/tags.py:148: UserWarning: Compound tags like Tags.ITEM_ID have been deprecated and will be removed in a future version. Please use the atomic versions of these tags, like [<Tags.ITEM: 'item'>, <Tags.ID: 'id'>].\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "from merlin.datasets.synthetic import generate_data\n",
+    "\n",
+    "DATA_FOLDER = os.environ.get(\"DATA_FOLDER\", \"/raid/data/\")\n",
+    "\n",
+    "NUM_ROWS = os.environ.get(\"NUM_ROWS\", 10000000)\n",
+    "SYNTHETIC_DATA = eval(os.environ.get(\"SYNTHETIC_DATA\", \"True\"))\n",
+    "\n",
+    "if SYNTHETIC_DATA:\n",
+    "    train, valid = generate_data(\"aliccp-raw\", int(NUM_ROWS), set_sizes=(0.7, 0.3))\n",
+    "    # save the datasets as parquet files\n",
+    "    train.to_ddf().to_parquet(os.path.join(DATA_FOLDER, \"train\"))\n",
+    "    valid.to_ddf().to_parquet(os.path.join(DATA_FOLDER, \"valid\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0bceb739-6f0b-4f7c-8f0e-acc38f3a10d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_path = os.path.join(DATA_FOLDER, \"train\", \"*.parquet\")\n",
+    "valid_path = os.path.join(DATA_FOLDER, \"valid\", \"*.parquet\")\n",
+    "output_path = os.path.join(DATA_FOLDER, \"processed\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8755fb80-bc3c-40cd-a924-cddbe66d0cde",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "user_id = [\"user_id\"] >> Categorify(freq_threshold=5) >> TagAsUserID()\n",
+    "item_id = [\"item_id\"] >> Categorify(freq_threshold=5) >> TagAsItemID()\n",
+    "add_feat = [\n",
+    "    \"user_item_categories\",\n",
+    "    \"user_item_shops\",\n",
+    "    \"user_item_brands\",\n",
+    "    \"user_item_intentions\",\n",
+    "    \"item_category\",\n",
+    "    \"item_shop\",\n",
+    "    \"item_brand\",\n",
+    "] >> Categorify()\n",
+    "\n",
+    "te_feat = (\n",
+    "    [\"user_id\", \"item_id\"] + add_feat\n",
+    "    >> TargetEncoding([\"click\"], kfold=1, p_smooth=20)\n",
+    "    >> Normalize()\n",
+    ")\n",
+    "\n",
+    "targets = [\"click\"] >> AddMetadata(tags=[Tags.BINARY_CLASSIFICATION, \"target\"])\n",
+    "\n",
+    "outputs = user_id + item_id + targets + add_feat + te_feat\n",
+    "\n",
+    "# Remove rows where item_id==0 and user_id==0\n",
+    "outputs = outputs >> Filter(f=lambda df: (df[\"item_id\"] != 0) & (df[\"user_id\"] != 0))\n",
+    "\n",
+    "workflow_fit_transform(outputs, train_path, valid_path, output_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "934a1523-562f-455b-9ea6-403cdf50a440",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./train.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%writefile './train.py'\n",
+    "\n",
+    "import argparse\n",
+    "import os\n",
+    "import random\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# we can control how much memory to give tensorflow with this environment variable\n",
+    "# IMPORTANT: make sure you do this before you initialize TF's runtime, otherwise\n",
+    "# TF will have claimed all free GPU memory\n",
+    "os.environ[\"TF_MEMORY_ALLOCATION\"] = \"0.3\"  # fraction of free memory\n",
+    "\n",
+    "import cupy\n",
+    "import horovod.tensorflow as hvd\n",
+    "import numpy as np\n",
+    "import tensorflow as tf\n",
+    "\n",
+    "import merlin.models.tf as mm\n",
+    "from merlin.io.dataset import Dataset\n",
+    "from merlin.schema.tags import Tags\n",
+    "#from merlin.models.tf.distributed.backend import hvd\n",
+    "\n",
+    "hvd.init()\n",
+    "\n",
+    "# Seed with system randomness (or a static seed)\n",
+    "os.environ[\"TF_CUDNN_DETERMINISTIC\"] = str(hvd.rank())\n",
+    "random.seed(42)\n",
+    "np.random.seed(42)\n",
+    "tf.random.set_seed(42)\n",
+    "cupy.random.seed(None)\n",
+    "\n",
+    "\n",
+    "def seed_fn():\n",
+    "    \"\"\"\n",
+    "    Generate consistent dataloader shuffle seeds across workers\n",
+    "\n",
+    "    Reseeds each worker's dataloader each epoch to get fresh a shuffle\n",
+    "    that's consistent across workers.\n",
+    "    \"\"\"\n",
+    "    min_int, max_int = tf.int32.limits\n",
+    "    max_rand = max_int // hvd.size()\n",
+    "\n",
+    "    # Generate a seed fragment on each worker\n",
+    "    seed_fragment = cupy.random.randint(0, max_rand).get()\n",
+    "\n",
+    "    # Aggregate seed fragments from all Horovod workers\n",
+    "    seed_tensor = tf.constant(seed_fragment)\n",
+    "    reduced_seed = hvd.allreduce(\n",
+    "        seed_tensor,\n",
+    "        name=\"shuffle_seed\",\n",
+    "        op=hvd.mpi_ops.Sum,\n",
+    "    )\n",
+    "\n",
+    "    return reduced_seed % max_rand\n",
+    "\n",
+    "\n",
+    "def train():\n",
+    "    base_dir = Path(args.base_dir)\n",
+    "    train = Dataset(base_dir / \"train\" / \"*.parquet\")\n",
+    "    ddf = train.to_ddf().repartition(npartitions=hvd.size())\n",
+    "    train = Dataset(ddf, schema=train.schema)\n",
+    "\n",
+    "    train_loader = mm.Loader(\n",
+    "        train,\n",
+    "        schema=train.schema,\n",
+    "        batch_size=args.batch_size,\n",
+    "        shuffle=True,\n",
+    "        drop_last=True,\n",
+    "        seed_fn=seed_fn,\n",
+    "    )\n",
+    "\n",
+    "    target_column = train.schema.select_by_tag(Tags.TARGET).column_names[0]\n",
+    "\n",
+    "    model = mm.DLRMModel(\n",
+    "        train.schema,\n",
+    "        embedding_dim=args.embedding_dim,\n",
+    "        bottom_block=mm.MLPBlock([128, 64]),\n",
+    "        top_block=mm.MLPBlock([128, 64, 32]),\n",
+    "        prediction_tasks=mm.BinaryClassificationTask(target_column),\n",
+    "    )\n",
+    "\n",
+    "    opt = tf.keras.optimizers.Adagrad(learning_rate=args.learning_rate)\n",
+    "    model.compile(optimizer=opt, run_eagerly=False, metrics=[tf.keras.metrics.AUC()])\n",
+    "\n",
+    "    \n",
+    "    model.fit(\n",
+    "        train_loader,\n",
+    "        batch_size=args.batch_size,\n",
+    "    )\n",
+    "\n",
+    "    if hvd.rank() == 0:\n",
+    "        model.save(base_dir)\n",
+    "        print(f\"Training complete. Model saved to {base_dir}\")\n",
+    "\n",
+    "\n",
+    "def parse_args():\n",
+    "    parser = argparse.ArgumentParser()\n",
+    "    parser.add_argument(\"--base_dir\", type=str, default=\"./data\", help=\"Input directory\")\n",
+    "    parser.add_argument(\"--batch_size\", type=int, default=16 * 1024)\n",
+    "    parser.add_argument(\"--learning_rate\", type=float, default=0.03)\n",
+    "    parser.add_argument(\"--embedding_dim\", type=int, default=64)\n",
+    "    args = parser.parse_args()\n",
+    "    return args\n",
+    "\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    args = parse_args()\n",
+    "    train()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "4b25813b-5c06-42e8-9e54-130c15ccf46a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting ./hvd_wrapper.sh\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%writefile './hvd_wrapper.sh'\n",
+    "\n",
+    "#!/bin/bash\n",
+    "\n",
+    "# Get local process ID from OpenMPI or alternatively from SLURM\n",
+    "if [ -z \"${CUDA_VISIBLE_DEVICES:-}\" ]; then\n",
+    "    if [ -n \"${OMPI_COMM_WORLD_LOCAL_RANK:-}\" ]; then\n",
+    "        LOCAL_RANK=\"${OMPI_COMM_WORLD_LOCAL_RANK}\"\n",
+    "    elif [ -n \"${SLURM_LOCALID:-}\" ]; then\n",
+    "        LOCAL_RANK=\"${SLURM_LOCALID}\"\n",
+    "    fi\n",
+    "    export CUDA_VISIBLE_DEVICES=${LOCAL_RANK}\n",
+    "fi\n",
+    "\n",
+    "exec \"$@\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5777d784-dc92-4b2e-96a5-e8d6d680e2bf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2022-10-20 07:45:24.934467: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+      "[1,1]<stderr>:2022-10-20 07:45:27.343749: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+      "[1,0]<stderr>:2022-10-20 07:45:27.343747: I tensorflow/core/util/util.cc:169] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
+      "[1,1]<stderr>:2022-10-20 07:45:30.072011: I tensorflow/core/platform/cpu_feature_guard.cc:194] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
+      "[1,1]<stderr>:To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "[1,0]<stderr>:2022-10-20 07:45:30.074778: I tensorflow/core/platform/cpu_feature_guard.cc:194] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
+      "[1,0]<stderr>:To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "[1,1]<stderr>:2022-10-20 07:45:31.112092: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1532] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 14742 MB memory:  -> device: 0, name: NVIDIA RTX A6000, pci bus id: 0000:b3:00.0, compute capability: 8.6\n",
+      "[1,0]<stderr>:2022-10-20 07:45:31.151544: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1532] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 14742 MB memory:  -> device: 0, name: NVIDIA RTX A6000, pci bus id: 0000:17:00.0, compute capability: 8.6\n",
+      "[1,1]<stderr>:2022-10-20 07:45:33.970259: I tensorflow/stream_executor/cuda/cuda_blas.cc:1804] TensorFloat-32 will be used for the matrix multiplication. This will only be logged once.\n",
+      "[1,0]<stderr>:2022-10-20 07:45:33.979826: I tensorflow/stream_executor/cuda/cuda_blas.cc:1804] TensorFloat-32 will be used for the matrix multiplication. This will only be logged once.\n",
+      "427/427 [==============================] - 12s 17ms/step - loss: 0.6578 - auc: 0.6503 - regularization_loss: 0.0000e+00stdout>ut>:[1,1]<stdout[1,0]<stdout[1,1]<stdout[1,0]<stdout[1,0]<stdout[1,0]<stdout[1,0]<stdout>[1,0]<stdout>[1,1]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,1]<stdout>[1,1]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,0]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,0]<stdout>[1,0]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,0]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,1]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,0]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,0]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,0]<stdout>[1,0]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>[1,1]<stdout>\n",
+      "427/427 [==============================] - 12s 17ms/step - loss: 0.6579 - auc: 0.6503 - regularization_loss: 0.0000e+00stdout>\n",
+      "[1,1]<stderr>:/usr/lib/python3/dist-packages/requests/__init__.py:89: RequestsDependencyWarning: urllib3 (1.26.12) or chardet (3.0.4) doesn't match a supported version!\n",
+      "[1,1]<stderr>:  warnings.warn(\"urllib3 ({}) or chardet ({}) doesn't match a supported \"\n",
+      "[1,1]<stderr>:/usr/local/lib/python3.8/dist-packages/merlin/schema/tags.py:148: UserWarning: Compound tags like Tags.USER_ID have been deprecated and will be removed in a future version. Please use the atomic versions of these tags, like [<Tags.USER: 'user'>, <Tags.ID: 'id'>].\n",
+      "[1,1]<stderr>:  warnings.warn(\n",
+      "[1,1]<stderr>:/usr/local/lib/python3.8/dist-packages/merlin/schema/tags.py:148: UserWarning: Compound tags like Tags.ITEM_ID have been deprecated and will be removed in a future version. Please use the atomic versions of these tags, like [<Tags.ITEM: 'item'>, <Tags.ID: 'id'>].\n",
+      "[1,1]<stderr>:  warnings.warn(\n",
+      "[1,0]<stderr>:/usr/lib/python3/dist-packages/requests/__init__.py:89: RequestsDependencyWarning: urllib3 (1.26.12) or chardet (3.0.4) doesn't match a supported version!\n",
+      "[1,0]<stderr>:  warnings.warn(\"urllib3 ({}) or chardet ({}) doesn't match a supported \"\n",
+      "[1,0]<stderr>:/usr/local/lib/python3.8/dist-packages/merlin/schema/tags.py:148: UserWarning: Compound tags like Tags.USER_ID have been deprecated and will be removed in a future version. Please use the atomic versions of these tags, like [<Tags.USER: 'user'>, <Tags.ID: 'id'>].\n",
+      "[1,0]<stderr>:  warnings.warn(\n",
+      "[1,0]<stderr>:/usr/local/lib/python3.8/dist-packages/merlin/schema/tags.py:148: UserWarning: Compound tags like Tags.ITEM_ID have been deprecated and will be removed in a future version. Please use the atomic versions of these tags, like [<Tags.ITEM: 'item'>, <Tags.ID: 'id'>].\n",
+      "[1,0]<stderr>:  warnings.warn(\n",
+      "[1,0]<stderr>:WARNING:absl:Function `_wrapped_model` contains input name(s) TE_item_brand_click, TE_item_category_click, TE_item_id_click, TE_item_shop_click, TE_user_id_click, TE_user_item_brands_click, TE_user_item_categories_click, TE_user_item_intentions_click, TE_user_item_shops_click with unsupported characters which will be renamed to te_item_brand_click, te_item_category_click, te_item_id_click, te_item_shop_click, te_user_id_click, te_user_item_brands_click, te_user_item_categories_click, te_user_item_intentions_click, te_user_item_shops_click in the SavedModel.\n",
+      "[1,0]<stderr>:WARNING:absl:Found untraced functions such as model_context_layer_call_fn, model_context_layer_call_and_return_conditional_losses, output_layer_layer_call_fn, output_layer_layer_call_and_return_conditional_losses, prediction_layer_call_fn while saving (showing 5 of 92). These functions will not be directly callable after loading.\n",
+      "[1,0]<stdout>:Training complete. Model saved to /raid/data/processed\n"
+     ]
+    }
+   ],
+   "source": [
+    "! horovodrun -np 2 sh hvd_wrapper.sh python train.py --base_dir {output_path}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4a6b4503-4d47-4538-b01a-d9d473cc96ea",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['saved_model.pb', 'keras_metadata.pb', 'assets', 'variables', 'valid', 'train']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(os.listdir(output_path))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
A draft PR that shows the workflow. Depends on #783.

Currently uses a workaround that re-partitions the dataset, i.e., `ddf = train.to_ddf().repartition(npartitions=hvd.size())`.

After some preprocessing with nvtabular, the training code is written out to a file `train.py`. Also note that we use `hvd_wrapper.sh` to set the environment variables. Finally, distributed training is initiated with `horovodrun` in the final code cell via shell command.

Open questions:
- Can we make the usecase cleaner with Ray? https://github.com/horovod/horovod/blob/master/examples/ray/tensorflow2_mnist_ray.py
- An automated test for this notebook might be tricky with `testbook` because `horovodrun` needs to be run from outside of the Python environment.