### PR TITLE
Fix two tower model load context variable

### DIFF
--- a/merlin/models/tf/blocks/retrieval/base.py
+++ b/merlin/models/tf/blocks/retrieval/base.py
@@ -195,15 +195,12 @@ class ItemRetrievalScorer(Block):
     def build(self, input_shapes):
         if isinstance(input_shapes, dict):
             query_shape = input_shapes[self.query_name]
-            self.context.add_variable(
-                tf.Variable(
-                    initial_value=tf.zeros([1, query_shape[-1]], dtype=tf.float32),
-                    name="query",
-                    trainable=False,
-                    validate_shape=False,
-                    dtype=tf.float32,
-                    shape=tf.TensorShape([None, query_shape[-1]]),
-                )
+            self.context.add_weight(
+                name="query",
+                shape=query_shape,
+                dtype=tf.float32,
+                trainable=False,
+                initializer=tf.keras.initializers.Zeros(),
             )
 
         super().build(input_shapes)

--- a/merlin/models/tf/core/base.py
+++ b/merlin/models/tf/core/base.py
@@ -94,9 +94,6 @@ class ModelContext(Layer):
     (This is created automatically in the model and doesn't need to be created manually.)
     """
 
-    def add_variable(self, variable):
-        setattr(self, variable.name, variable)
-
     def add_embedding_table(self, name, embedding_table):
         embedding_tables = getattr(self, "embedding_tables", {})
         embedding_tables[name] = embedding_table

--- a/tests/unit/tf/models/test_retrieval.py
+++ b/tests/unit/tf/models/test_retrieval.py
@@ -274,7 +274,7 @@ def test_two_tower_model_save(tmpdir, ecommerce_data: Dataset):
         embedding_options=mm.EmbeddingOptions(infer_embedding_sizes=True),
     )
 
-    testing_utils.model_test(model, dataset, reload_model=False)
+    testing_utils.model_test(model, dataset, reload_model=True)
 
     query_tower = model.retrieval_block.query_block()
     query_tower_path = Path(tmpdir) / "query_tower"


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

- Fixes #498 
- Unblocks #886 

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Enable re-loading of a saved `TwoTowerModel`.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

Reloading a saved `TwoTowerModel` has been failing due to an assertion about unbound variables

```
AssertionError: Found 1 Python objects that were not bound to checkpointed values, likely due to changes in the Python program. Showing 1 of 1 unmatched objects: [<tf.Variable 'query:0' shape=(None, 4) dtype=float32, numpy=array([[0., 0., 0., 0.]], dtype=float32)>]
```

Using the keras `add_weight` method to create the variable intead of creating a `tf.Variable` instance and assigning as an attrribute allows this to bind correctly and be saved/reloaded.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->

Updated existing test for saving two tower model that has been failing when `reload_model=True` 