### PR TITLE
Adding per-batch loss metric (loss_batch)

### DIFF
--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -720,8 +720,11 @@ class BaseModel(tf.keras.Model):
 
         metrics = self.train_compute_metrics(outputs, self.compiled_metrics)
 
-        # Adding regularization loss to metrics
+        # Batch regularization loss
         metrics["regularization_loss"] = tf.reduce_sum(cast_losses_to_common_dtype(self.losses))
+        # Batch loss (the default loss metric from Keras is the incremental average per epoch,
+        # not the actual batch loss)
+        metrics["loss_batch"] = loss
 
         return metrics
 
@@ -744,12 +747,15 @@ class BaseModel(tf.keras.Model):
             # so we need to retrieve top-k negative scores to compute the loss
             outputs = self.pre_eval_topk.call_outputs(outputs)
 
-        self.compute_loss(x, outputs.targets, outputs.predictions, outputs.sample_weight)
+        loss = self.compute_loss(x, outputs.targets, outputs.predictions, outputs.sample_weight)
 
         metrics = self.compute_metrics(outputs)
 
-        # Adding regularization loss to metrics
+        # Batch regularization loss
         metrics["regularization_loss"] = tf.reduce_sum(cast_losses_to_common_dtype(self.losses))
+        # Batch loss (the default loss metric from Keras is the incremental average per epoch,
+        # not the actual batch loss)
+        metrics["loss_batch"] = loss
 
         return metrics
 

--- a/tests/integration/tf/test_ci_01_getting_started.py
+++ b/tests/integration/tf/test_ci_01_getting_started.py
@@ -15,6 +15,7 @@ def test_func(tb):
     metrics = tb.ref("metrics")
     assert sorted(list(metrics.keys())) == [
         "loss",
+        "loss_batch",
         "rating_binary/binary_classification_task/auc",
         "rating_binary/binary_classification_task/binary_accuracy",
         "rating_binary/binary_classification_task/precision",

--- a/tests/integration/tf/test_ci_02_dataschema.py
+++ b/tests/integration/tf/test_ci_02_dataschema.py
@@ -16,6 +16,7 @@ def test_func(tb):
     metrics = tb.ref("metrics")
     assert sorted(list(metrics.keys())) == [
         "loss",
+        "loss_batch",
         "rating_binary/binary_classification_task/auc",
         "rating_binary/binary_classification_task/binary_accuracy",
         "rating_binary/binary_classification_task/precision",

--- a/tests/integration/tf/test_ci_03_exploring_different_models.py
+++ b/tests/integration/tf/test_ci_03_exploring_different_models.py
@@ -24,30 +24,35 @@ def test_func(tb):
     assert sorted(list(metrics_ncf.keys())) == [
         "auc",
         "loss",
+        "loss_batch",
         "regularization_loss",
     ]
     metrics_mlp = tb.ref("metrics_mlp")
     assert sorted(list(metrics_mlp.keys())) == [
         "auc_1",
         "loss",
+        "loss_batch",
         "regularization_loss",
     ]
     metrics_mlp = tb.ref("metrics_wide_n_deep")
     assert sorted(list(metrics_mlp.keys())) == [
         "auc_2",
         "loss",
+        "loss_batch",
         "regularization_loss",
     ]
     metrics_dlrm = tb.ref("metrics_dlrm")
     assert sorted(list(metrics_dlrm.keys())) == [
         "auc_3",
         "loss",
+        "loss_batch",
         "regularization_loss",
     ]
     metrics_dcn = tb.ref("metrics_dcn")
     assert sorted(list(metrics_dcn.keys())) == [
         "auc_4",
         "loss",
+        "loss_batch",
         "regularization_loss",
     ]
     assert os.path.isfile("results.txt")

--- a/tests/integration/tf/test_ci_06_advanced_own_architecture.py
+++ b/tests/integration/tf/test_ci_06_advanced_own_architecture.py
@@ -23,6 +23,7 @@ def test_func(tb):
         "loss",
         "rating_binary/binary_classification_task/auc",
         "regularization_loss",
+        "loss_batch",
         "total_loss",
     ]
     assert os.path.isdir("custom_dlrm")

--- a/tests/unit/tf/core/test_encoder.py
+++ b/tests/unit/tf/core/test_encoder.py
@@ -93,6 +93,7 @@ def test_topk_encoder(music_streaming_data: Dataset):
     assert set(topk_evaluation_metrics.keys()) == set(
         [
             "loss",
+            "loss_batch",
             "mrr_at_10",
             "ndcg_at_10",
             "map_at_10",

--- a/tests/unit/tf/examples/test_01_getting_started.py
+++ b/tests/unit/tf/examples/test_01_getting_started.py
@@ -44,6 +44,7 @@ def test_example_01_getting_started(tb):
             "auc",
             "binary_accuracy",
             "loss",
+            "loss_batch",
             "regularization_loss",
             "precision",
             "recall",

--- a/tests/unit/tf/examples/test_02_dataschema.py
+++ b/tests/unit/tf/examples/test_02_dataschema.py
@@ -60,6 +60,7 @@ def test_example_02_nvt_integration(tb, tmpdir):
             "auc",
             "binary_accuracy",
             "loss",
+            "loss_batch",
             "regularization_loss",
             "precision",
             "recall",

--- a/tests/unit/tf/examples/test_03_exploring_different_models.py
+++ b/tests/unit/tf/examples/test_03_exploring_different_models.py
@@ -21,6 +21,7 @@ def test_example_03_exploring_different_models(tb, tmpdir):
         [
             "auc",
             "loss",
+            "loss_batch",
             "regularization_loss",
         ]
     )
@@ -29,6 +30,7 @@ def test_example_03_exploring_different_models(tb, tmpdir):
         [
             "auc_1",
             "loss",
+            "loss_batch",
             "regularization_loss",
         ]
     )
@@ -37,6 +39,7 @@ def test_example_03_exploring_different_models(tb, tmpdir):
         [
             "auc_2",
             "loss",
+            "loss_batch",
             "regularization_loss",
         ]
     )
