### PR TITLE
Removing mask from PredictionContext, since it's unused

### DIFF
--- a/merlin/models/tf/core/prediction.py
+++ b/merlin/models/tf/core/prediction.py
@@ -25,17 +25,15 @@ TensorLike = Union[tf.Tensor, tf.SparseTensor, tf.RaggedTensor]
 class PredictionContext(NamedTuple):
     features: Dict[str, TensorLike]
     targets: Optional[Union[tf.Tensor, Dict[str, tf.Tensor]]] = None
-    mask: tf.Tensor = (None,)
     training: bool = False
     testing: bool = False
 
     def with_updates(
-        self, targets=None, features=None, mask=None, training=None, testing=None
+        self, targets=None, features=None, training=None, testing=None
     ) -> "PredictionContext":
         return PredictionContext(
             features if features is not None else self.features,
             targets if targets is not None else self.targets,
-            mask if mask is not None else self.mask,
             training or self.training,
             testing or self.testing,
         )
@@ -48,7 +46,6 @@ class PredictionContext(NamedTuple):
         }
 
         if self.training or self.testing:
-            outputs["mask"] = self.mask
             outputs["targets"] = self.targets
 
         return outputs


### PR DESCRIPTION
### Goals :soccer:
Remove un-used property `mask` from `PredictionContext` since it's unused and leads to issues with Keras-layers like `LSTM`.