### PR TITLE
Use tf.function for list column operations

### DIFF
--- a/merlin/models/tf/outputs/topk.py
+++ b/merlin/models/tf/outputs/topk.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 from tensorflow.keras.layers import Layer
 
 import merlin.io
-from merlin.core.dispatch import DataFrameType
+from merlin.core.dispatch import DataFrameType, make_df
 from merlin.models.tf.core.base import Block, block_registry
 from merlin.models.tf.core.prediction import Prediction, TopKPrediction
 from merlin.models.tf.outputs.base import MetricsFn, ModelOutput
@@ -100,7 +100,7 @@ class TopKLayer(Layer):
         if check_unique_ids:
             self._check_unique_ids(data=data)
         values = tf_utils.df_to_tensor(data)
-        ids = tf_utils.df_to_tensor(data.index)
+        ids = tf_utils.df_to_tensor(make_df({"index": data.index}))
 
         if len(ids.shape) == 2:
             ids = tf.squeeze(ids)

--- a/merlin/models/tf/transforms/features.py
+++ b/merlin/models/tf/transforms/features.py
@@ -881,6 +881,7 @@ class BroadcastToSequence(tf.keras.layers.Layer):
 
         return seq_features_shapes, sequence_length
 
+    @tf.function
     def _broadcast(self, inputs, target):
         seq_features_shapes, sequence_length = self._get_seq_features_shapes(inputs)
         if len(seq_features_shapes) > 0:

--- a/merlin/models/tf/transforms/sequence.py
+++ b/merlin/models/tf/transforms/sequence.py
@@ -371,6 +371,7 @@ class SequenceTargetAsInput(SequenceTransform):
         so that the tensors sequences can be processed
     """
 
+    @tf.function
     def call(
         self, inputs: TabularData, targets=None, training=False, testing=False, **kwargs
     ) -> Prediction:
@@ -441,6 +442,7 @@ class SequenceMaskRandom(SequenceTargetAsInput):
         self.masking_prob = masking_prob
         super().__init__(schema, target, **kwargs)
 
+    @tf.function
     def compute_mask(self, inputs, mask=None):
         """Selects (masks) some positions of the targets to be predicted.
         This method is called by Keras after call()

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -459,6 +459,7 @@ def get_sub_blocks(blocks: Sequence[Block]) -> List[Block]:
     return list(result_blocks)
 
 
+@tf.function
 def list_col_to_ragged(col: Tuple[tf.Tensor, tf.Tensor]):
     values = col[0][:, 0]
     row_lengths = col[1][:, 0]

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,5 @@
 -r dev.txt
 -r pytorch.txt
 
-tensorflow<2.10
+tensorflow<2.11
 numpy<1.24

--- a/tests/unit/tf/test_loader.py
+++ b/tests/unit/tf/test_loader.py
@@ -72,17 +72,29 @@ def test_nested_list():
     )
 
     batch = next(iter(loader))
+
     # [[1,2,3],[3,1],[...],[]]
-    nested_data_col = tf.RaggedTensor.from_row_lengths(
-        batch[0]["data"][0][:, 0], tf.cast(batch[0]["data"][1][:, 0], tf.int32)
-    ).to_tensor()
+    @tf.function
+    def _ragged_for_nested_data_col():
+        nested_data_col = tf.RaggedTensor.from_row_lengths(
+            batch[0]["data"][0][:, 0], tf.cast(batch[0]["data"][1][:, 0], tf.int32)
+        ).to_tensor()
+        return nested_data_col
+
+    nested_data_col = _ragged_for_nested_data_col()
     true_data_col = tf.reshape(
         tf.ragged.constant(df.iloc[:batch_size, 0].tolist()).to_tensor(), [batch_size, -1]
     )
+
     # [1,2,3]
-    multihot_data2_col = tf.RaggedTensor.from_row_lengths(
-        batch[0]["data2"][0][:, 0], tf.cast(batch[0]["data2"][1][:, 0], tf.int32)
-    ).to_tensor()
+    @tf.function
+    def _ragged_for_multihot_data_col():
+        multihot_data2_col = tf.RaggedTensor.from_row_lengths(
+            batch[0]["data2"][0][:, 0], tf.cast(batch[0]["data2"][1][:, 0], tf.int32)
+        ).to_tensor()
+        return multihot_data2_col
+
+    multihot_data2_col = _ragged_for_multihot_data_col()
     true_data2_col = tf.reshape(
         tf.ragged.constant(df.iloc[:batch_size, 1].tolist()).to_tensor(), [batch_size, -1]
     )


### PR DESCRIPTION
Addresses https://github.com/NVIDIA-Merlin/dataloader/issues/74.

### Goals :soccer:
In Tensorflow >= 2.10, there seems to be a race condition or some thread safety issue when Dataloader is loading list columns. The errors described in the above issue happen non-deterministically. When the list column tensors are copied successfully by the time tensorflow begins its execution, the tests run successfully. If the copy is incomplete, the tests fail. This PR proposes a workaround for this issue by using the `@tf.function` decorator on the methods that involve list columns.

### Implementation Details :construction:

Some observations:
1. This does not happen on CPU, and only happens on GPUs.
2. This does not happen in graph mode, and only happens in eager mode.

The above two observations suggest two workarounds:
1. Move the problematic operations to CPU (by using `with tf.device("CPU")`).
2. Take the problematic operations out of eager execution and convert them to graph executions (by using `tf.function`).

The second workaround seems to be the superior approach. One could also argue that _all_ methods, not just the ones involving list columns, that were written in eager mode should be wrapped with `@tf.function` for efficiency. However, I consider it to be out of scope for this PR. This PR has the minimum changes required to have the unit tests complete successfully; the `@tf.function` decorator is applied only to the methods that are failing unit tests in Tensorflow 2.10.

Also has a minor fix due to `cudf.RangeIndex` not having an `empty` property anymore, which was copied from https://github.com/NVIDIA-Merlin/models/pull/904#discussion_r1053664632.

### Testing Details :mag:
Removed the upper bound on tensorflow from `2.10` to `2.11` in `GPU CI / gpu-ci (pull_request)`.
This issue is currently blocking the `22.12` release pipeline. Tested manually with `nvcr.io/nvstaging/merlin/tmp-merlin-tensorflow-stg:22.12` (which has tensorflow 2.10).