### PR TITLE
pytest mark notebooks

### DIFF
--- a/tests/unit/tf/examples/test_01_getting_started.py
+++ b/tests/unit/tf/examples/test_01_getting_started.py
@@ -13,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+import pytest
 from testbook import testbook
 
 from tests.conftest import REPO_ROOT
 
 
 @testbook(REPO_ROOT / "examples/01-Getting-started.ipynb", execute=False)
+@pytest.mark.notebook
 def test_example_01_getting_started(tb):
     tb.inject(
         """

--- a/tests/unit/tf/examples/test_02_dataschema.py
+++ b/tests/unit/tf/examples/test_02_dataschema.py
@@ -1,9 +1,11 @@
+import pytest
 from testbook import testbook
 
 from tests.conftest import REPO_ROOT
 
 
 @testbook(REPO_ROOT / "examples/02-Merlin-Models-and-NVTabular-integration.ipynb", execute=False)
+@pytest.mark.notebook
 def test_example_02_nvt_integration(tb, tmpdir):
     tb.inject(
         f"""

--- a/tests/unit/tf/examples/test_03_exploring_different_models.py
+++ b/tests/unit/tf/examples/test_03_exploring_different_models.py
@@ -1,11 +1,13 @@
 import os
 
+import pytest
 from testbook import testbook
 
 from tests.conftest import REPO_ROOT
 
 
 @testbook(REPO_ROOT / "examples/03-Exploring-different-models.ipynb", execute=False)
+@pytest.mark.notebook
 def test_example_03_exploring_different_models(tb, tmpdir):
     tb.inject(
         f"""

--- a/tests/unit/tf/examples/test_04_export_ranking_models.py
+++ b/tests/unit/tf/examples/test_04_export_ranking_models.py
@@ -1,11 +1,13 @@
 import os
 
+import pytest
 from testbook import testbook
 
 from tests.conftest import REPO_ROOT
 
 
 @testbook(REPO_ROOT / "examples/04-Exporting-ranking-models.ipynb", execute=False)
+@pytest.mark.notebook
 def test_example_04_exporting_ranking_models(tb, tmpdir):
     tb.inject(
         f"""

--- a/tests/unit/tf/examples/test_05_export_retrieval_model.py
+++ b/tests/unit/tf/examples/test_05_export_retrieval_model.py
@@ -1,11 +1,13 @@
 import os
 
+import pytest
 from testbook import testbook
 
 from tests.conftest import REPO_ROOT
 
 
 @testbook(REPO_ROOT / "examples/05-Retrieval-Model.ipynb", execute=False)
+@pytest.mark.notebook
 def test_example_05_retrieval_models(tb, tmpdir):
     tb.inject(
         f"""

--- a/tests/unit/tf/examples/test_06_advanced_own_architecture.py
+++ b/tests/unit/tf/examples/test_06_advanced_own_architecture.py
@@ -1,5 +1,6 @@
 import os
 
+import pytest
 from testbook import testbook
 
 from tests.conftest import REPO_ROOT
@@ -8,6 +9,7 @@ from tests.conftest import REPO_ROOT
 @testbook(
     REPO_ROOT / "examples/06-Define-your-own-architecture-with-Merlin-Models.ipynb", execute=False
 )
+@pytest.mark.notebook
 def test_example_06_defining_own_architecture(tb, tmpdir):
     tb.inject(
         f"""

--- a/tests/unit/tf/examples/test_07_train_traditional_models.py
+++ b/tests/unit/tf/examples/test_07_train_traditional_models.py
@@ -13,6 +13,7 @@ pytest.importorskip("implicit")
     REPO_ROOT / "examples/07-Train-traditional-ML-models-using-the-Merlin-Models-API.ipynb",
     execute=False,
 )
+@pytest.mark.notebook
 @pytest.mark.skipif(not HAS_GPU, reason="No GPU available")
 def test_func(tb):
     tb.execute()

--- a/tests/unit/tf/examples/test_usecase_accelerate_training_by_lazyadam.py
+++ b/tests/unit/tf/examples/test_usecase_accelerate_training_by_lazyadam.py
@@ -14,6 +14,7 @@ p = "examples/usecases/accelerate-training-of-large-embedding-tables-by-LazyAdam
     timeout=180,
     execute=False,
 )
+@pytest.mark.notebook
 @pytest.mark.skipif(not HAS_GPU, reason="No GPU available")
 def test_usecase_accelerate_training_by_lazyadam(tb):
     tb.inject(

--- a/tests/unit/tf/examples/test_usecase_data_parallel.py
+++ b/tests/unit/tf/examples/test_usecase_data_parallel.py
@@ -1,3 +1,4 @@
+import pytest
 from testbook import testbook
 
 from tests.conftest import REPO_ROOT
@@ -8,6 +9,7 @@ from tests.conftest import REPO_ROOT
     execute=False,
     timeout=180,
 )
+@pytest.mark.notebook
 def test_usecase_data_parallel(tb, tmpdir):
     tb.inject(
         f"""

--- a/tests/unit/tf/examples/test_usecase_ecommerce_session_based.py
+++ b/tests/unit/tf/examples/test_usecase_ecommerce_session_based.py
@@ -14,6 +14,7 @@ p = "examples/usecases/ecommerce-session-based-next-item-prediction-for-fashion.
     timeout=180,
     execute=False,
 )
+@pytest.mark.notebook
 def test_usecase_ecommerce_session_based(tb):
     tb.inject(
         """

--- a/tests/unit/tf/examples/test_usecase_incremental_training_layer_freezing.py
+++ b/tests/unit/tf/examples/test_usecase_incremental_training_layer_freezing.py
@@ -1,5 +1,6 @@
 # Test is currently breaks in TF 2.10
 
+import pytest
 from testbook import testbook
 
 from tests.conftest import REPO_ROOT
@@ -12,6 +13,7 @@ p = "examples/usecases/incremental-training-with-layer-freezing.ipynb"
     timeout=180,
     execute=False,
 )
+@pytest.mark.notebook
 def test_usecase_incremental_training_layer_freezing(tb):
     tb.inject(
         """

--- a/tests/unit/tf/examples/test_usecase_pretrained_embeddings.py
+++ b/tests/unit/tf/examples/test_usecase_pretrained_embeddings.py
@@ -1,3 +1,4 @@
+import pytest
 from testbook import testbook
 
 from tests.conftest import REPO_ROOT
@@ -6,6 +7,7 @@ from tests.conftest import REPO_ROOT
 @testbook(
     REPO_ROOT / "examples/usecases/entertainment-with-pretrained-embeddings.ipynb", execute=False
 )
+@pytest.mark.notebook
 def test_usecase_pretrained_embeddings(tb):
     tb.execute()
     history = tb.ref("history")

--- a/tests/unit/tf/examples/test_usecase_retrieval_with_hpo.py
+++ b/tests/unit/tf/examples/test_usecase_retrieval_with_hpo.py
@@ -9,6 +9,7 @@ optuna = pytest.importorskip("optuna")
 @testbook(
     REPO_ROOT / "examples/usecases/retrieval-with-hyperparameter-optimization.ipynb", execute=False
 )
+@pytest.mark.notebook
 def test_usecase_pretrained_embeddings(tb):
     tb.inject(
         """

--- a/tests/unit/tf/examples/test_usecase_transformers_next_item_prediction.py
+++ b/tests/unit/tf/examples/test_usecase_transformers_next_item_prediction.py
@@ -11,6 +11,7 @@ pytest.importorskip("transformers")
     timeout=180,
     execute=False,
 )
+@pytest.mark.notebook
 def test_next_item_prediction(tb):
     tb.inject(
         """


### PR DESCRIPTION
This PR adds `pytest.mark.notebook` to tests that run notebook examples. The motivation is to make it easy to skip these tests that are often resource heavy and take long by simply adding `-m "not notebook"` to the pytest command, e.g., `python -m pytest tests/unit/tf/ -m "not notebook"`.

The plan is to follow up with another PR ([draft](https://github.com/NVIDIA-Merlin/core/pull/193)) that adds `-m "not notebook"` to the [pytest command in Merlin Core](https://github.com/NVIDIA-Merlin/core/blob/368cbbdacc6aeb4d3e78fbd86636fe3967679e88/tox.ini#L72) which is running Models tests, but not being able to filter out the notebook tests often results in github actions running out of resources and throwing an error.