### PR TITLE
Quick fix to parse post in transformer when a string is passed in

### DIFF
--- a/merlin/models/tf/transformers/block.py
+++ b/merlin/models/tf/transformers/block.py
@@ -99,6 +99,12 @@ class TransformerBlock(Block):
             transformer_post = block_registry.parse(transformer_post)
         self.transformer_post = transformer_post
 
+        if isinstance(pre, str):
+            pre = block_registry.parse(pre)
+
+        if isinstance(post, str):
+            post = block_registry.parse(post)
+
         self.post = post
         self.pre = pre
 

--- a/tests/unit/tf/transformers/test_block.py
+++ b/tests/unit/tf/transformers/test_block.py
@@ -71,6 +71,22 @@ def test_transformer_encoder_with_list_to_dense(max_seq_length):
         assert list(outputs.shape) == [NUM_ROWS, SEQ_LENGTH, EMBED_DIM]
 
 
+def test_transformer_encoder_with_post():
+    NUM_ROWS = 100
+    SEQ_LENGTH = 10
+    EMBED_DIM = 128
+    inputs = tf.RaggedTensor.from_tensor(tf.random.uniform((NUM_ROWS, SEQ_LENGTH, EMBED_DIM)))
+
+    transformer_encod = mm.TransformerBlock(
+        transformer=BertConfig(hidden_size=EMBED_DIM, num_attention_heads=16),
+        pre=mm.ListToDense(max_seq_length=5),
+        post="sequence_mean",
+    )
+    outputs = transformer_encod(inputs)
+
+    assert list(outputs.shape) == [NUM_ROWS, EMBED_DIM]
+
+
 @pytest.mark.parametrize("encoder", [XLNetBlock, BertBlock, AlbertBlock, RobertaBlock, GPT2Block])
 def test_hf_tranformers_blocks(encoder):
     NUM_ROWS = 100


### PR DESCRIPTION
Fixes 
- #831

### Goals :soccer:
Fixes bug. Now `TransformerBlock(..., post="sequence_mean")` works as expected.