@@ -45,6 +48,7 @@ def test_example_03_exploring_different_models(tb, tmpdir):
         [
             "auc_3",
             "loss",
+            "loss_batch",
             "regularization_loss",
         ]
     )
@@ -53,6 +57,7 @@ def test_example_03_exploring_different_models(tb, tmpdir):
         [
             "auc_4",
             "loss",
+            "loss_batch",
             "regularization_loss",
         ]
     )

--- a/tests/unit/tf/examples/test_06_advanced_own_architecture.py
+++ b/tests/unit/tf/examples/test_06_advanced_own_architecture.py
@@ -29,5 +29,5 @@ def test_example_06_defining_own_architecture(tb, tmpdir):
     )
     tb.execute()
     metrics = tb.ref("metrics")
-    assert set(metrics.keys()) == set(["auc", "loss", "regularization_loss"])
+    assert set(metrics.keys()) == set(["auc", "loss", "loss_batch", "regularization_loss"])
     assert os.path.isdir(os.path.join(tmpdir, "custom_dlrm"))

--- a/tests/unit/tf/examples/test_usecase_accelerate_training_by_lazyadam.py
+++ b/tests/unit/tf/examples/test_usecase_accelerate_training_by_lazyadam.py
@@ -25,6 +25,7 @@ def test_usecase_accelerate_training_by_lazyadam(tb):
     assert set(model1_lazyadam.history.history.keys()) == set(
         [
             "loss",
+            "loss_batch",
             "recall_at_10",
             "mrr_at_10",
             "ndcg_at_10",
@@ -36,6 +37,7 @@ def test_usecase_accelerate_training_by_lazyadam(tb):
     assert set(model2_adam.history.history.keys()) == set(
         [
             "loss",
+            "loss_batch",
             "recall_at_10",
             "mrr_at_10",
             "ndcg_at_10",

--- a/tests/unit/tf/examples/test_usecase_ecommerce_session_based.py
+++ b/tests/unit/tf/examples/test_usecase_ecommerce_session_based.py
@@ -37,6 +37,7 @@ def test_usecase_ecommerce_session_based(tb):
     assert set(metrics_mlp.keys()) == set(
         [
             "loss",
+            "loss_batch",
             "recall_at_100",
             "mrr_at_100",
             "ndcg_at_100",
@@ -49,6 +50,7 @@ def test_usecase_ecommerce_session_based(tb):
     assert set(metrics_bi_lstm.keys()) == set(
         [
             "loss",
+            "loss_batch",
             "recall_at_100",
             "mrr_at_100",
             "ndcg_at_100",

--- a/tests/unit/tf/examples/test_usecase_incremental_training_layer_freezing.py
+++ b/tests/unit/tf/examples/test_usecase_incremental_training_layer_freezing.py
@@ -24,6 +24,7 @@ def test_usecase_incremental_training_layer_freezing(tb):
     assert set(model.history.history.keys()) == set(
         [
             "loss",
+            "loss_batch",
             "recall_at_10",
             "mrr_at_10",
             "ndcg_at_10",

--- a/tests/unit/tf/examples/test_usecase_pretrained_embeddings.py
+++ b/tests/unit/tf/examples/test_usecase_pretrained_embeddings.py
@@ -9,4 +9,4 @@ from tests.conftest import REPO_ROOT
 def test_usecase_pretrained_embeddings(tb):
     tb.execute()
     history = tb.ref("history")
-    assert set(history.keys()) == set(["auc", "loss", "regularization_loss"])
+    assert set(history.keys()) == set(["auc", "loss", "loss_batch", "regularization_loss"])

--- a/tests/unit/tf/models/test_ranking.py
+++ b/tests/unit/tf/models/test_ranking.py
@@ -111,6 +111,7 @@ def test_dlrm_model_with_sample_weights_and_weighted_metrics(music_streaming_dat
     assert set(metrics.keys()) == set(
         [
             "loss",
+            "loss_batch",
             "regularization_loss",
             "binary_accuracy",
             "recall",

--- a/tests/unit/tf/models/test_retrieval.py
+++ b/tests/unit/tf/models/test_retrieval.py
@@ -610,7 +610,7 @@ def test_two_tower_retrieval_model_with_metrics(ecommerce_data: Dataset, run_eag
 
     # Checking train metrics
     expected_metrics = ["recall_at_5", "mrr_at_5", "ndcg_at_5", "map_at_5", "precision_at_5"]
-    expected_loss_metrics = ["loss", "regularization_loss"]
+    expected_loss_metrics = ["loss", "loss_batch", "regularization_loss"]
     expected_metrics_all = expected_metrics + expected_loss_metrics
     expected_metrics_valid = [f"val_{k}" for k in expected_metrics_all]
     assert set(losses.history.keys()) == set(expected_metrics_all + expected_metrics_valid)
@@ -655,7 +655,7 @@ def test_two_tower_retrieval_model_with_topk_metrics_aggregator(
 
     # Checking train metrics
     expected_metrics = ["recall_at_5", "mrr_at_5", "ndcg_at_5", "map_at_5", "precision_at_5"]
-    expected_loss_metrics = ["loss", "regularization_loss"]
+    expected_loss_metrics = ["loss", "loss_batch", "regularization_loss"]
     expected_metrics_all = expected_metrics + expected_loss_metrics
     expected_metrics_valid = [f"val_{k}" for k in expected_metrics_all]
     assert set(losses.history.keys()) == set(expected_metrics_all + expected_metrics_valid)
@@ -702,7 +702,7 @@ def test_two_tower_retrieval_model_v2_with_topk_metrics_aggregator(
 
     # Checking train metrics
     expected_metrics = ["recall_at_5", "mrr_at_5", "ndcg_at_5", "map_at_5", "precision_at_5"]
-    expected_loss_metrics = ["loss", "regularization_loss"]
+    expected_loss_metrics = ["loss", "loss_batch", "regularization_loss"]
     expected_metrics_all = expected_metrics + expected_loss_metrics
     expected_metrics_valid = [f"val_{k}" for k in expected_metrics_all]
     assert set(losses.history.keys()) == set(expected_metrics_all + expected_metrics_valid)

--- a/tests/unit/tf/models/test_retrieval.py
+++ b/tests/unit/tf/models/test_retrieval.py
@@ -466,6 +466,7 @@ def test_two_tower_model_with_custom_options(
     assert set(metrics.keys()) == set(
         [
             "loss",
+            "loss_batch",
             "regularization_loss",
             "auc",
             "recall_at_5",
@@ -573,6 +574,7 @@ def test_two_tower_model_v2_with_custom_options(
     assert set(metrics.keys()) == set(
         [
             "loss",
+            "loss_batch",
             "regularization_loss",
             "auc",
             "recall_at_5",

--- a/tests/unit/tf/outputs/test_base.py
+++ b/tests/unit/tf/outputs/test_base.py
@@ -96,15 +96,17 @@ def test_parallel_outputs(ecommerce_data: Dataset, run_eagerly):
 
     _, history = testing_utils.model_test(model, ecommerce_data, run_eagerly=run_eagerly)
 
-    assert list(history.history.keys()) == [
-        "loss",
-        "loss_batch",
-        "click/model_output_loss",
-        "conversion/model_output_loss",
-        "click/model_output/precision",
-        "conversion/model_output/precision",
-        "regularization_loss",
-    ]
+    assert set(list(history.history.keys())) == set(
+        [
+            "loss",
+            "loss_batch",
+            "click/model_output_loss",
+            "conversion/model_output_loss",
+            "click/model_output/precision",
+            "conversion/model_output/precision",
+            "regularization_loss",
+        ]
+    )
 
 
 def _BinaryPrediction(name, **kwargs):

--- a/tests/unit/tf/outputs/test_base.py
+++ b/tests/unit/tf/outputs/test_base.py
@@ -34,6 +34,7 @@ def test_prediction_block(ecommerce_data: Dataset, run_eagerly):
 
     assert set(history.history.keys()) == {
         "loss",
+        "loss_batch",
         "precision",
         "regularization_loss",
     }
@@ -97,6 +98,7 @@ def test_parallel_outputs(ecommerce_data: Dataset, run_eagerly):
 
     assert list(history.history.keys()) == [
         "loss",
+        "loss_batch",
         "click/model_output_loss",
         "conversion/model_output_loss",
         "click/model_output/precision",

--- a/tests/unit/tf/outputs/test_classification.py
+++ b/tests/unit/tf/outputs/test_classification.py
@@ -35,6 +35,7 @@ def test_binary_output(ecommerce_data: Dataset, run_eagerly):
 
     assert set(history.history.keys()) == {
         "loss",
+        "loss_batch",
         "precision",
         "recall",
         "binary_accuracy",
@@ -56,6 +57,7 @@ def test_categorical_output(sequence_testing_data: Dataset, run_eagerly):
 
     assert set(history.history.keys()) == {
         "loss",
+        "loss_batch",
         "ndcg_at_10",
         "precision_at_10",
         "map_at_10",

--- a/tests/unit/tf/outputs/test_contrastive.py
+++ b/tests/unit/tf/outputs/test_contrastive.py
@@ -120,6 +120,7 @@ def test_contrastive_output(ecommerce_data: Dataset, run_eagerly):
 
     assert set(history.history.keys()) == {
         "loss",
+        "loss_batch",
         "ndcg_at_10",
         "precision_at_10",
         "map_at_10",

--- a/tests/unit/tf/outputs/test_regression.py
+++ b/tests/unit/tf/outputs/test_regression.py
@@ -32,6 +32,7 @@ def test_regression_output(ecommerce_data: Dataset, run_eagerly):
 
     assert set(history.history.keys()) == {
         "loss",
+        "loss_batch",
         "root_mean_squared_error",
         "regularization_loss",
     }

--- a/tests/unit/tf/prediction_tasks/test_multi_task.py
+++ b/tests/unit/tf/prediction_tasks/test_multi_task.py
@@ -37,6 +37,7 @@ def test_model_with_multiple_tasks(music_streaming_data: Dataset, task_blocks, r
     assert set(list(metrics.keys())) == set(
         [
             "loss",
+            "loss_batch",
             "regularization_loss",
             "click/binary_classification_task_loss",
             "play_percentage/regression_task_loss",
@@ -72,6 +73,7 @@ def test_mmoe_head(music_streaming_data: Dataset, run_eagerly: bool):
     assert set(metrics.keys()) == set(
         [
             "loss",
+            "loss_batch",
             "click/binary_classification_task_loss",
             "like/binary_classification_task_loss",
             "play_percentage/regression_task_loss",
@@ -151,6 +153,7 @@ def test_mmoe_head_task_specific_sample_weight_and_weighted_metrics(
     assert set(metrics.keys()) == set(
         [
             "loss",
+            "loss_batch",
             "regularization_loss",
             "click/binary_classification_task_auc",
             "click/binary_classification_task_binary_accuracy",
@@ -193,6 +196,7 @@ def test_ple_head(music_streaming_data: Dataset, run_eagerly: bool):
     assert set(metrics.keys()) == set(
         [
             "loss",
+            "loss_batch",
             "click/binary_classification_task_loss",
             "like/binary_classification_task_loss",
             "play_percentage/regression_task_loss",


### PR DESCRIPTION
### Goals :soccer:
By default, TF Keras loss metric is the epoch cumulative average loss, which is reset every epoch as the other metric.
When the loss is unstable (i.e., does not monotonically decrease over time), like reported in #857 , it is hard to figure out in which steps we have loss spikes from the averaged loss metric.

### Goals :soccer:
- Introduce the `loss_batch` metric, that computes the actual per-batch loss (differently from the per-epoch averaged loss from Keras), as can be seen in below plot.

![image](https://user-images.githubusercontent.com/504752/200072283-386a5213-ee4a-4698-979e-083dd48976f5.png)


### Implementation Details :construction:
- Changed our overriden `Model` `train_step()` and `test_step()` to log the `loss_batch` metric.
