### PR TITLE
Set upper-bound on numpy version in tox.ini

### DIFF
--- a/merlin/models/tf/loader.py
+++ b/merlin/models/tf/loader.py
@@ -335,10 +335,6 @@ class Loader(merlin.dataloader.tensorflow.Loader):
         self.sparse_as_dense = sparse_as_dense
 
     @property
-    def input_schema(self) -> Schema:
-        return self.dataset.schema
-
-    @property
     def output_schema(self) -> Schema:
         schema = self.input_schema
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ sitepackages = true
 deps =
     -rrequirements/dev.txt
     tensorflow<2.10
+    numpy<1.24
 setenv =
     TF_GPU_ALLOCATOR=cuda_malloc_async
 commands =
@@ -44,6 +45,7 @@ sitepackages = true
 deps =
     -rrequirements/dev.txt
     tensorflow<2.10
+    numpy<1.24
 setenv =
     TF_GPU_ALLOCATOR=cuda_malloc_async
 allowlist_externals =


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Set upper-bound on numpy version in tox.ini. numpy 1.24.0 is incompatible with the latest version of `numba`.

Fixes `SystemError: initialization of _internal failed without raising an exception` from an import `from numba import cuda`

The reason we're getting `numpy==1.24.0` is because it's installed in the Jenkins envionment and we have `sitepackages=true` in our tox config which means we're inheriting the version from the oustide environment.

## Follow-up

We should follow-up with an investigation into what packages are requires from `sitepackages` and whether we're able to set this to false by installing all required packages in the tox env or somehow specify the specific packages that we want to inherit from the system env instead of everything