### PR TITLE
revert tox usage in ci unit test script

### DIFF
--- a/ci/test_unit.sh
+++ b/ci/test_unit.sh
@@ -17,9 +17,4 @@
 #!/bin/bash
 set -e
 
-tox -e py38-gpu $@
-
-# skip multi-gpu testing if any arguments are supplied.
-if [[ $# -eq 0 ]] ; then
-  tox -e py38-multi-gpu
-fi
+pytest --cov-report term --cov merlin -rxs tests/unit


### PR DESCRIPTION
Tox should only be used when you need to build an environment. CI scripts in the ci folder are meant to be leveraged by the container build process, we do NOT want to use tox to create a new environment. We are testing to make sure that the stuff in the containers has everything necessary to run the targeted commit for the project. 