### PR TITLE
Ensure metrics passed to `model.compile()` are always reset

### DIFF
--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -375,8 +375,8 @@ class BaseModel(tf.keras.Model):
             out = metrics
 
         for metric in tf.nest.flatten(out):
-            # We need to ensure metrics passed to `compile()` are reset
-            if metric and metric.built:
+            # We ensure metrics passed to `compile()` are reset
+            if metric:
                 metric.reset_state()
         return out
 
@@ -403,8 +403,7 @@ class BaseModel(tf.keras.Model):
                         out[block.full_name] = weighted_metrics[i]
 
         for metric in tf.nest.flatten(out):
-            # We need to ensure metrics passed to `compile()` are reset
-            if metric and metric.built:
+            if metric:
                 metric.reset_state()
 
         return out

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -374,6 +374,10 @@ class BaseModel(tf.keras.Model):
         else:
             out = metrics
 
+        for metric in tf.nest.flatten(out):
+            # We need to ensure metrics passed to `compile()` are reset
+            if metric and metric.built:
+                metric.reset_states()
         return out
 
     def _create_weighted_metrics(self, weighted_metrics=None):
@@ -397,6 +401,11 @@ class BaseModel(tf.keras.Model):
                 else:
                     for i, block in enumerate(self.model_outputs):
                         out[block.full_name] = weighted_metrics[i]
+
+        for metric in tf.nest.flatten(out):
+            # We need to ensure metrics passed to `compile()` are reset
+            if metric and metric.built:
+                metric.reset_states()
 
         return out
 

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -377,7 +377,7 @@ class BaseModel(tf.keras.Model):
         for metric in tf.nest.flatten(out):
             # We need to ensure metrics passed to `compile()` are reset
             if metric and metric.built:
-                metric.reset_states()
+                metric.reset_state()
         return out
 
     def _create_weighted_metrics(self, weighted_metrics=None):
@@ -405,7 +405,7 @@ class BaseModel(tf.keras.Model):
         for metric in tf.nest.flatten(out):
             # We need to ensure metrics passed to `compile()` are reset
             if metric and metric.built:
-                metric.reset_states()
+                metric.reset_state()
 
         return out
 

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -140,7 +140,8 @@ class UpdateCountMetric(tf.keras.metrics.Metric):
         return self.call_count[0]
 
     def reset_state(self):
-        self.call_count.assign(tf.constant([0.0]))
+        if self.built:
+            self.call_count.assign(tf.constant([0.0]))
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -125,14 +125,14 @@ class UpdateCountMetric(tf.keras.metrics.Metric):
 
     def __init__(self, name="update_count_metric", **kwargs):
         super().__init__(name=name, **kwargs)
-        self._built = False
+        self.built = False
 
     def update_state(self, y_true, y_pred, sample_weight=None):
-        if not self._built:
+        if not self.built:
             self.call_count = self.add_weight(
                 "call_count", shape=tf.TensorShape([1]), initializer="zeros"
             )
-            self._built = True
+            self.built = True
 
         self.call_count.assign(self.call_count + tf.constant([1.0]))
 


### PR DESCRIPTION
Fixes #144 

### Goals :soccer:

- Debugging the source of issue #144, I noticed that Keras `.evaluate()` method does not reset metrics defined in the `compile()` methods. 

- While this is ok for almost all use cases where metrics are set for the first time in the `compile`, this is an issue in the case of top-k evaluation where the metrics passed to the `recommender.compile()` were already used in the training of the retrieval model and already contains training results. 

- In fact, our current logic of top-k evaluation is : 
         - Train a retrieval model with top-k metrics.
         - Convert the retrieval model to a top-k recommender.
         - Compile the top-k recommender with the same metrics and run .evaluate() to score over the whole catalog instead of in-batch items. 

- The source of the issue related to Keras not resetting the metrics at the first call of `fit` or `evaluate` that happens after the `compile()` is related to: 
    - When model.compile is called : The [metrics are wrapped](https://github.com/keras-team/keras/blob/v2.10.0/keras/engine/training.py#L729-L734) in a [MetricsContainer](https://github.com/keras-team/keras/blob/v2.10.0/keras/engine/compile_utils.py#L369) saved as self.compiled_metrics
    - The [model.metrics property](https://github.com/keras-team/keras/blob/v2.10.0/keras/engine/training.py#L792-L840) extracts the metrics from the MetricsContainer from `self.compiled_metrics.metrics` 
    - Reset_metrics[ is called prior to evaluation on the dataset](https://github.com/keras-team/keras/blob/v2.10.0/keras/engine/training.py#L1940) which loops through the values returned by self.metrics and calls reset_state
    - However, the first time model.evaluate is called, self.metrics returns [] because the [MetricsContainer doesn't return the metrics since it's not built](https://github.com/keras-team/keras/blob/v2.10.0/keras/engine/compile_utils.py#L438-L443) (according to `MetricsContainer._built` set by default to False).
   - This is why the metrics are not reset the first call to model.evaluate()
   - The [build](https://github.com/keras-team/keras/blob/b80dd12da9c0bc3f569eca3455e77762cf2ee8ef/keras/engine/compile_utils.py#L508) method of  `MetricsContainer` is responsible for building the metrics and set the flag `._built` to True. 
  - So maybe, building the metrics before calling `reset_states` in .evaluate() could fix this issue.

- In the meantime of creating a reproducible code and opening a feature request in Keras for our specific use case, I added a logic inside the base model class of merlin to ensure metrics passed to compile are always reset. 

### Implementation Details :construction:
- Add logic of reset metrics states in `_create_metrics` and `_create_weighted_metrics`
- We need to check that the metric isn't `None` and is `built` ([default value](https://github.com/keras-team/keras/blob/b80dd12da9c0bc3f569eca3455e77762cf2ee8ef/keras/metrics/base_metric.py#L120) of keras metrics) before reset_states  


