### PR TITLE
Update tox.ini gpu test to use github actions

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,0 +1,5 @@
+-r dev.txt
+-r pytorch.txt
+
+tensorflow<2.10
+numpy<1.24

--- a/tox.ini
+++ b/tox.ini
@@ -10,20 +10,10 @@ commands =
     pip install -e .[all]
 
 [testenv:py38-gpu]
-passenv = 
-    OPAL_PREFIX
-    WANDB_API_KEY
-sitepackages = true
-; Runs in: Internal Jenkins
+; Runs in: Github Actions
 ; Runs GPU-based tests.
-; The jenkins jobs run on an image based on merlin-hugectr. This will include all cudf configuration
-; and other gpu-specific libraries that we can enxpect will always exist. Thus, we don't need
-; to install requirements.txt yet. As we get better at python environment isolation, we will
-; need to add some back.
 deps =
-    -rrequirements/dev.txt
-    tensorflow<2.10
-    numpy<1.24
+    -rrequirements/test.txt
 setenv =
     TF_GPU_ALLOCATOR=cuda_malloc_async
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -17,10 +17,10 @@ deps =
 setenv =
     TF_GPU_ALLOCATOR=cuda_malloc_async
 commands =
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/nvtabular.git
-    python -m pytest --cov-report term --cov merlin -rxs {posargs:tests/unit}
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git@{posargs:main}
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/nvtabular.git@{posargs:main}
+    python -m pytest --cov-report term --cov merlin -rxs tests/unit/
 
 [testenv:py38-multi-gpu]
 passenv =


### PR DESCRIPTION
Jenkins is dead. This PR updates `tox.ini` to run [tox -e py38-gpu -- $branch](https://github.com/NVIDIA-Merlin/models/blob/642f77f91ca36bfd43b4a3cf08ecbdc27291968a/.github/workflows/gpu-ci.yml#L30) on github actions.