### PR TITLE
Update `ParallelBlock.select_by_tag` to handle base case and kwargs

### DIFF
--- a/merlin/models/tf/core/combinators.py
+++ b/merlin/models/tf/core/combinators.py
@@ -483,6 +483,10 @@ class ParallelBlock(TabularBlock):
         -------
         ParallelBlock
         """
+
+        if self.schema is not None and self.schema == self.schema.select_by_tag(tags):
+            return self
+
         if not isinstance(tags, (list, tuple)):
             tags = [tags]
 
@@ -508,7 +512,16 @@ class ParallelBlock(TabularBlock):
 
         if not selected_branches:
             return
-        return ParallelBlock(selected_branches, schema=selected_schemas)
+        return ParallelBlock(
+            selected_branches,
+            schema=selected_schemas,
+            is_input=self.is_input,
+            post=self.post,
+            pre=self.pre,
+            aggregation=self.aggregation,
+            strict=self.strict,
+            automatic_pruning=self.automatic_pruning,
+        )
 
     def __getitem__(self, key) -> "Block":
         return self.parallel_dict[key]

--- a/tests/unit/tf/core/test_combinators.py
+++ b/tests/unit/tf/core/test_combinators.py
@@ -137,7 +137,7 @@ def test_parallel_block_select_by_tags(music_streaming_data):
     assert parallel_block.select_by_tag([Tags.SEQUENCE, Tags.TIME]) is None
 
     # InputBlock is also a ParallelBlock.
-    input_block = mm.InputBlockV2(music_streaming_data.schema)
+    input_block = mm.InputBlockV2(music_streaming_data.schema, aggregation=None)
     item_inputs = input_block.select_by_tag(Tags.ITEM)
     assert sorted(item_inputs.schema.column_names) == [
         "item_category",


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

- Update `ParallelBlock.select_by_tag` to handle base case and kwargs.
  - Motivated by test in  #841

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

- When `ParallelBlock.select_by_tag` is used, return a new ParallelBlock with the same optional args (e.g. pre/post/aggregation/is_input)
  - This is useful when taking a sub-selection of an input_block
- Handle base case where the schema selection results in the same schema as the block itself, so that not all leaf branches need to have a `select_by_tag` implenmentation with a schema



### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

- Adds a test for ParallelBlock with kwargs and sub-selection