### PR TITLE
Return Ragged Tensor instead of tuple from dataloader

### DIFF
--- a/merlin/models/loader/backend.py
+++ b/merlin/models/loader/backend.py
@@ -633,8 +633,14 @@ class DataLoader:
                     )
                 X[column_name] = self._to_sparse_tensor(X[column_name], column_name)
 
+        for col_name in X:
+            if isinstance(X[col_name], tuple):
+                values, offsets, diff_offsets, num_rows = self._pull_values_offsets(X[col_name])
+                X[col_name] = self._get_ragged_tensor(values, offsets, diff_offsets, num_rows)
+
         # TODO: use dict for labels as well?
         # would require output layers to match naming
         if len(self.label_names) > 1:
             labels = self._tensor_split(labels, len(self.label_names), axis=1)
+
         return X, labels

--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -161,7 +161,7 @@ from merlin.models.tf.transforms.sequence import (
     SequencePredictRandom,
     SequenceTargetAsInput,
 )
-from merlin.models.tf.transforms.tensor import ExpandDims, ListToDense, ListToRagged, ListToSparse
+from merlin.models.tf.transforms.tensor import ExpandDims, ListToDense, ListToSparse
 from merlin.models.tf.utils import repr_utils
 from merlin.models.tf.utils.tf_utils import TensorInitializer
 
