### PR TITLE
Removing automatic broadcasting of contextual-features in aggregation

### DIFF
--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -142,6 +142,7 @@ if is_transformers_available():
     )
 
 from merlin.models.tf.transforms.features import (
+    BroadcastToSequence,
     CategoryEncoding,
     HashedCross,
     HashedCrossAll,
@@ -219,6 +220,7 @@ __all__ = [
     "ToDense",
     "ToTarget",
     "CategoryEncoding",
+    "BroadcastToSequence",
     "HashedCross",
     "HashedCrossAll",
     "ElementwiseSum",

--- a/merlin/models/tf/core/aggregation.py
+++ b/merlin/models/tf/core/aggregation.py
@@ -53,7 +53,6 @@ class ConcatFeatures(TabularAggregation):
         self.output_dtype = output_dtype
 
     def call(self, inputs: TabularData, **kwargs) -> tf.Tensor:
-        self._expand_non_sequential_features(inputs)
         self._check_concat_shapes(inputs)
 
         tensors = []

--- a/merlin/models/tf/core/aggregation.py
+++ b/merlin/models/tf/core/aggregation.py
@@ -253,7 +253,6 @@ class ElementwiseSumItemMulti(ElementwiseFeatureAggregation):
     def call(self, inputs: TabularData, **kwargs) -> tf.Tensor:
         schema: Schema = self.schema  # type: ignore
         item_id_inputs = self.get_item_ids_from_inputs(inputs)
-        self._expand_non_sequential_features(inputs)
         self._check_input_shapes_equal(inputs)
 
         item_id_column = schema.select_by_tag(Tags.ITEM_ID).first.name

--- a/merlin/models/tf/core/aggregation.py
+++ b/merlin/models/tf/core/aggregation.py
@@ -100,7 +100,6 @@ class StackFeatures(TabularAggregation):
         self.output_dtype = output_dtype
 
     def call(self, inputs: TabularData, **kwargs) -> tf.Tensor:
-        self._expand_non_sequential_features(inputs)
         self._check_concat_shapes(inputs)
 
         tensors = []
@@ -227,7 +226,6 @@ class ElementwiseSum(ElementwiseFeatureAggregation):
         self.stack = StackFeatures(axis=0)
 
     def call(self, inputs: TabularData, **kwargs) -> tf.Tensor:
-        self._expand_non_sequential_features(inputs)
         self._check_input_shapes_equal(inputs)
 
         return tf.reduce_sum(self.stack(inputs), axis=0)

--- a/merlin/models/tf/core/tabular.py
+++ b/merlin/models/tf/core/tabular.py
@@ -27,18 +27,6 @@ class TabularAggregation(
     def call(self, inputs: TabularData, **kwargs) -> tf.Tensor:
         raise NotImplementedError()
 
-    def _expand_non_sequential_features(self, inputs: TabularData) -> TabularData:
-        inputs_sizes = {k: v.shape for k, v in inputs.items()}
-        seq_features_shapes, sequence_length = self._get_seq_features_shapes(inputs_sizes)
-
-        if len(seq_features_shapes) > 0:
-            non_seq_features = set(inputs.keys()).difference(set(seq_features_shapes.keys()))
-            for fname in non_seq_features:
-                # Including the 2nd dim and repeating for the sequence length
-                inputs[fname] = tf.tile(tf.expand_dims(inputs[fname], 1), (1, sequence_length, 1))
-
-        return inputs
-
     def _get_seq_features_shapes(self, inputs_sizes: Dict[str, tf.TensorShape]):
         seq_features_shapes = dict()
         for fname, fshape in inputs_sizes.items():

--- a/merlin/models/tf/inputs/base.py
+++ b/merlin/models/tf/inputs/base.py
@@ -136,7 +136,7 @@ def InputBlock(
         sparse_interactions = InputBlock(
             sparse_schema,
             branches,
-            post,
+            post=kwargs.get("post_sparse", None),
             aggregation=agg,
             seq=True,
             max_seq_length=max_seq_length,
@@ -159,7 +159,7 @@ def InputBlock(
         return InputBlock(
             context_schema,
             branches,
-            post,
+            post=kwargs.get("post_context", None),
             aggregation=agg,
             seq=False,
             add_continuous_branch=add_continuous_branch,
@@ -200,7 +200,6 @@ def InputBlock(
             ParallelBlock(branches),
             continuous_projection,
             aggregation=aggregation,
-            post=post,
             name="continuous_projection",
         )
 

--- a/merlin/models/tf/inputs/continuous.py
+++ b/merlin/models/tf/inputs/continuous.py
@@ -84,16 +84,10 @@ class ContinuousFeatures(TabularBlock):
 
     def call(self, inputs, *args, **kwargs):
         cont_features = self.filter_features(inputs)
-        outputs = {}
-        for name, tensor in cont_features.items():
-            if isinstance(tensor, tf.RaggedTensor) and len(tensor.shape) == 2:
-                tensor = tf.expand_dims(tensor, axis=-1)
-            if len(tensor.shape) == 1:
-                tensor = tf.expand_dims(tensor, -1)
-
-            outputs[name] = tensor
-
-        return outputs
+        cont_features = {
+            k: tf.expand_dims(v, -1) if len(v.shape) == 1 else v for k, v in cont_features.items()
+        }
+        return cont_features
 
     def compute_call_output_shape(self, input_shapes):
         cont_features_sizes = self.filter_features.compute_output_shape(input_shapes)


### PR DESCRIPTION
Fixes 
- #814

### Goals :soccer:
This PR fixes a bug w.r.t. broadcasting continuous features to a sequence. Our current approach is to try to infer broadcasting automatically as part of a `aggregation`. This leads to some tricky edge-cases, so this PR removes the automatic broadcast in favor of `BroadcastToSequence`. This is a transformation that can be used as a `post` in the `InputBlock` & `InputBlockV2`.

### Implementation Details :construction:
```python
schema = ...
context_schema = schema.remove_by_tag(Tags.SEQUENCE)
sequence_schema = schema.select_by_tag(Tags.SEQUENCE)

inputs = mm.InputBlock(
  schema, 
  post=ml.BroadcastToSequence(context_schema, sequence_schema)
)

inputs_v2 = mm.InputBlockV2(
  schema, 
  post=ml.BroadcastToSequence(context_schema, sequence_schema)
)

```
