### PR TITLE
Fix passing targets to `logits_scaler`

### DIFF
--- a/merlin/models/tf/outputs/base.py
+++ b/merlin/models/tf/outputs/base.py
@@ -140,7 +140,8 @@ class ModelOutput(Layer):
 
         if getattr(self, "logits_scaler", None):
             if isinstance(outputs, tf.Tensor):
-                outputs = Prediction(outputs)
+                targets = kwargs.pop("targets", None)
+                outputs = Prediction(outputs, targets)
             outputs = self.logits_scaler(outputs)
 
         return outputs


### PR DESCRIPTION
Fixes #867 

### Goals :soccer:
- Pass the actual targets to the logits scaler

### Testing Details :mag:
- Add a simple test of training `CategoricalOutputs` with a `logits_temperature` scaling. 
