### PR TITLE
Do not copy source to docs output

### DIFF
--- a/.github/workflows/docs-remove-stale-reviews.yaml
+++ b/.github/workflows/docs-remove-stale-reviews.yaml
@@ -1,0 +1,11 @@
+name: docs-remove-stale-reviews
+
+on:
+  schedule:
+    # 42 minutes after 0:00 UTC on Sundays
+    - cron: "42 0 * * 0"
+  workflow_dispatch:
+
+jobs:
+  remove:
+    uses: nvidia-merlin/.github/.github/workflows/docs-remove-stale-reviews-common.yaml@main

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -109,6 +109,7 @@ html_static_path = []
 source_suffix = [".rst", ".md"]
 
 nbsphinx_allow_errors = True
+html_copy_source = False
 html_show_sourcelink = False
 
 if os.path.exists(gitdir):


### PR DESCRIPTION
Set `html_copy_source` to `False` to
avoid copying the documentation source
files to the output. This should help
reduce the size of the `gh-pages` branch.