@@ -213,7 +213,6 @@ __all__ = [
     "MatrixFactorizationBlock",
     "QueryItemIdsEmbeddingsBlock",
     "ListToDense",
-    "ListToRagged",
     "ListToSparse",
     "ToSparse",
     "ToDense",

--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -145,6 +145,8 @@ from merlin.models.tf.transforms.features import (
     CategoryEncoding,
     HashedCross,
     HashedCrossAll,
+    RaggedToDense,
+    RaggedToSparse,
     ToDense,
     ToOneHot,
     ToSparse,
@@ -161,7 +163,7 @@ from merlin.models.tf.transforms.sequence import (
     SequencePredictRandom,
     SequenceTargetAsInput,
 )
-from merlin.models.tf.transforms.tensor import ExpandDims, ListToDense, ListToSparse
+from merlin.models.tf.transforms.tensor import ExpandDims
 from merlin.models.tf.utils import repr_utils
 from merlin.models.tf.utils.tf_utils import TensorInitializer
 
@@ -212,11 +214,11 @@ __all__ = [
     "TwoTowerBlock",
     "MatrixFactorizationBlock",
     "QueryItemIdsEmbeddingsBlock",
-    "ListToDense",
-    "ListToSparse",
     "ToSparse",
     "ToDense",
     "ToTarget",
+    "RaggedToDense",
+    "RaggedToSparse",
     "CategoryEncoding",
     "HashedCross",
     "HashedCrossAll",

--- a/merlin/models/tf/inputs/base.py
+++ b/merlin/models/tf/inputs/base.py
@@ -30,7 +30,7 @@ from merlin.models.tf.inputs.embedding import (
     Embeddings,
     SequenceEmbeddingFeatures,
 )
-from merlin.models.tf.transforms.tensor import ListToDense
+from merlin.models.tf.transforms.features import RaggedToDense
 from merlin.schema import Schema, Tags, TagsType
 
 LOG = logging.getLogger("merlin-models")
@@ -177,7 +177,7 @@ def InputBlock(
     ):
         pre = None
         if max_seq_length and seq:
-            pre = ListToDense(max_seq_length)
+            pre = RaggedToDense(max_seq_length=max_seq_length)
         branches["continuous"] = ContinuousFeatures.from_schema(  # type: ignore
             schema,
             tags=continuous_tags,

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -42,12 +42,7 @@ from merlin.models.tf.transforms.tensor import ListToDense, ListToSparse
 # https://github.com/PyCQA/pylint/issues/3613
 # pylint: disable=no-value-for-parameter, unexpected-keyword-arg
 from merlin.models.tf.typing import TabularData
-from merlin.models.tf.utils.tf_utils import (
-    call_layer,
-    df_to_tensor,
-    list_col_to_ragged,
-    tensor_to_df,
-)
+from merlin.models.tf.utils.tf_utils import call_layer, df_to_tensor, tensor_to_df
 from merlin.models.utils import schema_utils
 from merlin.models.utils.doc_utils import docstring_parameter
 from merlin.models.utils.schema_utils import (
@@ -388,9 +383,6 @@ class EmbeddingTable(EmbeddingTableBase):
         return out
 
     def _call_table(self, inputs, **kwargs):
-        if isinstance(inputs, tuple) and len(inputs) == 2:
-            inputs = list_col_to_ragged(inputs)
-
         # Eliminating the last dim==1 of dense tensors before embedding lookup
         if isinstance(inputs, tf.Tensor):
             inputs = tf.squeeze(inputs, axis=-1)

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -36,7 +36,7 @@ from merlin.models.tf.core.tabular import (
     TabularAggregationType,
     TabularBlock,
 )
-from merlin.models.tf.transforms.tensor import ListToDense, ListToSparse
+from merlin.models.tf.transforms.features import RaggedToDense, RaggedToSparse
 
 # pylint has issues with TF array ops, so disable checks until fixed:
 # https://github.com/PyCQA/pylint/issues/3613
@@ -720,7 +720,7 @@ class EmbeddingFeatures(TabularBlock):
         **kwargs,
     ):
         if add_default_pre:
-            embedding_pre = [Filter(list(feature_config.keys())), ListToSparse()]
+            embedding_pre = [Filter(list(feature_config.keys())), RaggedToSparse()]
             pre = [embedding_pre, pre] if pre else embedding_pre  # type: ignore
         self.feature_config = feature_config
         self.l2_reg = l2_reg
@@ -1074,7 +1074,10 @@ class SequenceEmbeddingFeatures(EmbeddingFeatures):
         **kwargs,
     ):
         if add_default_pre:
-            embedding_pre = [Filter(list(feature_config.keys())), ListToDense(max_seq_length)]
+            embedding_pre = [
+                Filter(list(feature_config.keys())),
+                RaggedToDense(max_seq_length=max_seq_length),
+            ]
             pre = [embedding_pre, pre] if pre else embedding_pre  # type: ignore
 
         super().__init__(

--- a/merlin/models/tf/loader.py
+++ b/merlin/models/tf/loader.py
@@ -606,7 +606,7 @@ def sample_batch(
             "Sparse values cannot be converted to both ragged tensors and dense tensors"
         )
 
-    from merlin.models.tf.transforms.tensor import ListToDense, ListToRagged
+    from merlin.models.tf.transforms.features import RaggedToDense
 
     if not isinstance(data, Loader):
         data = Loader(data, batch_size=batch_size, shuffle=shuffle)
@@ -615,10 +615,8 @@ def sample_batch(
     # batch could be of type Prediction, so we can't unpack directly
     inputs, targets = batch[0], batch[1]
 
-    if to_ragged:
-        inputs = ListToRagged()(inputs)
-    elif to_dense:
-        inputs = ListToDense()(inputs)
+    if to_dense:
+        inputs = RaggedToDense()(inputs)
     if not include_targets:
         return inputs
     return inputs, targets

--- a/merlin/models/tf/loader.py
+++ b/merlin/models/tf/loader.py
@@ -496,6 +496,10 @@ class Loader(tf.keras.utils.Sequence, DataLoader):
         )
         return sparse_tensor
 
+    def _get_ragged_tensor(self, values, offsets, diff_offsets, num_rows):
+        ragged = tf.RaggedTensor.from_row_lengths(values=values, row_lengths=diff_offsets)
+        return ragged
+
     def _build_sparse_tensor(self, values, offsets, diff_offsets, num_rows, seq_limit):
         ragged = tf.RaggedTensor.from_row_lengths(values=values, row_lengths=diff_offsets)
         tensor = tf.RaggedTensor.from_tensor(ragged.to_tensor(shape=[None, seq_limit])).to_sparse()

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -27,7 +27,6 @@ from merlin.models.tf.models.utils import parse_prediction_tasks
 from merlin.models.tf.outputs.base import ModelOutput
 from merlin.models.tf.outputs.contrastive import ContrastiveOutput
 from merlin.models.tf.prediction_tasks.base import ParallelPredictionBlock, PredictionTask
-from merlin.models.tf.transforms.tensor import ListToRagged
 from merlin.models.tf.typing import TabularData
 from merlin.models.tf.utils.search_utils import find_all_instances_in_layers
 from merlin.models.tf.utils.tf_utils import (
@@ -1001,9 +1000,8 @@ class Model(BaseModel):
 
     def _maybe_build(self, inputs):
         if isinstance(inputs, dict):
-            _ragged_inputs = ListToRagged()(inputs)
-            feature_shapes = {k: v.shape for k, v in _ragged_inputs.items()}
-            feature_dtypes = {k: v.dtype for k, v in _ragged_inputs.items()}
+            feature_shapes = {k: v.shape for k, v in inputs.items()}
+            feature_dtypes = {k: v.dtype for k, v in inputs.items()}
 
             for block in self.blocks:
                 block._feature_shapes = feature_shapes
@@ -1048,7 +1046,7 @@ class Model(BaseModel):
 
     def call(self, inputs, targets=None, training=False, testing=False, output_context=False):
         context = self._create_context(
-            ListToRagged()(inputs),
+            inputs,
             targets=targets,
             training=training,
             testing=testing,

--- a/merlin/models/tf/transforms/negative_sampling.py
+++ b/merlin/models/tf/transforms/negative_sampling.py
@@ -19,7 +19,6 @@ import tensorflow as tf
 
 from merlin.models.tf.core.prediction import Prediction
 from merlin.models.tf.typing import TabularData
-from merlin.models.tf.utils.tf_utils import list_col_to_ragged
 from merlin.models.utils import schema_utils
 from merlin.schema import Schema, Tags
 
@@ -107,9 +106,6 @@ class InBatchNegatives(tf.keras.layers.Layer):
         item_cols = self.schema.column_names
         outputs = {}
         for name, val in inputs.items():
-            if isinstance(val, tuple):
-                val = list_col_to_ragged(val)
-
             if name in item_cols:
                 negatives = tf.gather(val, sampled_positive_idx)
             else:

--- a/merlin/models/tf/transforms/sequence.py
+++ b/merlin/models/tf/transforms/sequence.py
@@ -18,10 +18,9 @@ from typing import Optional, Tuple, Union
 import tensorflow as tf
 from tensorflow.keras.backend import random_bernoulli
 
-from merlin.models.tf.core.base import Block, BlockType, PredictionOutput
+from merlin.models.tf.core.base import Block, PredictionOutput
 from merlin.models.tf.core.combinators import TabularBlock
 from merlin.models.tf.core.prediction import Prediction
-from merlin.models.tf.transforms.tensor import ListToRagged
 from merlin.models.tf.typing import TabularData
 from merlin.models.tf.utils import tf_utils
 from merlin.models.utils import schema_utils
@@ -96,13 +95,9 @@ class SequenceTransform(TabularBlock):
         self,
         schema: Schema,
         target: Union[str, Tags, ColumnSchema],
-        pre: Optional[BlockType] = None,
         **kwargs,
     ):
-        _pre = ListToRagged()
-        if pre:
-            _pre = _pre.connect(pre)
-        super().__init__(pre=_pre, schema=schema, **kwargs)
+        super().__init__(schema=schema, **kwargs)
 
         self.target = target
         self.target_name = self._get_target(target)

--- a/merlin/models/tf/transforms/tensor.py
+++ b/merlin/models/tf/transforms/tensor.py
@@ -13,111 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Dict, Optional, Union
+from typing import Dict, Union
 
 import tensorflow as tf
 from keras.layers.preprocessing import preprocessing_utils as utils
 
-from merlin.models.tf.core.base import Block
 from merlin.models.tf.core.combinators import TabularBlock
 from merlin.models.tf.typing import TabularData
-from merlin.models.tf.utils.tf_utils import list_col_to_ragged
 
 ONE_HOT = utils.ONE_HOT
 MULTI_HOT = utils.MULTI_HOT
 COUNT = utils.COUNT
-
-
-@Block.registry.register("list-to-sparse")
-@tf.keras.utils.register_keras_serializable(package="merlin.models")
-class ListToSparse(TabularBlock):
-    """Convert all list-inputs to sparse-tensors.
-
-    By default, the dataloader will represent list-columns as a tuple of values & row-lengths.
-
-    """
-
-    def call(self, inputs: TabularData, **kwargs) -> TabularData:
-        outputs = {}
-        for name, val in inputs.items():
-            if isinstance(val, tuple):
-                val = list_col_to_ragged(val)
-            if isinstance(val, tf.RaggedTensor):
-                outputs[name] = val.to_sparse()
-            else:
-                outputs[name] = val
-
-        return outputs
-
-    def compute_output_shape(self, input_shape):
-        return input_shape
-
-
-@Block.registry.register("list-to-dense")
-@tf.keras.utils.register_keras_serializable(package="merlin.models")
-class ListToDense(TabularBlock):
-    """Convert all list-inputs to dense-tensors.
-
-    By default, the dataloader will represent list-columns as a tuple of values & row-lengths.
-
-
-    Parameters
-    ----------
-    max_seq_length : int
-        The maximum length of multi-hot features.
-    """
-
-    def __init__(self, max_seq_length: Optional[int] = None, **kwargs):
-        super().__init__(**kwargs)
-        self.max_seq_length = max_seq_length
-
-    def call(self, inputs: Union[tuple, tf.RaggedTensor, TabularData], **kwargs) -> TabularData:
-        if isinstance(inputs, (tf.RaggedTensor, tuple)):
-            return self._convert_tensor_to_dense(inputs)
-
-        outputs = {}
-        for name, val in inputs.items():
-            outputs[name] = self._convert_tensor_to_dense(val)
-        return outputs
-
-    def compute_output_shape(self, input_shape):
-        if not isinstance(input_shape, dict):
-            return self._get_output_tensor_shape(input_shape)
-
-        outputs = {}
-        for key, val in input_shape.items():
-            outputs[key] = self._get_output_tensor_shape(val)
-        return outputs
-
-    def _get_output_tensor_shape(self, val_shape):
-        if isinstance(val_shape, tuple) and isinstance(val_shape[1], tf.TensorShape):
-            val_shape = val_shape[1]
-            return tf.TensorShape([val_shape[0], self.max_seq_length])
-        if val_shape.rank > 1 and val_shape[-1] != 1:
-            shapes = val_shape.as_list()
-            if self.max_seq_length:
-                shapes[1] = self.max_seq_length
-            return tf.TensorShape(shapes)
-        return tf.TensorShape((val_shape[0]))
-
-    def _convert_tensor_to_dense(self, val):
-        if isinstance(val, tuple):
-            val = list_col_to_ragged(val)
-        if isinstance(val, tf.RaggedTensor):
-            if self.max_seq_length:
-                shape = [None] * val.shape.rank
-                shape[1] = self.max_seq_length
-                val = val.to_tensor(shape=shape)
-            else:
-                val = tf.squeeze(val.to_tensor())
-            return val
-        return tf.squeeze(val)
-
-    def get_config(self):
-        config = super().get_config()
-        config.update({"max_seq_length": self.max_seq_length})
-
-        return config
 
 
 @tf.keras.utils.register_keras_serializable(package="merlin.models")

--- a/merlin/models/tf/transforms/tensor.py
+++ b/merlin/models/tf/transforms/tensor.py
@@ -28,36 +28,6 @@ MULTI_HOT = utils.MULTI_HOT
 COUNT = utils.COUNT
 
 
-@Block.registry.register("list-to-ragged")
-@tf.keras.utils.register_keras_serializable(package="merlin.models")
-class ListToRagged(TabularBlock):
-    """Convert all list (multi-hot/sequential) features to tf.RaggedTensor"""
-
-    def call(self, inputs: TabularData, **kwargs) -> TabularData:
-        outputs = {}
-        for name, val in inputs.items():
-            if isinstance(val, tuple):
-                outputs[name] = list_col_to_ragged(val)
-            else:
-                outputs[name] = val
-
-        return outputs
-
-    def compute_output_shape(self, input_shapes):
-        output_shapes = {}
-        for k, v in input_shapes.items():
-            # If it is a list/sparse feature (in tuple representation), uses the offset as shape
-            if isinstance(v, tuple) and isinstance(v[1], tf.TensorShape):
-                output_shapes[k] = tf.TensorShape([v[1][0], None])
-            else:
-                output_shapes[k] = v
-
-        return output_shapes
-
-    def compute_call_output_shape(self, input_shapes):
-        return self.compute_output_shape(input_shapes)
-
-
 @Block.registry.register("list-to-sparse")
 @tf.keras.utils.register_keras_serializable(package="merlin.models")
 class ListToSparse(TabularBlock):

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -453,13 +453,3 @@ def get_sub_blocks(blocks: Sequence[Block]) -> List[Block]:
                 if type(sub_module) != ModelContext:
                     deque.append(sub_module)
     return list(result_blocks)
-
-
-def list_col_to_ragged(col: Tuple[tf.Tensor, tf.Tensor]):
-    values = col[0][:, 0]
-    row_lengths = col[1][:, 0]
-
-    if row_lengths.dtype.is_floating:
-        row_lengths = tf.cast(row_lengths, tf.int32)
-
-    return tf.RaggedTensor.from_row_lengths(values, row_lengths)

--- a/tests/unit/tf/blocks/test_interactions.py
+++ b/tests/unit/tf/blocks/test_interactions.py
@@ -70,7 +70,7 @@ def test_fm_block_with_multi_hot_categ_features(testing_data: Dataset):
             ),
             "categorical_mhe": mm.SequentialBlock(
                 mm.Filter(cat_schema_multihot),
-                mm.ListToDense(max_seq_length=cat_schema_multihot["categories"].int_domain.max),
+                mm.RaggedToDense(max_seq_length=cat_schema_multihot["categories"].int_domain.max),
                 mm.CategoryEncoding(cat_schema_multihot, sparse=True, output_mode="multi_hot"),
             ),
             "continuous": mm.SequentialBlock(

--- a/tests/unit/tf/models/test_ranking.py
+++ b/tests/unit/tf/models/test_ranking.py
@@ -318,13 +318,13 @@ def test_wide_deep_model_wide_onehot_multihot_feature_interaction(ecommerce_data
         # Multi-hot features
         mm.SequentialBlock(
             mm.Filter(cat_schema_multihot),
-            mm.ListToDense(max_seq_length=6),
+            mm.RaggedToDense(max_seq_length=6),
             mm.CategoryEncoding(cat_schema_multihot, sparse=True, output_mode="multi_hot"),
         ),
         # 2nd level feature interactions of one-hot features
         mm.SequentialBlock(
             mm.Filter(cat_schema),
-            mm.ListToDense(max_seq_length=6),
+            mm.RaggedToDense(max_seq_length=6),
             mm.HashedCrossAll(
                 cat_schema,
                 num_bins=100,

--- a/tests/unit/tf/models/test_retrieval.py
+++ b/tests/unit/tf/models/test_retrieval.py
@@ -349,10 +349,7 @@ def test_youtube_dnn_retrieval(sequence_testing_data: Dataset):
     )
     model.compile(optimizer="adam", run_eagerly=False)
 
-    as_ragged = mm.ListToRagged()
-
     def last_interaction_as_target(inputs, targets):
-        inputs = as_ragged(inputs)
         items = inputs["item_id_seq"]
         _items = items[:, :-1]
         targets = items[:, -1:].flat_values

--- a/tests/unit/tf/outputs/test_classification.py
+++ b/tests/unit/tf/outputs/test_classification.py
@@ -92,7 +92,6 @@ def test_next_item_prediction(sequence_testing_data: Dataset, run_eagerly):
 
 def _next_item_loader(sequence_testing_data: Dataset):
     def _last_interaction_as_target(inputs, targets):
-        inputs = mm.ListToRagged()(inputs)
         items = inputs["item_id_seq"]
         _items = items[:, :-1]
         targets = tf.one_hot(items[:, -1:].flat_values, 51997)

--- a/tests/unit/tf/outputs/test_contrastive.py
+++ b/tests/unit/tf/outputs/test_contrastive.py
@@ -247,7 +247,6 @@ def _retrieval_inputs_(batch_size):
 
 def _next_item_loader(sequence_testing_data: Dataset, to_one_hot=True):
     def _last_interaction_as_target(inputs, targets):
-        inputs = mm.ListToRagged()(inputs)
         items = inputs["item_id_seq"]
         _items = items[:, :-1]
 

--- a/tests/unit/tf/transformers/test_block.py
+++ b/tests/unit/tf/transformers/test_block.py
@@ -61,7 +61,7 @@ def test_transformer_encoder_with_list_to_dense(max_seq_length):
 
     transformer_encod = mm.TransformerBlock(
         transformer=BertConfig(hidden_size=EMBED_DIM, num_attention_heads=16),
-        pre=mm.ListToDense(max_seq_length=max_seq_length),
+        pre=mm.RaggedToDense(max_seq_length=max_seq_length),
     )
     outputs = transformer_encod(inputs)
 

--- a/tests/unit/tf/transforms/test_sequence.py
+++ b/tests/unit/tf/transforms/test_sequence.py
@@ -28,7 +28,7 @@ from merlin.schema import Tags
 def test_seq_predict_next(sequence_testing_data: Dataset, use_loader: bool):
     seq_schema = sequence_testing_data.schema.select_by_tag(Tags.SEQUENCE)
     target = sequence_testing_data.schema.select_by_tag(Tags.ITEM_ID).column_names[0]
-    predict_next = mm.SequencePredictNext(schema=seq_schema, target=target, pre=mm.ListToRagged())
+    predict_next = mm.SequencePredictNext(schema=seq_schema, target=target)
 
     batch = mm.sample_batch(sequence_testing_data, batch_size=8, include_targets=False)
     if use_loader:
@@ -40,9 +40,6 @@ def test_seq_predict_next(sequence_testing_data: Dataset, use_loader: bool):
         output = predict_next(batch)
     output_x, output_y = output
     output_y = output_y[target]
-
-    as_ragged = mm.ListToRagged()
-    batch = as_ragged(batch)
 
     # Checks if sequential input features were truncated in the last position
     for k, v in batch.items():
@@ -74,9 +71,6 @@ def test_seq_predict_last(sequence_testing_data: Dataset, use_loader: bool):
         output = predict_last(batch)
     output_x, output_y = output
     output_y = output_y[target]
-
-    as_ragged = mm.ListToRagged()
-    batch = as_ragged(batch)
 
     # Checks if sequential input features were truncated in the last position
     for k, v in batch.items():
@@ -110,8 +104,6 @@ def test_seq_predict_random(sequence_testing_data: Dataset, use_loader: bool):
     output_x, output_y = output
     output_y = output_y[target]
 
-    as_ragged = mm.ListToRagged()
-    batch = as_ragged(batch)
     batch_size = batch[target].shape[0]
 
     for k, v in batch.items():
@@ -193,9 +185,6 @@ def test_seq_random_masking(sequence_testing_data: Dataset):
     target_mask = output_y._keras_mask
 
     asserts_mlm_target_mask(target_mask)
-
-    as_ragged = mm.ListToRagged()
-    batch = as_ragged(batch)
 
     for k, v in batch.items():
         # Checking if inputs values didn't change

--- a/tests/unit/tf/transforms/test_tensor.py
+++ b/tests/unit/tf/transforms/test_tensor.py
@@ -59,28 +59,3 @@ def test_expand_dims_axis_as_dict():
     assert list(expanded_inputs["cont_feat1"].shape) == [NUM_ROWS]
     assert list(expanded_inputs["cont_feat2"].shape) == [1, NUM_ROWS]
     assert list(expanded_inputs["multi_hot_categ_feat"].shape) == [NUM_ROWS, 1, 4]
-
-
-def test_list_to_dense():
-    NUM_ROWS = 100
-    MAX_LEN = 10
-    inputs = {
-        "cont_feat": tf.random.uniform((NUM_ROWS,)),
-        "multi_hot_categ_feat": tf.RaggedTensor.from_tensor(
-            tf.random.uniform((NUM_ROWS, 4), minval=1, maxval=100, dtype=tf.int32)
-        ),
-        "multi_hot_embedding_feat": tf.RaggedTensor.from_tensor(
-            tf.random.uniform((NUM_ROWS, 4, 32), minval=1, maxval=100, dtype=tf.int32)
-        ),
-    }
-    list_to_dense_op = mm.ListToDense(max_seq_length=MAX_LEN)
-    dense_inputs = list_to_dense_op(inputs)
-    dense_tensor = list_to_dense_op(inputs["multi_hot_embedding_feat"])
-    output_shape = list_to_dense_op.compute_output_shape(inputs["multi_hot_embedding_feat"].shape)
-
-    assert inputs.keys() == dense_inputs.keys()
-    assert list(dense_inputs["cont_feat"].shape) == [NUM_ROWS]
-    assert list(dense_inputs["multi_hot_categ_feat"].shape) == [NUM_ROWS, MAX_LEN]
-    assert list(dense_inputs["multi_hot_embedding_feat"].shape) == [NUM_ROWS, MAX_LEN, 32]
-    assert list(dense_tensor.shape) == [NUM_ROWS, MAX_LEN, 32]
-    assert list(output_shape) == [NUM_ROWS, MAX_LEN, 32]


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Simplify input features to model and layers by updating dataloader to return ragged tensors for list-columns instead of tuple of (values, row_lengths).

Support TensorFlow 2.10 by avoiding bugs related to list-to-ragged conversions.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

- Removes `ListToRagged`
- Renames `ListToDense`/`ListToSparse` to `RaggedToDense`/`RaggedToSparse` and drop support for tuple-like inputs.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
