### PR TITLE
Adding SequenceSummary transforms for transformers

### DIFF
--- a/tests/unit/tf/transformers/test_block.py
+++ b/tests/unit/tf/transformers/test_block.py
@@ -5,7 +5,7 @@ from transformers import BertConfig
 
 import merlin.models.tf as mm
 from merlin.io import Dataset
-from merlin.models.tf.loader import Loader, sample_batch
+from merlin.models.tf.loader import Loader
 from merlin.models.tf.transformers.block import (
     AlbertBlock,
     BertBlock,
@@ -195,11 +195,9 @@ def test_transformer_with_causal_language_modeling(sequence_testing_data: Datase
     assert predictions.shape == (8, 3, 51997)
 
 
-@pytest.mark.parametrize("transformer_cls", [BertBlock, GPT2Block, XLNetBlock, RobertaBlock])
 @pytest.mark.parametrize("run_eagerly", [True, False])
-def test_transformer_with_masked_language_modeling(
-    sequence_testing_data: Dataset, transformer_cls, run_eagerly
-):
+def test_transformer_with_masked_language_modeling(sequence_testing_data: Dataset, run_eagerly):
+
     seq_schema = sequence_testing_data.schema.select_by_tag(Tags.SEQUENCE).select_by_tag(
         Tags.CATEGORICAL
     )
@@ -213,7 +211,8 @@ def test_transformer_with_masked_language_modeling(
                 seq_schema.select_by_tag(Tags.CATEGORICAL), sequence_combiner=None
             ),
         ),
-        transformer_cls(d_model=48, n_head=4, n_layer=2, pre=mm.ReplaceMaskedEmbeddings()),
+        # BertBlock(d_model=48, n_head=8, n_layer=2, pre=mm.ReplaceMaskedEmbeddings()),
+        GPT2Block(d_model=48, n_head=4, n_layer=2, pre=mm.ReplaceMaskedEmbeddings()),
         mm.CategoricalOutput(
             seq_schema.select_by_name(target),
             default_loss="categorical_crossentropy",
@@ -221,7 +220,7 @@ def test_transformer_with_masked_language_modeling(
     )
     seq_mask_random = mm.SequenceMaskRandom(schema=seq_schema, target=target, masking_prob=0.3)
 
-    inputs, targets = sample_batch(sequence_testing_data, batch_size=8, to_ragged=True)
+    inputs, targets = next(iter(loader))
     outputs = model(inputs, targets=targets, training=True)
     assert list(outputs.shape) == [8, 4, 51997]
     testing_utils.model_test(
@@ -246,6 +245,7 @@ def test_transformer_with_masked_language_modeling(
 def test_transformer_with_masked_language_modeling_check_eval_masked(
     sequence_testing_data: Dataset, run_eagerly
 ):
+
     seq_schema = sequence_testing_data.schema.select_by_tag(Tags.SEQUENCE).select_by_tag(
         Tags.CATEGORICAL
     )
@@ -259,6 +259,7 @@ def test_transformer_with_masked_language_modeling_check_eval_masked(
                 seq_schema.select_by_tag(Tags.CATEGORICAL), sequence_combiner=None
             ),
         ),
+        # BertBlock(d_model=48, n_head=8, n_layer=2, pre=mm.ReplaceMaskedEmbeddings()),
         GPT2Block(d_model=48, n_head=4, n_layer=2, pre=mm.ReplaceMaskedEmbeddings()),
         mm.CategoricalOutput(
             seq_schema.select_by_name(target),

--- a/tests/unit/tf/transformers/test_transforms.py
+++ b/tests/unit/tf/transformers/test_transforms.py
@@ -2,6 +2,7 @@ import pytest
 import tensorflow as tf
 from transformers.modeling_tf_outputs import TFBaseModelOutputWithPoolingAndCrossAttentions
 
+from merlin.models.tf.core.base import block_registry
 from merlin.models.tf.transformers import transforms
 
 TRANSFORMER_IN = tf.random.uniform((1, 1, 8))
@@ -51,3 +52,10 @@ def test_transformer_post(in_out):
             tf.assert_equal(out_element, expected_output_element)
     else:
         tf.assert_equal(out, expected_output)
+
+
+@pytest.mark.parametrize("post", ["first", "last", "mean", "cls_index"])
+def test_post(post):
+    transformer_post = block_registry.parse("sequence_" + post)
+
+    assert transformer_post(TRANSFORMER_IN) is not None


### PR DESCRIPTION
Fixes: 
- #824

### Goals :soccer:
In T4Rec we have a `summary_type` that can be passed to transformer-blocks. This PR adds the same transforms but integrates it into the `post`. This allows users to do things like: `BertBlock(..., post="sequence_mean")`.

### Testing Details :mag:
Added a test to ensure correct behaviour.
