### PR TITLE
remove transform parameter from loader

### DIFF
--- a/merlin/models/tf/loader.py
+++ b/merlin/models/tf/loader.py
@@ -198,8 +198,6 @@ class Loader(merlin.dataloader.tensorflow.Loader):
         `reader_kwargs` will be ignored
     batch_size: int
         Number of samples to yield at each iteration
-    transform: Union[Callable, SchemaAwareTransform], optional
-        Transformation to apply to each batch of data.
     label_names: list(str)
         Column name of the target variable in the dataframe specified by
         `paths_or_dataset`
@@ -250,7 +248,6 @@ class Loader(merlin.dataloader.tensorflow.Loader):
         self,
         paths_or_dataset,
         batch_size,
-        transform=None,
         label_names=None,
         feature_columns=None,
         cat_names=None,


### PR DESCRIPTION
A follow-up to #845 

### Goals :soccer:
Remove `transform` parameter from `merlin.models.tf.Loader`.

### Implementation Details :construction:
The `transform` parameter was removed when we migrated the loader to use the dataloader package, in favor of dataloader's `transforms` (with an s). As a result, the `transform` parameter will not do anything even if it's used, and not removing it was a miss in the previous PR. This PR properly cleans up the unused parameter.

### Testing Details :mag:
Existing tests.
