### PR TITLE
Fix the serialization of `SequenceSummary` block

### DIFF
--- a/merlin/models/tf/transformers/transforms.py
+++ b/merlin/models/tf/transformers/transforms.py
@@ -193,6 +193,10 @@ class SequenceSummary(TFSequenceSummary):
         config = SimpleNamespace(summary_type=summary)
         super().__init__(config, initializer_range=initializer_range, **kwargs)
 
+    def get_config(self):
+        config = super().get_config()
+        return config
+
 
 @Block.registry.register("sequence_last")
 @tf.keras.utils.register_keras_serializable(package="merlin.models")

--- a/merlin/models/tf/transformers/transforms.py
+++ b/merlin/models/tf/transformers/transforms.py
@@ -190,12 +190,20 @@ class PrepareTransformerInputs(tf.keras.layers.Layer):
 @tf.keras.utils.register_keras_serializable(package="merlin.models")
 class SequenceSummary(TFSequenceSummary):
     def __init__(self, summary: str, initializer_range: float = 0.02, **kwargs):
+        self.summary = summary
         config = SimpleNamespace(summary_type=summary)
         super().__init__(config, initializer_range=initializer_range, **kwargs)
 
     def get_config(self):
         config = super().get_config()
+        config["summary"] = self.summary
         return config
+
+    @classmethod
+    def from_config(cls, config, custom_objects=None):
+        output = SequenceSummary(**config)
+        output.__class__ = cls
+        return output
 
 
 @Block.registry.register("sequence_last")

--- a/tests/unit/tf/transformers/test_block.py
+++ b/tests/unit/tf/transformers/test_block.py
@@ -141,7 +141,7 @@ def test_transformer_encoder_with_post():
         post="sequence_mean",
     )
     outputs = transformer_encod(inputs)
-
+    testing_utils.assert_serialization(transformer_encod)
     assert list(outputs.shape) == [NUM_ROWS, EMBED_DIM]
 
 


### PR DESCRIPTION
Saving a transformer-based model with `SequenceSummary` as a post block was throwing an error: 
```
E       NotImplementedError: 
E       Layer SequenceMean has arguments ['self', 'initializer_range']
E       in `__init__` and therefore must override `get_config()`.
E       
E       Example:
```

### Goals :soccer:
- Add a `get_config` method to the `SequenceSummary` block


### Testing Details :mag:
- Update the test `test_transformer_encoder_with_post` to check the serialization of the transformer block defined with a `SequenceSummary` post block. 