### PR TITLE
Add `seed` to `TopKMetric` for consistent metrics when ties in ranking

### DIFF
--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -696,7 +696,7 @@ class BaseModel(tf.keras.Model):
         x, _, _ = unpack_x_y_sample_weight(data)
 
         if getattr(self, "predict_pre", None):
-            out = call_layer(self.predict_pr, x, features=x, training=False)
+            out = call_layer(self.predict_pre, x, features=x, training=False)
             if isinstance(out, Prediction):
                 x = out.outputs
             else:

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -141,6 +141,7 @@ def extract_topk(
     labels: tf.Tensor,
     shuffle_ties: bool = False,
     shuffle_ties_epsilon=1e-6,
+    seed=None,
 ) -> Tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
     """Extracts top-k values of predictions, sorting the corresponding
     labels accordingly.
@@ -155,10 +156,11 @@ def extract_topk(
         Tensor with the labels per example
     shuffle_ties : bool, optional
         Adds a small random value to predictions to break ties if any, by default False
-    shuffle_ties_epsilon : _type_, optional
+    shuffle_ties_epsilon : float, optional
         The maximum random value to be added to break ties (used only if shuffle_ties=True),
         by default 1e-6
-
+    seed : int, optional
+        Random seed to use for tie breaking
     Returns
     -------
     Tuple(tf.Tensor,tf.Tensor,tf.Tensor)
@@ -175,6 +177,8 @@ def extract_topk(
 
     if shuffle_ties:
         # Adds a small random value to break ties in the range [0,shuffle_ties_epsilon)
+        if seed is not None:
+            tf.random.set_seed(seed)
         predictions = predictions + (
             tf.random.uniform(tf.shape(predictions)) * shuffle_ties_epsilon
         )

--- a/tests/unit/tf/metrics/test_metrics_topk.py
+++ b/tests/unit/tf/metrics/test_metrics_topk.py
@@ -37,6 +37,17 @@ from merlin.models.tf.metrics.topk import (
 from merlin.models.tf.utils.tf_utils import extract_topk
 
 
+def test_ndcg_with_ties_seed():
+    y_true = tf.constant([1, 1, 1, 2])
+    y_pred = tf.constant([1, 2, 1, 2])
+    results = []
+    for _ in range(10):
+        metric = NDCGAt(4, seed=44)
+        metric.update_state(y_true, y_pred)
+        results.append(metric.result().numpy())
+    assert len(set(results)) == 1
+
+
 @pytest.fixture
 def topk_metrics_test_data():
     labels = tf.convert_to_tensor([[0, 1, 0, 1, 0], [1, 0, 0, 1, 0], [0, 0, 0, 0, 1]], tf.float32)

--- a/tests/unit/tf/transformers/test_block.py
+++ b/tests/unit/tf/transformers/test_block.py
@@ -277,7 +277,7 @@ def test_transformer_with_masked_language_modeling_check_eval_masked(
         run_eagerly=run_eagerly,
         reload_model=True,
         fit_kwargs={"pre": seq_mask_random},
-        metrics=[mm.RecallAt(5000), mm.NDCGAt(5000)],
+        metrics=[mm.RecallAt(5000, seed=42), mm.NDCGAt(5000, seed=42)],
     )
 
     # This transform only extracts targets, but without applying mask

--- a/tests/unit/tf/transformers/test_block.py
+++ b/tests/unit/tf/transformers/test_block.py
@@ -1,3 +1,5 @@
+import itertools
+
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -268,16 +270,17 @@ def test_transformer_with_masked_language_modeling_check_eval_masked(
     )
     seq_mask_random = mm.SequenceMaskRandom(schema=seq_schema, target=target, masking_prob=0.3)
 
-    inputs, targets = next(iter(loader))
-    outputs = model(inputs, targets=targets, training=True)
+    inputs = itertools.islice(iter(loader), 1)
+    outputs = model.predict(inputs, pre=seq_mask_random)
     assert list(outputs.shape) == [8, 4, 51997]
+
     testing_utils.model_test(
         model,
         loader,
         run_eagerly=run_eagerly,
         reload_model=True,
         fit_kwargs={"pre": seq_mask_random},
-        metrics=[mm.RecallAt(5000, seed=42), mm.NDCGAt(5000, seed=42)],
+        metrics=[mm.RecallAt(5000), mm.NDCGAt(5000, seed=4)],
     )
 
     # This transform only extracts targets, but without applying mask


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

- Improve reliability of tests using top-k metrics 

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

- Adds `seed` parameter to TopKMetric classes to ensure results are consistent when evaluation run multiple times on the same data.
- Fixes `pre` parameter when using `model.predict` (typo in variable referenced)

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

- Adds a test for `seed` parameter with NDCGAt

