### PR TITLE
Adding a first property to ParallelBlock

### DIFF
--- a/merlin/models/tf/core/combinators.py
+++ b/merlin/models/tf/core/combinators.py
@@ -516,6 +516,10 @@ class ParallelBlock(TabularBlock):
     def __setitem__(self, key: str, item: "Block"):
         self.parallel_dict[key] = item
 
+    @property
+    def first(self) -> "Block":
+        return self.parallel_values[0]
+
     def add_branch(self, name: str, block: "Block") -> "ParallelBlock":
         if isinstance(self.parallel_layers, dict):
             self.parallel_layers[name] = block


### PR DESCRIPTION
### Goals :soccer:
Tiny PR that adds a `.first` property to a `ParallelBlock`. This is useful for things like weight-tying where you could do:

```python
import merlin.models.tf as mm

inputs = mm.InputBlockV2(schema)
outputs = mm.CategoricalOutput(inputs.select_by_tag(Tags.ITEM_ID).first)
```