### PR TITLE
Replaces GPT2Block by BertBlock in the masked language modeling tests

### DIFF
--- a/tests/unit/tf/transformers/test_block.py
+++ b/tests/unit/tf/transformers/test_block.py
@@ -226,8 +226,7 @@ def test_transformer_with_masked_language_modeling(sequence_testing_data: Datase
                 seq_schema.select_by_tag(Tags.CATEGORICAL), sequence_combiner=None
             ),
         ),
-        # BertBlock(d_model=48, n_head=8, n_layer=2, pre=mm.ReplaceMaskedEmbeddings()),
-        GPT2Block(d_model=48, n_head=4, n_layer=2, pre=mm.ReplaceMaskedEmbeddings()),
+        BertBlock(d_model=48, n_head=8, n_layer=2, pre=mm.ReplaceMaskedEmbeddings()),
         mm.CategoricalOutput(
             seq_schema.select_by_name(target),
             default_loss="categorical_crossentropy",
@@ -274,8 +273,7 @@ def test_transformer_with_masked_language_modeling_check_eval_masked(
                 seq_schema.select_by_tag(Tags.CATEGORICAL), sequence_combiner=None
             ),
         ),
-        # BertBlock(d_model=48, n_head=8, n_layer=2, pre=mm.ReplaceMaskedEmbeddings()),
-        GPT2Block(d_model=48, n_head=4, n_layer=2, pre=mm.ReplaceMaskedEmbeddings()),
+        BertBlock(d_model=48, n_head=8, n_layer=2, pre=mm.ReplaceMaskedEmbeddings()),
         mm.CategoricalOutput(
             seq_schema.select_by_name(target),
             default_loss="categorical_crossentropy",

--- a/tests/unit/tf/transformers/test_block.py
+++ b/tests/unit/tf/transformers/test_block.py
@@ -273,7 +273,8 @@ def test_transformer_with_masked_language_modeling_check_eval_masked(
                 seq_schema.select_by_tag(Tags.CATEGORICAL), sequence_combiner=None
             ),
         ),
-        BertBlock(d_model=48, n_head=8, n_layer=2, pre=mm.ReplaceMaskedEmbeddings()),
+        # BertBlock(d_model=48, n_head=8, n_layer=2, pre=mm.ReplaceMaskedEmbeddings()),
+        GPT2Block(d_model=48, n_head=8, n_layer=2, pre=mm.ReplaceMaskedEmbeddings()),
         mm.CategoricalOutput(
             seq_schema.select_by_name(target),
             default_loss="categorical_crossentropy",
@@ -306,7 +307,7 @@ def test_transformer_with_masked_language_modeling_check_eval_masked(
     def _metrics_almost_equal(metrics1, metrics2):
         return np.all(
             [
-                np.isclose(metrics1[k], metrics2[k])
+                np.isclose(metrics1[k], metrics2[k], atol=1e-05)
                 for k in metrics1
                 if k not in "regularization_loss"
             ]


### PR DESCRIPTION
### Goals :soccer:
Quick fix that replaces in the tests of masked language modeling (auto-encoding) the `GPT2Block` by `BertBlock`, as the former is originally designed for causal language modeling (auto-regressive).
Tests are typically used as reference for examples and by the users, so it is important to have them consistent on how the users should use the blocks in practice.