### PR TITLE
remove coverage parameters from pytest call

### DIFF
--- a/ci/test_unit.sh
+++ b/ci/test_unit.sh
@@ -17,4 +17,4 @@
 #!/bin/bash
 set -e
 
-pytest --cov-report term --cov merlin -rxs tests/unit
+pytest -rxs tests/unit


### PR DESCRIPTION
With coverage parameters the pipeline container build fails. Removing them to attempt to get these unit tests to run in container pipeline.