### PR TITLE
Update BroadcastToSequence to preseve static dims of inputs

### DIFF
--- a/merlin/models/tf/transforms/features.py
+++ b/merlin/models/tf/transforms/features.py
@@ -840,26 +840,21 @@ class BroadcastToSequence(tf.keras.layers.Layer):
             for k, v in inputs.items():
                 if k in self.sequence_schema.column_names:
                     if isinstance(v, tf.RaggedTensor):
-                        if sequence_length is not None:
-                            sequence_lengths_equal = tf.math.reduce_all(
-                                tf.equal(v.row_lengths(), sequence_length)
-                            )
-                            tf.Assert(
-                                sequence_lengths_equal,
-                                [
-                                    "sequence features must share the same sequence lengths",
-                                    v.row_lengths(),
-                                ],
-                            )
-                        sequence_length = v.row_lengths()
+                        new_sequence_length = v.row_lengths()
                     else:
-                        if sequence_length is not None:
-                            if sequence_length != [v.shape[1]]:
-                                raise ValueError(
-                                    "sequence features must share the same sequence lengths"
-                                    " {}".format(seq_features_shapes)
-                                )
-                        sequence_length = [v.shape[1]]
+                        new_sequence_length = [v.shape[1]]
+                    if sequence_length is not None:
+                        sequence_lengths_equal = tf.math.reduce_all(
+                            tf.equal(new_sequence_length, sequence_length)
+                        )
+                        tf.Assert(
+                            sequence_lengths_equal,
+                            [
+                                "sequence features must share the same sequence lengths",
+                                (sequence_length, new_sequence_length),
+                            ],
+                        )
+                    sequence_length = new_sequence_length
 
         return seq_features_shapes, sequence_length
 

--- a/merlin/models/tf/transforms/features.py
+++ b/merlin/models/tf/transforms/features.py
@@ -887,10 +887,6 @@ class BroadcastToSequence(tf.keras.layers.Layer):
         for k in input_shape:
             if k in self.context_schema.column_names:
                 rest_shape = input_shape[k][1:]
-                # If sequence length is None, we have ragged tensors.
-                # non-batch dims become ragged (None) during transform.
-                if sequence_length is None:
-                    rest_shape = [None] * len(rest_shape)
                 context_shapes[k] = (
                     input_shape[k][:1] + tf.TensorShape([sequence_length]) + rest_shape
                 )

--- a/merlin/models/tf/transforms/features.py
+++ b/merlin/models/tf/transforms/features.py
@@ -862,14 +862,9 @@ class BroadcastToSequence(tf.keras.layers.Layer):
                     if target[fname] is None:
                         continue
                     if isinstance(sequence_length, tf.Tensor):
-                        rows = []
-                        for row, row_sequence_length in zip(target[fname], sequence_length):
-                            rows.append(
-                                tf.RaggedTensor.from_tensor(
-                                    tf.repeat(tf.expand_dims(row, 1), row_sequence_length, axis=0)
-                                )
-                            )
-                        non_seq_target[fname] = tf.stack(rows)
+                        non_seq_target[fname] = tf.RaggedTensor.from_row_lengths(
+                            tf.repeat(target[fname], sequence_length, axis=0), sequence_length
+                        )
                     else:
                         shape = target[fname].shape
                         target_shape = shape[:1] + sequence_length + shape[1:]

