### PR TITLE
Fixing, adding tests and docstrings to Residual Networks (DenseResidualBlock and DenseMaybeLowRank)

### DIFF
--- a/merlin/models/tf/blocks/mlp.py
+++ b/merlin/models/tf/blocks/mlp.py
@@ -19,7 +19,7 @@ from typing import List, Optional, Union
 import tensorflow as tf
 
 from merlin.models.tf.core.base import Block
-from merlin.models.tf.core.combinators import ResidualBlock, SequentialBlock
+from merlin.models.tf.core.combinators import ResidualBlock, SequentialBlock, TabularAggregationType
 from merlin.models.tf.core.tabular import Filter, tabular_aggregation_registry
 from merlin.models.tf.utils.tf_utils import (
     maybe_deserialize_keras_objects,
@@ -136,32 +136,47 @@ def MLPBlock(
 
 def DenseResidualBlock(
     low_rank_dim: Optional[int] = None,
-    activation="relu",
+    activation: Optional[Union[str, tf.keras.layers.Layer]] = "relu",
     use_bias: bool = True,
     dropout: Optional[float] = None,
     normalization: Optional[Union[str, tf.keras.layers.Layer]] = "batch_norm",
     depth: int = 1,
+    **dense_kwargs,
 ) -> Block:
     """A block that applies a dense residual block to the input.
+    The residual consists in the input summed element-wise with the
+    output of the dense block.
+    The dense block projects the inputs using dense layers to the same output dim.
+    If the input dim is very high dimensional, the low_rank_dim can
+    be used to create a low rank matrix and reduce the necessary number
+    of parameters for this projection.
+
+    Example usage::
+        block = ml.DenseResidualBlock(depth=3).connect(ml.MLPBlock([1]))
 
     Parameters
     ----------
-    low_rank_dim: int
-        The dimension of the low rank matrix.
-    activation: str
-        The activation function to use.
+    low_rank_dim: int, optional
+        The dimension of the low rank matrix. If set, it projects the input to the
+        low_rank_dim (`LR`) and then back to the input dim (`I`) as output.
+        That requires much less parameters (`I*LR + LR*I`) than projecting the
+        inputs dim directly to the same dim (`I*I`). By default None
+    activation: Union[str, tf.keras.layers.Layer], optional
+        The activation function to use. By default "relu"
     use_bias: bool
-        Whether to use a bias in the MLP.
+        Whether to use a bias in the MLP. By default True
     dropout: float
-        The dropout rate to use.
-    normalization: str or Layer
-        The normalization layer to use.
+        The dropout rate to use. By default 0.0
+    normalization: Union[str, tf.keras.layers.Layer], optional
+        The normalization layer to use. By the default None.
     depth: int
-        The number of residual blocks to apply.
+        The number of residual blocks to stack. By default 1
     """
 
     block_layers = []
-    block_layers.append(DenseMaybeLowRank(low_rank_dim, activation=None, use_bias=use_bias))
+    block_layers.append(
+        DenseMaybeLowRank(low_rank_dim, activation=None, use_bias=use_bias, **dense_kwargs)
+    )
     if dropout:
         block_layers.append(tf.keras.layers.Dropout(dropout))
     if normalization:
@@ -178,6 +193,10 @@ def DenseResidualBlock(
 
     if depth > 1:
         return output.repeat(depth - 1)
+    elif depth < 1:
+        raise ValueError(
+            "The depth (number of stacked residual blocks) needs " "to be equal or greater than 1."
+        )
 
     return output
 
@@ -251,24 +270,58 @@ class DenseMaybeLowRank(tf.keras.layers.Layer):
         self,
         low_rank_dim: Optional[int] = None,
         use_bias: bool = True,
-        activation=None,
+        activation: Optional[Union[str, tf.keras.layers.Layer]] = None,
         kernel_initializer: InitializerType = "truncated_normal",
         bias_initializer: InitializerType = "zeros",
         kernel_regularizer: Optional[RegularizerType] = None,
         bias_regularizer: Optional[RegularizerType] = None,
-        pre_aggregation="concat",
+        pre_aggregation: Optional[TabularAggregationType] = "concat",
         dense: Optional[tf.keras.layers.Dense] = None,
         dense_u: Optional[tf.keras.layers.Dense] = None,
         **kwargs,
     ):
+        """A block that projects the inputs the same input dim.
+        If the input dim is very high dimensional, the low_rank_dim can
+        be used to create a low rank matrix and reduce the necessary number
+        of parameters for this projection.
+
+        Parameters
+        ----------
+        low_rank_dim : Optional[int], optional
+            The dimension of the low rank matrix. If set, it projects the input to the
+            low_rank_dim (`LR`) and then back to the input dim (`I`) as output.
+            That requires much less parameters (`I*LR + LR*I`) than projecting the
+            inputs dim directly to the same dim (`I*I`), by default None.
+        use_bias : bool, optional
+            Whether to use a bias in the MLP, by default True
+        activation : Optional[Union[str,tf.keras.layers.Layer]], optional
+            The activation function to use. By default None
+        kernel_initializer: InitializerType
+            Initializer for the kernel weights matrix. Defaults to "glorot_uniform".
+        bias_initializer: InitializerType
+            Initializer for the bias vector. Default to "zeros".
+        kernel_regularizer: Optional[RegularizerType]
+            Regularizer function applied to the kernel weights matrix. Default to None.
+        bias_regularizer: Optional[RegularizerType]
+            Regularizer function applied to the bias vector.  Default to None.
+        pre_aggregation : Optional[TabularAggregationType], optional
+            Aggregation to be done before projection, by default "concat"
+        dense : Optional[tf.keras.layers.Dense], optional
+            An optional dense layer to be used for projection,
+            by default None. If not set it is created internally.
+        dense_u : Optional[tf.keras.layers.Dense], optional
+            An optional dense layer to be called first if low_rank_dim is set,
+            by default None. If not set it is created internally.
+        """
+
         super().__init__(**kwargs)
         self.low_rank_dim = low_rank_dim
         self.use_bias = use_bias
         self.activation = activation
-        self.kernel_initializer = tf.keras.initializers.get(kernel_initializer)
-        self.bias_initializer = tf.keras.initializers.get(bias_initializer)
-        self.kernel_regularizer = tf.keras.regularizers.get(kernel_regularizer)
-        self.bias_regularizer = tf.keras.regularizers.get(bias_regularizer)
+        self.kernel_initializer = kernel_initializer
+        self.bias_initializer = bias_initializer
+        self.kernel_regularizer = kernel_regularizer
+        self.bias_regularizer = bias_regularizer
         self.pre_aggregation = pre_aggregation
         self.dense = dense
         self.dense_u = dense_u
@@ -299,7 +352,7 @@ class DenseMaybeLowRank(tf.keras.layers.Layer):
 
     def call(self, inputs: tf.Tensor, **kwargs) -> tf.Tensor:
         if isinstance(inputs, dict):
-            inputs = tabular_aggregation_registry.parse(self.pre_aggregation)(inputs)
+            inputs = self.pre_aggregation(inputs)
 
         if self.low_rank_dim is None:
             return self.dense(inputs)  # type: ignore
@@ -308,8 +361,7 @@ class DenseMaybeLowRank(tf.keras.layers.Layer):
 
     def compute_output_shape(self, input_shape):
         if isinstance(input_shape, dict):
-            agg = tabular_aggregation_registry.parse(self.pre_aggregation)
-            input_shape = agg.compute_output_shape(input_shape)
+            input_shape = self.pre_aggregation.compute_output_shape(input_shape)
 
         return input_shape
 
@@ -317,26 +369,40 @@ class DenseMaybeLowRank(tf.keras.layers.Layer):
         config = dict(
             low_rank_dim=self.low_rank_dim,
             use_bias=self.use_bias,
-            activation=self.activation,
-            pre_aggregation=self.pre_aggregation,
         )
         config.update(super(DenseMaybeLowRank, self).get_config())
 
-        return maybe_serialize_keras_objects(
+        config = maybe_serialize_keras_objects(
             self,
             config,
             [
-                "dense",
-                "dense_u",
+                "activation",
                 "kernel_initializer",
                 "bias_initializer",
                 "kernel_regularizer",
                 "bias_regularizer",
+                "pre_aggregation",
+                "dense",
+                "dense_u",
             ],
         )
 
+        return config
+
     @classmethod
     def from_config(cls, config):
-        config = maybe_deserialize_keras_objects(config, ["dense", "dense_u"])
+        config = maybe_deserialize_keras_objects(
+            config,
+            [
+                "activation",
+                "kernel_initializer",
+                "bias_initializer",
+                "kernel_regularizer",
+                "bias_regularizer",
+                "pre_aggregation",
+                "dense",
+                "dense_u",
+            ],
+        )
 
         return cls(**config)

--- a/merlin/models/tf/core/base.py
+++ b/merlin/models/tf/core/base.py
@@ -230,7 +230,7 @@ class Block(SchemaMixin, ContextMixin, Layer):
         """
         from merlin.models.tf.core.combinators import SequentialBlock
 
-        repeated = []
+        repeated = [self]
         for _ in range(num):
             repeated.append(self.copy())
 

--- a/tests/unit/tf/blocks/test_mlp.py
+++ b/tests/unit/tf/blocks/test_mlp.py
@@ -149,7 +149,7 @@ def test_dense_residual_block(
         kernel_initializer=kernel_initializer,
         bias_initializer=bias_initializer,
         kernel_regularizer=kernel_regularizer,
-        bias_regularizer=kernel_regularizer,
+        bias_regularizer=bias_regularizer,
     )
 
     batch = ml.sample_batch(testing_data, batch_size=100, include_targets=False)
@@ -161,7 +161,8 @@ def test_dense_residual_block(
 
     res_block = residual_block
     if depth > 1:
-        res_block = residual_block.layers[0]
+        # Checks properties of the last stacked ResidualBlock
+        res_block = residual_block.layers[-1]
 
     assert res_block.aggregation.activation.__name__ == activation
     assert res_block.layers[0].layers[0].dense.units == input_dim
@@ -180,7 +181,7 @@ def test_dense_residual_block(
 
 
 @pytest.mark.parametrize("run_eagerly", [False, True])
-def test_model_with_dense_residual(ecommerce_data: Dataset, run_eagerly: bool, tmp_path):
+def test_model_with_dense_residual(ecommerce_data: Dataset, run_eagerly: bool):
     model = ml.Model.from_block(
         ml.DenseResidualBlock(
             low_rank_dim=32,
@@ -189,8 +190,8 @@ def test_model_with_dense_residual(ecommerce_data: Dataset, run_eagerly: bool, t
             dropout=0.5,
             normalization=tf.keras.layers.BatchNormalization(),
             depth=2,
-            kernel_initializer=regularizers.l2(1e-5),
-            bias_initializer=regularizers.l2(1e-5),
+            kernel_initializer="glorot_uniform",
+            bias_initializer="zeros",
             kernel_regularizer=regularizers.l2(1e-5),
             bias_regularizer=regularizers.l2(1e-5),
         ),

--- a/tests/unit/tf/blocks/test_mlp.py
+++ b/tests/unit/tf/blocks/test_mlp.py
@@ -20,6 +20,7 @@ from tensorflow.keras import regularizers
 
 import merlin.models.tf as ml
 from merlin.io import Dataset
+from merlin.models.tf.utils import testing_utils
 
 
 @pytest.mark.parametrize("dim", [32, 64])
@@ -28,7 +29,7 @@ from merlin.io import Dataset
 @pytest.mark.parametrize(
     "normalization", [None, "batch_norm", tf.keras.layers.BatchNormalization()]
 )
-def test_mlp_block_yoochoose(
+def test_mlp_block(
     testing_data: Dataset,
     dim,
     activation,
@@ -116,3 +117,84 @@ def test_mlp_block_activation_dimensions_length_mismatch():
     with pytest.raises(ValueError) as excinfo:
         _ = ml.MLPBlock(dimensions=[32], activation=["relu", "linear"])
     assert "Activation and Dimensions length mismatch." in str(excinfo.value)
+
+
+@pytest.mark.parametrize("low_rank_dim", [None, 32])
+@pytest.mark.parametrize("depth", [1, 2])
+@pytest.mark.parametrize("dropout", [0.5, None])
+@pytest.mark.parametrize("use_bias", [False, True])
+@pytest.mark.parametrize("normalization", [None, tf.keras.layers.BatchNormalization()])
+def test_dense_residual_block(
+    testing_data: Dataset,
+    low_rank_dim,
+    depth,
+    use_bias,
+    normalization,
+    dropout,
+    activation="selu",
+    kernel_initializer="glorot_uniform",
+    bias_initializer="zeros",
+    kernel_regularizer=regularizers.l2(1e-5),
+    bias_regularizer=regularizers.l2(1e-5),
+):
+    inputs = ml.InputBlockV2(testing_data.schema)
+
+    residual_block = ml.DenseResidualBlock(
+        low_rank_dim=low_rank_dim,
+        activation=activation,
+        use_bias=use_bias,
+        dropout=dropout,
+        normalization=normalization,
+        depth=depth,
+        kernel_initializer=kernel_initializer,
+        bias_initializer=bias_initializer,
+        kernel_regularizer=kernel_regularizer,
+        bias_regularizer=kernel_regularizer,
+    )
+
+    batch = ml.sample_batch(testing_data, batch_size=100, include_targets=False)
+    outputs = inputs(batch)
+    input_dim = outputs.shape[-1]
+    outputs = residual_block(outputs)
+
+    assert list(outputs.shape) == [100, input_dim]
+
+    res_block = residual_block
+    if depth > 1:
+        res_block = residual_block.layers[0]
+
+    assert res_block.aggregation.activation.__name__ == activation
+    assert res_block.layers[0].layers[0].dense.units == input_dim
+    if low_rank_dim is not None:
+        assert res_block.layers[0].layers[0].dense_u.units == low_rank_dim
+    else:
+        assert res_block.layers[0].layers[0].dense_u is None
+
+    if dropout:
+        assert res_block.layers[0].layers[1].rate == dropout
+    if normalization:
+        if normalization == "batch_norm":
+            normalization = tf.keras.layers.BatchNormalization()
+
+        assert res_block.layers[0].layers[-1].__class__.__name__ == normalization.__class__.__name__
+
+
+@pytest.mark.parametrize("run_eagerly", [False, True])
+def test_model_with_dense_residual(ecommerce_data: Dataset, run_eagerly: bool, tmp_path):
+    model = ml.Model.from_block(
+        ml.DenseResidualBlock(
+            low_rank_dim=32,
+            activation="relu",
+            use_bias=True,
+            dropout=0.5,
+            normalization=tf.keras.layers.BatchNormalization(),
+            depth=2,
+            kernel_initializer=regularizers.l2(1e-5),
+            bias_initializer=regularizers.l2(1e-5),
+            kernel_regularizer=regularizers.l2(1e-5),
+            bias_regularizer=regularizers.l2(1e-5),
+        ),
+        ecommerce_data.schema,
+    )
+
+    testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly, reload_model=False)


### PR DESCRIPTION
### Goals :soccer:
Residual Nets have been shown to be very effective for deep networks, like in deep CNN and Transformers.
This PR adds some fixes, improvements, docstrings and tests to `DenseResidualBlock` and `DenseMaybeLowRank`