### PR TITLE
Session based inference support, triton ragged support changes

### DIFF
--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -461,8 +461,8 @@ def get_sub_blocks(blocks: Sequence[Block]) -> List[Block]:
 
 @tf.function
 def list_col_to_ragged(col: Tuple[tf.Tensor, tf.Tensor]):
-    values = col[0][:, 0]
-    row_lengths = col[1][:, 0]
+    values = col[0]
+    row_lengths = col[1]
 
     if row_lengths.dtype.is_floating:
         row_lengths = tf.cast(row_lengths, tf.int32)


### PR DESCRIPTION
This PR is required to make https://github.com/NVIDIA-Merlin/systems/pull/282 in merlin systems work. It will help provide ragged tensor support for triton (inference).