--- a/tests/unit/tf/transforms/test_features.py
+++ b/tests/unit/tf/transforms/test_features.py
@@ -741,7 +741,7 @@ class TestBroadcastToSequence(tf.test.TestCase):
     def test_different_sequence_lengths(self):
         context_schema = Schema([ColumnSchema("c1")])
         sequence_schema = Schema([ColumnSchema("s1"), ColumnSchema("s2")])
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(Exception) as exc_info:
             layer = BroadcastToSequence(context_schema, sequence_schema)
             inputs = {
                 "c1": tf.constant([[1], [2]]),

--- a/tests/unit/tf/transforms/test_features.py
+++ b/tests/unit/tf/transforms/test_features.py
@@ -764,6 +764,19 @@ class TestBroadcastToSequence(tf.test.TestCase):
             layer(inputs)
         assert "sequence features must share the same sequence lengths" in str(exc_info.value)
 
+    def test_ragged_and_dense_features(self):
+        context_schema = Schema([ColumnSchema("c1")])
+        sequence_schema = Schema([ColumnSchema("s1"), ColumnSchema("s2")])
+        with pytest.raises(ValueError) as exc_info:
+            layer = BroadcastToSequence(context_schema, sequence_schema)
+            inputs = {
+                "c1": tf.constant([[1], [2]]),
+                "s1": tf.constant([[[1, 2], [3, 4]], [[6, 3], [2, 3]]]),
+                "s2": tf.ragged.constant([[[1, 2], [3, 4]], [[6, 3], [2, 3]]]),
+            }
+            layer(inputs)
+        assert "sequence features must all be ragged or all dense, not both" in str(exc_info.value)
+
     def test_mask_propagation(self):
         masking_layer = tf.keras.layers.Masking(mask_value=0)
         partially_masked_inputs = {

--- a/tests/unit/tf/transforms/test_features.py
+++ b/tests/unit/tf/transforms/test_features.py
@@ -813,6 +813,21 @@ class TestBroadcastToSequence(tf.test.TestCase):
         self.assertAllEqual(output_shape["a"], tf.TensorShape([2, None, None]))
         self.assertAllEqual(output_shape["b"], tf.TensorShape([2, None, None]))
 
+    def test_sequence_embedding(self):
+        embedding = tf.keras.layers.Embedding(6, 4)
+        inputs = {
+            "sequence_embedding": embedding(tf.ragged.constant([[1, 2], [3], [4, 5, 6]])),
+            "context_a": tf.constant([[1], [2], [3]]),
+            "context_b": tf.constant([1, 2, 3]),
+        }
+        context_schema = Schema([ColumnSchema("context_a"), ColumnSchema("context_b")])
+        sequence_schema = Schema([ColumnSchema("sequence_embedding")])
+        broadcast_layer = BroadcastToSequence(context_schema, sequence_schema)
+        outputs = broadcast_layer(inputs)
+        self.assertAllEqual(outputs["sequence_embedding"].shape, tf.TensorShape([3, None, 4]))
+        self.assertAllEqual(outputs["context_a"].shape, tf.TensorShape([3, None, 1]))
+        self.assertAllEqual(outputs["context_b"].shape, tf.TensorShape([3, None]))
+
 
 @pytest.mark.parametrize(
     "only_selected_in_schema",

--- a/tests/unit/tf/transforms/test_features.py
+++ b/tests/unit/tf/transforms/test_features.py
@@ -749,9 +749,20 @@ class TestBroadcastToSequence(tf.test.TestCase):
                 "s2": tf.constant([[[1, 2], [3, 4]], [[6, 3], [2, 3]]]),
             }
             layer(inputs)
-        assert "All sequential features must share the same shape in the first two dims" in str(
-            exc_info.value
-        )
+        assert "sequence features must share the same sequence lengths" in str(exc_info.value)
+
+    def test_different_sequence_lengths_ragged(self):
+        context_schema = Schema([ColumnSchema("c1")])
+        sequence_schema = Schema([ColumnSchema("s1"), ColumnSchema("s2")])
+        with pytest.raises(Exception) as exc_info:
+            layer = BroadcastToSequence(context_schema, sequence_schema)
+            inputs = {
+                "c1": tf.constant([[1], [2]]),
+                "s1": tf.ragged.constant([[[1, 2], [3, 4], [5, 6]], [[6, 3], [2, 3], [7, 3]]]),
+                "s2": tf.ragged.constant([[[1, 2], [3, 4]], [[6, 3], [2, 3]]]),
+            }
+            layer(inputs)
+        assert "sequence features must share the same sequence lengths" in str(exc_info.value)
 
     def test_mask_propagation(self):
         masking_layer = tf.keras.layers.Masking(mask_value=0)


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

- Update BroadcastToSequence to preseve static dims of inputs

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

- The implementation of the broadcasting with `tf.stack` didn't preserve the static dimensions of input features.
- This change updates this with a single call to `tf.RaggedTensor.from_row_lengths` that handles this.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
