### PR TITLE
Fixes support of sequential continuous features for sequential and non-sequential models

### DIFF
--- a/merlin/models/tf/core/aggregation.py
+++ b/merlin/models/tf/core/aggregation.py
@@ -15,7 +15,6 @@
 #
 import abc
 import inspect
-from enum import Enum
 from typing import Optional, Union
 
 import tensorflow as tf
@@ -372,62 +371,77 @@ def masked_mean(
     return output_tensor
 
 
-class SequenceAggregation(Enum):
-    MEAN = tf.reduce_mean
-    SUM = tf.reduce_sum
-    MAX = tf.reduce_max
-    MIN = tf.reduce_min
-    MASKED_MEAN = masked_mean
-
-    def __str__(self):
-        return self.value
-
-    def __eq__(self, o: object) -> bool:
-        return str(o) == str(self)
-
-
 @tf.keras.utils.register_keras_serializable(package="merlin.models")
 class SequenceAggregator(Block):
-    """Computes the aggregation of elements across dimensions of a 3-D tensor.
+    """Computes an aggregation across one dimension (axis) of the tensor.
+    This is useful for averaging sequences of continuous or categorical features, for example.
+    If a dict of tensor is passed, performs the aggregation only for tensors whose rank
+    is higher than axis+1, keeping the other tensors unchanged.
     Args:
-        combiner:
-            tensorflow method to use for aggregation
-            Defaults to SequenceAggregation.MEAN
+        combiner: Optional[str]
+            Method to use for aggregation.
+            Accepts an str ("max", "min", "sum", "mean", "masked_mean").
+            Defaults to "mean"
         axis: int
             The dimensions to reduce.
             Defaults to 1
     """
 
-    def __init__(self, combiner=SequenceAggregation.MEAN, axis: int = 1, **kwargs):
+    def __init__(self, combiner: Optional[str] = "mean", axis: int = 1, **kwargs):
         super().__init__(**kwargs)
         self.axis = axis
         self.combiner = combiner
 
     def call(self, inputs: tf.Tensor, **kwargs) -> tf.Tensor:
-        assert len(inputs.shape) == 3, "inputs should be a 3-D tensor"
+        combiner = self.parse_combiner(self.combiner)
+
         kwargs = {}
         if (
-            "mask" in inspect.signature(self.combiner).parameters
+            "mask" in inspect.signature(combiner).parameters
             and "valid_items_mask" in self.context.named_variables
         ):
             kwargs["mask"] = self.context["valid_items_mask"]
 
-        return self.combiner(inputs, axis=self.axis, **kwargs)
+        if isinstance(inputs, dict):
+            outputs = {}
+            for k, v in inputs.items():
+                if len(v.shape) > self.axis + 1:
+                    outputs[k] = combiner(v, axis=self.axis, **kwargs)
+                else:
+                    outputs[k] = v
+            return outputs
+        else:
+            assert len(inputs.shape) == 3, "Tensor inputs should be 3-D"
+            return combiner(inputs, axis=self.axis, **kwargs)
+
+    def parse_combiner(self, combiner):
+        if isinstance(combiner, str):
+            if combiner == "sum":
+                combiner = tf.reduce_sum
+            elif combiner == "max":
+                combiner = tf.reduce_max
+            elif combiner == "min":
+                combiner = tf.reduce_min
+            elif combiner == "mean":
+                combiner = tf.reduce_mean
+            elif combiner == "masked_mean":
+                combiner = masked_mean
+        return combiner
 
     def compute_output_shape(self, input_shape):
-        batch_size, _, last_dim = input_shape
-        return batch_size, last_dim
+        if isinstance(input_shape, dict):
+            outputs = {}
+            for k, v in input_shape.items():
+                if len(v) > self.axis + 1:
+                    outputs[k] = tf.TensorShape(list(v)[: self.axis] + list(v)[self.axis + 1 :])
+                else:
+                    outputs[k] = v
+            return outputs
+        else:
+            batch_size, _, last_dim = input_shape
+            return batch_size, last_dim
 
     def get_config(self):
         config = super().get_config()
-        config = tf_utils.maybe_serialize_keras_objects(
-            self, config, {"combiner": tf.keras.layers.serialize}
-        )
+        config.update(axis=self.axis, combiner=self.combiner)
         return config
-
-    @classmethod
-    def from_config(cls, config):
-        config = tf_utils.maybe_deserialize_keras_objects(
-            config, ["combiner"], tf.keras.layers.deserialize
-        )
-        return super().from_config(config)

--- a/merlin/models/tf/core/aggregation.py
+++ b/merlin/models/tf/core/aggregation.py
@@ -380,8 +380,11 @@ class SequenceAggregator(Block):
     Args:
         combiner: Optional[str]
             Method to use for aggregation.
-            Accepts an str ("max", "min", "sum", "mean", "masked_mean").
-            Defaults to "mean"
+            Accepts an str ("max", "min", "sum", "mean", "masked_mean"). Defaults to "mean".
+            Note: "masked_mean" computes the mean of the specified axis considering only
+                masked values. It was originally created to ignore padded positions
+                on dense tensors representing sequences, but with RaggedTensor support
+                that can be done by just using regular TF mean aggregation.
         axis: int
             The dimensions to reduce.
             Defaults to 1

--- a/merlin/models/tf/inputs/base.py
+++ b/merlin/models/tf/inputs/base.py
@@ -31,7 +31,7 @@ from merlin.models.tf.inputs.embedding import (
     Embeddings,
     SequenceEmbeddingFeatures,
 )
-from merlin.models.tf.transforms.tensor import ListToDense
+from merlin.models.tf.transforms.tensor import ListToDense, ProcessList
 from merlin.schema import Schema, Tags, TagsType
 
 LOG = logging.getLogger("merlin-models")
@@ -325,9 +325,13 @@ def InputBlockV2(
     if not parsed:
         raise ValueError("No columns selected for the input block")
 
+    _pre = ProcessList(schema)
+    if pre:
+        _pre = _pre.connect(pre)
+
     return ParallelBlock(
         parsed,
-        pre=pre,
+        pre=_pre,
         post=post,
         aggregation=aggregation,
         is_input=True,

--- a/merlin/models/tf/inputs/base.py
+++ b/merlin/models/tf/inputs/base.py
@@ -20,7 +20,7 @@ from typing import Callable, Dict, Optional, Tuple, Type, Union
 
 from tensorflow.keras.layers import Layer
 
-from merlin.models.tf.core.aggregation import SequenceAggregation, SequenceAggregator
+from merlin.models.tf.core.aggregation import SequenceAggregator
 from merlin.models.tf.core.base import Block, BlockType
 from merlin.models.tf.core.combinators import ParallelBlock, TabularAggregationType
 from merlin.models.tf.inputs.continuous import Continuous, ContinuousFeatures
@@ -52,7 +52,7 @@ def InputBlock(
     categorical_tags: Optional[Union[TagsType, Tuple[Tags]]] = (Tags.CATEGORICAL,),
     sequential_tags: Optional[Union[TagsType, Tuple[Tags]]] = (Tags.SEQUENCE,),
     split_sparse: bool = False,
-    seq_aggregator: Block = SequenceAggregator(SequenceAggregation.MEAN),
+    seq_aggregator: Block = SequenceAggregator("mean"),
     **kwargs,
 ) -> Block:
     """The entry block of the model to process input features from a schema.

--- a/merlin/models/tf/inputs/continuous.py
+++ b/merlin/models/tf/inputs/continuous.py
@@ -39,8 +39,7 @@ class Continuous(Filter):
     inputs : Optional[Union[Sequence[str], Union[Schema, Tags]]], optional
         Indicates how the continuous features should be identified to be filtered.
         It accepts a schema, a column schema tag or a list with the feature names.
-        If None (default), it looks for columns with the CONTINUOUS tag in the
-        column schema.
+        If None (default), it looks for columns with the CONTINUOUS tag in the column schema.
     """
 
     def __init__(

--- a/merlin/models/tf/inputs/continuous.py
+++ b/merlin/models/tf/inputs/continuous.py
@@ -32,6 +32,17 @@ from merlin.schema import Schema, Tags
 
 @tf.keras.utils.register_keras_serializable(package="merlin.models")
 class Continuous(Filter):
+    """Filters (keeps) only the continuous features.
+
+    Parameters
+    ----------
+    inputs : Optional[Union[Sequence[str], Union[Schema, Tags]]], optional
+        Indicates how the continuous features should be identified to be filtered.
+        It accepts a schema, a column schema tag or a list with the feature names.
+        If None (default), it looks for columns with the CONTINUOUS tag in the
+        column schema.
+    """
+
     def __init__(
         self, inputs: Optional[Union[Sequence[str], Union[Schema, Tags]]] = None, **kwargs
     ):
@@ -44,6 +55,16 @@ def ContinuousProjection(
     schema: Schema,
     projection: tf.keras.layers.Layer,
 ) -> SequentialBlock:
+    """Concatenates the continuous features and combines them
+    using a layer
+
+    Parameters
+    ----------
+    schema : Schema
+        Schema that includes the continuous features
+    projection : tf.keras.layers.Layer
+        Layer that will be used to combine the continuous features
+    """
     return SequentialBlock(Continuous(schema, aggregation="concat"), projection)
 
 

--- a/merlin/models/tf/inputs/continuous.py
+++ b/merlin/models/tf/inputs/continuous.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from typing import List, Optional
+from typing import List, Optional, Sequence, Union
 
 import tensorflow as tf
 
@@ -27,12 +27,17 @@ from merlin.models.tf.core.tabular import (
     TabularBlock,
 )
 from merlin.models.utils.doc_utils import docstring_parameter
-from merlin.schema import Schema
+from merlin.schema import Schema, Tags
 
 
 @tf.keras.utils.register_keras_serializable(package="merlin.models")
 class Continuous(Filter):
-    ...
+    def __init__(
+        self, inputs: Optional[Union[Sequence[str], Union[Schema, Tags]]] = None, **kwargs
+    ):
+        if inputs is None:
+            inputs = Tags.CONTINUOUS
+        super().__init__(inputs, **kwargs)
 
 
 def ContinuousProjection(

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -452,11 +452,12 @@ class EmbeddingTable(EmbeddingTableBase):
 
         first_dims = input_shape
 
-        if (self.sequence_combiner is not None) and input_shape.rank > 2:
-            first_dims = [input_shape[0]]
+        if input_shape.rank > 1:
+            if self.sequence_combiner is not None:
+                first_dims = [input_shape[0]]
 
-        elif input_shape.rank > 1 and input_shape[-1] == 1:
-            first_dims = input_shape[:-1]
+            elif input_shape[-1] == 1:
+                first_dims = input_shape[:-1]
 
         output_shapes = tf.TensorShape(list(first_dims) + [self.dim])
 

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -451,9 +451,14 @@ class EmbeddingTable(EmbeddingTableBase):
             input_shape = tf.TensorShape([input_shape[1][0], None])
 
         first_dims = input_shape
-        if (self.sequence_combiner is not None) or (input_shape.rank > 1 and input_shape[-1] == 1):
+
+        if (self.sequence_combiner is not None) and input_shape.rank > 2:
+            first_dims = [input_shape[0]]
+
+        elif input_shape.rank > 1 and input_shape[-1] == 1:
             first_dims = input_shape[:-1]
-        output_shapes = tf.TensorShape(first_dims + [self.dim])
+
+        output_shapes = tf.TensorShape(list(first_dims) + [self.dim])
 
         return output_shapes
 

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -452,10 +452,7 @@ class EmbeddingTable(EmbeddingTableBase):
 
         first_dims = input_shape
         if (self.sequence_combiner is not None) or (input_shape.rank > 1 and input_shape[-1] == 1):
-            if len(input_shape) == 3:
-                first_dims = [input_shape[0]]
-            else:
-                first_dims = input_shape[:-1]
+            first_dims = input_shape[:-1]
         output_shapes = tf.TensorShape(first_dims + [self.dim])
 
         return output_shapes

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -50,7 +50,7 @@ from merlin.models.tf.models.utils import parse_prediction_blocks
 from merlin.models.tf.outputs.base import ModelOutput, ModelOutputType
 from merlin.models.tf.outputs.contrastive import ContrastiveOutput
 from merlin.models.tf.prediction_tasks.base import ParallelPredictionBlock, PredictionTask
-from merlin.models.tf.transforms.tensor import ListToRagged, ProcessList
+from merlin.models.tf.transforms.tensor import ProcessList
 from merlin.models.tf.typing import TabularData
 from merlin.models.tf.utils.search_utils import find_all_instances_in_layers
 from merlin.models.tf.utils.tf_utils import (
@@ -1433,7 +1433,8 @@ class Model(BaseModel):
                     f"\n\t{call_input_features.difference(model_input_features)}"
                 )
 
-            _ragged_inputs = ListToRagged()(inputs)
+            # _ragged_inputs = ListToRagged()(inputs)
+            _ragged_inputs = self.process_list(inputs)
             feature_shapes = {k: v.shape for k, v in _ragged_inputs.items()}
             feature_dtypes = {k: v.dtype for k, v in _ragged_inputs.items()}
 
@@ -1454,6 +1455,8 @@ class Model(BaseModel):
             The input shape, by default None
         """
         last_layer = None
+
+        input_shape = self.process_list.compute_output_shape(input_shape)
 
         if self.pre is not None:
             self.pre.build(input_shape)
@@ -1479,8 +1482,11 @@ class Model(BaseModel):
         self.built = True
 
     def call(self, inputs, targets=None, training=False, testing=False, output_context=False):
+        inputs = self.process_list(inputs)
+
         context = self._create_context(
-            self.process_list(inputs),
+            # self.process_list(inputs),
+            inputs,
             targets=targets,
             training=training,
             testing=testing,

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -1433,7 +1433,6 @@ class Model(BaseModel):
                     f"\n\t{call_input_features.difference(model_input_features)}"
                 )
 
-            # _ragged_inputs = ListToRagged()(inputs)
             _ragged_inputs = self.process_list(inputs)
             feature_shapes = {k: v.shape for k, v in _ragged_inputs.items()}
             feature_dtypes = {k: v.dtype for k, v in _ragged_inputs.items()}
@@ -1482,11 +1481,8 @@ class Model(BaseModel):
         self.built = True
 
     def call(self, inputs, targets=None, training=False, testing=False, output_context=False):
-        inputs = self.process_list(inputs)
-
         context = self._create_context(
-            # self.process_list(inputs),
-            inputs,
+            self.process_list(inputs),
             targets=targets,
             training=training,
             testing=testing,

--- a/merlin/models/tf/transforms/sequence.py
+++ b/merlin/models/tf/transforms/sequence.py
@@ -76,9 +76,8 @@ class RemovePad3D(Block):
 
 @tf.keras.utils.register_keras_serializable(package="merlin_models")
 class SequenceTransform(TabularBlock):
-    """Prepares sequential inputs and targets for next-item prediction.
-    The target is extracted from the shifted sequence of item ids and
-    the sequential input features are truncated in the last position.
+    """Base class for preparing sequential inputs and targets.
+
     Parameters
     ----------
     schema : Schema
@@ -99,6 +98,7 @@ class SequenceTransform(TabularBlock):
         pre: Optional[BlockType] = None,
         **kwargs,
     ):
+        # _pre = ProcessList(schema)
         _pre = ListToRagged()
         if pre:
             _pre = _pre.connect(pre)
@@ -140,12 +140,12 @@ class SequenceTransform(TabularBlock):
             )
 
         target_shape = inputs[self.target_name].get_shape().as_list()
