### PR TITLE
Skip retrieval_with_hpo notebook test when optuna is not installed

### DIFF
--- a/tests/unit/tf/examples/test_usecase_retrieval_with_hpo.py
+++ b/tests/unit/tf/examples/test_usecase_retrieval_with_hpo.py
@@ -3,10 +3,7 @@ from testbook import testbook
 
 from tests.conftest import REPO_ROOT
 
-try:
-    import optuna  # noqa: F401
-except ImportError:
-    pytest.skip("No module named 'optuna'", allow_module_level=True)
+optuna = pytest.importorskip("optuna")
 
 
 @testbook(

--- a/tests/unit/tf/examples/test_usecase_retrieval_with_hpo.py
+++ b/tests/unit/tf/examples/test_usecase_retrieval_with_hpo.py
@@ -1,6 +1,12 @@
+import pytest
 from testbook import testbook
 
 from tests.conftest import REPO_ROOT
+
+try:
+    import optuna  # noqa: F401
+except ImportError:
+    pytest.skip("No module named 'optuna'", allow_module_level=True)
 
 
 @testbook(


### PR DESCRIPTION
The retrieval_with_hpo notebook requires `optuna` but the library is not installed at the container level. As a result, the notebook test will fail when we run `pytest` from the `merlin-tensorflow` container or when we run the tests on Jenkins. This PR proposes to skip all tests in `test_usecase_retrieval_with_hpo.py` if `optuna` is not installed. The test will still run on GIthub actions or when we run tox, because it will be installed in [requirements/dev.txt](https://github.com/NVIDIA-Merlin/models/blob/f0805ad747c1ac783e60068ab22fb4980020c090/requirements/dev.txt#L19).