### PR TITLE
Removing from Loader unused 'transform' and 'multi_target_as_dict' constructor args

### DIFF
--- a/merlin/models/tf/loader.py
+++ b/merlin/models/tf/loader.py
@@ -198,8 +198,6 @@ class Loader(merlin.dataloader.tensorflow.Loader):
         `reader_kwargs` will be ignored
     batch_size: int
         Number of samples to yield at each iteration
-    transform: Union[Callable, SchemaAwareTransform], optional
-        Transformation to apply to each batch of data.
     label_names: list(str)
         Column name of the target variable in the dataframe specified by
         `paths_or_dataset`
@@ -250,7 +248,6 @@ class Loader(merlin.dataloader.tensorflow.Loader):
         self,
         paths_or_dataset,
         batch_size,
-        transform=None,
         label_names=None,
         feature_columns=None,
         cat_names=None,
@@ -267,7 +264,6 @@ class Loader(merlin.dataloader.tensorflow.Loader):
         drop_last=False,
         sparse_names=None,
         sparse_max=None,
-        multi_label_as_dict=True,
         sparse_as_dense=False,
         schema=None,
     ):

--- a/tests/unit/tf/models/test_ranking.py
+++ b/tests/unit/tf/models/test_ranking.py
@@ -87,7 +87,7 @@ def test_dlrm_model_with_sample_weights_and_weighted_metrics(music_streaming_dat
         sample_weight = tf.cast(features.pop(sample_weight_col_name), tf.float32)
         return features, labels, sample_weight
 
-    loader = mm.Loader(music_streaming_data, batch_size=10, transform=add_sample_weight)
+    loader = mm.Loader(music_streaming_data, batch_size=10).map(add_sample_weight)
     batch = next(iter(loader))
 
     model = mm.DLRMModel(

--- a/tests/unit/tf/test_loader.py
+++ b/tests/unit/tf/test_loader.py
@@ -42,7 +42,7 @@ def test_lazy_dataset_map():
         time.sleep(sleep_time_seconds)
         return (x, y)
 
-    loader = mm.Loader(dataset, batch_size=10, transform=identity)
+    loader = mm.Loader(dataset, batch_size=10).map(identity)
 
     elapsed_time_seconds = timeit.timeit(lambda: next(iter(loader)), number=1)
 


### PR DESCRIPTION

### Goals :soccer:
This PR removes from Loader unused 'transform' and 'multi_target_as_dict' constructor args

### Testing Details :mag:
The tests that were using `Loader(..., transform=...)` were updated to use `Loader.map()`, which is the new recommended way.