-        if len(target_shape) != 2:
+        if len(target_shape) < 2:
             raise ValueError(
-                f"The target column ({self.target_name}) is expected to be a 2D tensor,"
+                f"The sequential target column ({self.target_name}) cannot be a 1D tensor,"
                 f" but the shape is {target_shape}"
             )
-        if target_shape[-1] == 1:
+        if target_shape[1] == 1:
             raise ValueError(
                 f"The 2nd dim of the target column ({self.target_name}) should be greater"
                 " than 1, so that the sequential input can be shifted as target"
@@ -171,8 +171,7 @@ class SequenceTransform(TabularBlock):
                 if isinstance(v, tuple) and isinstance(v[1], tf.TensorShape):
                     new_input_shapes[k] = tf.TensorShape([v[1][0], None])
                 else:
-                    # Reducing 1 position of the seq length
-                    new_input_shapes[k] = tf.TensorShape([v[0], v[1] - 1])
+                    new_input_shapes[k] = v
 
         return new_input_shapes
 
@@ -237,6 +236,20 @@ class SequencePredictNext(SequenceTransform):
 
         return (new_inputs, targets)
 
+    def compute_output_shape(self, input_shape):
+        new_input_shapes = dict()
+        for k, v in input_shape.items():
+            new_input_shapes[k] = v
+            if k in self.schema.column_names:
+                # If it is a list/sparse feature (in tuple representation), uses the offset as shape
+                if isinstance(v, tuple) and isinstance(v[1], tf.TensorShape):
+                    new_input_shapes[k] = tf.TensorShape([v[1][0], None])
+                else:
+                    # Reducing 1 position of the seq length
+                    new_input_shapes[k] = tf.TensorShape([v[0], v[1] - 1])
+
+        return new_input_shapes
+
 
 @Block.registry.register_with_multiple_names("seq_predict_last")
 @tf.keras.utils.register_keras_serializable(package="merlin_models")
@@ -282,6 +295,20 @@ class SequencePredictLast(SequenceTransform):
                 new_inputs[k] = v
 
         return (new_inputs, targets)
+
+    def compute_output_shape(self, input_shape):
+        new_input_shapes = dict()
+        for k, v in input_shape.items():
+            new_input_shapes[k] = v
+            if k in self.schema.column_names:
+                # If it is a list/sparse feature (in tuple representation), uses the offset as shape
+                if isinstance(v, tuple) and isinstance(v[1], tf.TensorShape):
+                    new_input_shapes[k] = tf.TensorShape([v[1][0], None])
+                else:
+                    # Reducing 1 position of the seq length
+                    new_input_shapes[k] = tf.TensorShape([v[0], v[1] - 1])
+
+        return new_input_shapes
 
 
 @Block.registry.register_with_multiple_names("seq_predict_random")
@@ -371,7 +398,6 @@ class SequenceTargetAsInput(SequenceTransform):
         so that the tensors sequences can be processed
     """
 
-    @tf.function
     def call(
         self, inputs: TabularData, targets=None, training=False, testing=False, **kwargs
     ) -> Prediction:

--- a/merlin/models/tf/transforms/sequence.py
+++ b/merlin/models/tf/transforms/sequence.py
@@ -98,7 +98,6 @@ class SequenceTransform(TabularBlock):
         pre: Optional[BlockType] = None,
         **kwargs,
     ):
-        # _pre = ProcessList(schema)
         _pre = ListToRagged()
         if pre:
             _pre = _pre.connect(pre)
@@ -398,6 +397,7 @@ class SequenceTargetAsInput(SequenceTransform):
         so that the tensors sequences can be processed
     """
 
+    @tf.function
     def call(
         self, inputs: TabularData, targets=None, training=False, testing=False, **kwargs
     ) -> Prediction:

--- a/merlin/models/tf/transforms/tensor.py
+++ b/merlin/models/tf/transforms/tensor.py
@@ -86,13 +86,20 @@ class ProcessList(TabularBlock):
             is_ragged = True
             if name in self.schema:
                 val_count = self.schema[name].properties.get("value_count")
-                if val_count and val_count["min"] == val_count["max"]:
+                if (
+                    val_count
+                    and "min" in val_count
+                    and "max" in val_count
+                    and val_count["min"] == val_count["max"]
+                ):
                     is_ragged = False
 
             if isinstance(val, tuple):
                 ragged = list_col_to_ragged(val)
             elif isinstance(val, tf.SparseTensor):
                 ragged = tf.RaggedTensor.from_sparse(val)
+            elif isinstance(val, tf.RaggedTensor):
+                ragged = val
             else:
                 outputs[name] = val
                 continue
@@ -114,9 +121,14 @@ class ProcessList(TabularBlock):
             if isinstance(v, tuple) and isinstance(v[1], tf.TensorShape):
                 is_ragged = True
                 max_seq_length = None
-                if k in self.schema:
+                if k in self.schema.column_names:
                     val_count = self.schema[k].properties.get("value_count")
-                    if val_count and val_count["min"] == val_count["max"]:
+                    if (
+                        val_count
+                        and "min" in val_count
+                        and "max" in val_count
+                        and val_count["min"] == val_count["max"]
+                    ):
                         is_ragged = False
                         max_seq_length = val_count["min"]
 

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -86,12 +86,13 @@ def maybe_serialize_keras_objects(
 
 
 def maybe_deserialize_keras_objects(
-    config, to_deserialize, deserialize_fn=tf.keras.utils.deserialize_keras_object
+    config,
+    to_deserialize,
+    deserialize_fn=tf.keras.utils.deserialize_keras_object,
+    custom_objects={},
 ):
     if isinstance(to_deserialize, list):
         to_deserialize = {k: deserialize_fn for k in to_deserialize}
-
-    custom_objects = {}
 
     for key, fn in to_deserialize.items():
         maybe_val = config.get(key, None)

--- a/tests/unit/tf/blocks/test_mlp.py
+++ b/tests/unit/tf/blocks/test_mlp.py
@@ -20,7 +20,10 @@ from tensorflow.keras import regularizers
 
 import merlin.models.tf as ml
 from merlin.io import Dataset
+from merlin.models.tf.core.aggregation import SequenceAggregator
+from merlin.models.tf.loader import Loader
 from merlin.models.tf.utils import testing_utils
+from merlin.schema.tags import Tags
 
 
 @pytest.mark.parametrize("dim", [32, 64])
@@ -69,6 +72,42 @@ def test_mlp_block(
             normalization = tf.keras.layers.BatchNormalization()
 
         assert mlp.layers[-1].__class__.__name__ == normalization.__class__.__name__
+
+
+@pytest.mark.parametrize("run_eagerly", [True, False])
+def test_mlp_model_with_sequential_features_and_combiner(
+    sequence_testing_data: Dataset, run_eagerly
+):
+    schema = sequence_testing_data.schema
+    target = schema.select_by_tag(Tags.ITEM_ID).column_names[0]
+
+    loader = Loader(sequence_testing_data, batch_size=8, shuffle=False)
+
+    model = ml.Model(
+        ml.InputBlockV2(
+            schema,
+            categorical=ml.Embeddings(
+                schema.select_by_tag(Tags.CATEGORICAL), sequence_combiner="mean"
+            ),
+            continuous=ml.Continuous(post=SequenceAggregator("mean")),
+        ),
+        ml.MLPBlock([32]),
+        ml.CategoricalOutput(
+            schema.select_by_name(target), default_loss="categorical_crossentropy"
+        ),
+    )
+
+    predict_last = ml.SequencePredictLast(schema=schema.select_by_tag(Tags.SEQUENCE), target=target)
+
+    testing_utils.model_test(
+        model, loader, run_eagerly=run_eagerly, reload_model=False, fit_kwargs={"pre": predict_last}
+    )
+
+    metrics = model.evaluate(loader, batch_size=8, steps=1, return_dict=True, pre=predict_last)
+    assert len(metrics) > 0
+
+    predictions = model.predict(loader, batch_size=8, steps=1)
+    assert predictions.shape == (8, 51997)
 
 
 @pytest.mark.parametrize("no_activation_last_layer", [False, True])

--- a/tests/unit/tf/blocks/test_mlp.py
+++ b/tests/unit/tf/blocks/test_mlp.py
@@ -100,7 +100,7 @@ def test_mlp_model_with_sequential_features_and_combiner(
     predict_last = ml.SequencePredictLast(schema=schema.select_by_tag(Tags.SEQUENCE), target=target)
 
     testing_utils.model_test(
-        model, loader, run_eagerly=run_eagerly, reload_model=False, fit_kwargs={"pre": predict_last}
+        model, loader, run_eagerly=run_eagerly, reload_model=True, fit_kwargs={"pre": predict_last}
     )
 
     metrics = model.evaluate(loader, batch_size=8, steps=1, return_dict=True, pre=predict_last)


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Fixes #953 , Closes #960 

### Goals :soccer:
Add support to sequential continuous features on sequential models (e.g. Transformers, RNNs) and non-sequential models (e.g. averaging the sequential features and projecting with MLP).

### Implementation Details :construction:
- Fixed bugs when using concatenating continuous sequential columns with categorical sequential columns in sequential models (e.g. Transformers, RNNs)
- Added support to average continuous sequential features by using `SequenceAggregator`, which nows support dict inputs and applied the combiner only on tensors whose shape is higher than the reduction axis (e.g. 3D tensors). This allows keeping 2D tensors (batch_size, 1) of continuous features as they are and applying the reduction only on sequential continuous features (batch_size, None, 1).
- Removed `SequenceAggregation` enum, as it created difficulties for serialization/deserialization of custom objects. Now SequenceAgreggator just tasks str as input.

Here is an example on how to average both sequential categorical and continuous features for a non-sequential model (e.g. simple MLP):
P.s. The aggregation (average) will only apply for 3D features, keeping the other 2D features unchanged (e.g. user or session level features), so that they can be concatenated.

```python
ml.InputBlockV2(
            schema,
            categorical=ml.Embeddings(
                schema.select_by_tag(Tags.CATEGORICAL), sequence_combiner="mean"
            ),
            continuous=ml.Continuous(post=SequenceAggregator("mean")),
        )
```
*Other related fixes:*
- Included `MLPBlock` between `InputBlockV2` and Transformer blocks in the units tests to serve as example for the users that usually the concatenated features dim does not match the input dim of Transformers (d_model).
- Fixed `compute_output_shape()` of `SequenceTransform` derived classes
- Fixed `ProcessList` to return dense tensors when in column schema the value_count.max == value_count.min
- Changed `maybe_deserialize_keras_objects()` to expose the `custom_objects` argument
- Updated `compute_output_shape()` of `EmbeddingTable` to deal correctly with 3D input tensors (batch_size, seq_length, 1)
- Changed `Continuous` class to filter by default based on Tags.CONTINUOUS, if the filter is not provided

### Testing Details :mag:
- Added test (`test_mlp_model_with_sequential_features_and_combiner`) to demonstrate and test how to use sequential continuous and categorical features in non-sequential model by averaging.
- Changed Transformers tests to include not only categorical sequential features but also continuous ones.