### PR TITLE
Update branch name extraction for tag builds

### DIFF
--- a/.github/workflows/cpu-horovod.yml
+++ b/.github/workflows/cpu-horovod.yml
@@ -43,7 +43,6 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
-            raw=$(git branch -r --contains ${{ github.ref_name }})
-            branch=${raw/origin\/}
+            branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           cd ${{ github.workspace }}; tox -e py38-horovod-cpu -- $branch

--- a/.github/workflows/cpu-horovod.yml
+++ b/.github/workflows/cpu-horovod.yml
@@ -43,6 +43,7 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
+            git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release*:refs/remotes/origin/release*
             branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           cd ${{ github.workspace }}; tox -e py38-horovod-cpu -- $branch

--- a/.github/workflows/cpu-nvtabular.yml
+++ b/.github/workflows/cpu-nvtabular.yml
@@ -38,7 +38,6 @@ jobs:
         branch=main
         if [[ $ref_type == "tag"* ]]
         then
-          raw=$(git branch -r --contains ${{ github.ref_name }})
-          branch=${raw/origin\/}
+          branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
         fi
         GIT_COMMIT=`git rev-parse HEAD` tox -e py38-nvtabular-cpu -- $branch

--- a/.github/workflows/cpu-nvtabular.yml
+++ b/.github/workflows/cpu-nvtabular.yml
@@ -38,6 +38,7 @@ jobs:
         branch=main
         if [[ $ref_type == "tag"* ]]
         then
+          git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release*:refs/remotes/origin/release*
           branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
         fi
         GIT_COMMIT=`git rev-parse HEAD` tox -e py38-nvtabular-cpu -- $branch

--- a/.github/workflows/cpu-systems.yml
+++ b/.github/workflows/cpu-systems.yml
@@ -38,7 +38,6 @@ jobs:
         branch=main
         if [[ $ref_type == "tag"* ]]
         then
-          raw=$(git branch -r --contains ${{ github.ref_name }})
-          branch=${raw/origin\/}
+          branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
         fi
         GIT_COMMIT=`git rev-parse HEAD` tox -e py38-systems-cpu -- $branch

--- a/.github/workflows/cpu-systems.yml
+++ b/.github/workflows/cpu-systems.yml
@@ -38,6 +38,7 @@ jobs:
         branch=main
         if [[ $ref_type == "tag"* ]]
         then
+          git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release*:refs/remotes/origin/release*
           branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
         fi
         GIT_COMMIT=`git rev-parse HEAD` tox -e py38-systems-cpu -- $branch

--- a/.github/workflows/datasets.yml
+++ b/.github/workflows/datasets.yml
@@ -32,8 +32,7 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
-            raw=$(git branch -r --contains ${{ github.ref_name }})
-            branch=${raw/origin\/}
+            branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           pip install "pandas>=1.2.0,<1.4.0dev0"
           pip install "NVTabular@git+https://github.com/NVIDIA-Merlin/NVTabular.git@$branch"

--- a/.github/workflows/datasets.yml
+++ b/.github/workflows/datasets.yml
@@ -32,6 +32,7 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
+            git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release*:refs/remotes/origin/release*
             branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           pip install "pandas>=1.2.0,<1.4.0dev0"

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -24,6 +24,7 @@ jobs:
         branch=main
         if [[ $ref_type == "tag"* ]]
         then
+          git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release*:refs/remotes/origin/release*
           branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
         fi
         cd ${{ github.workspace }}; tox -e py38-gpu -- $branch

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -24,7 +24,6 @@ jobs:
         branch=main
         if [[ $ref_type == "tag"* ]]
         then
-          raw=$(git branch -r --contains ${{ github.ref_name }})
-          branch=${raw/origin\/}
+          branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
         fi
         cd ${{ github.workspace }}; tox -e py38-gpu -- $branch

--- a/.github/workflows/implicit.yml
+++ b/.github/workflows/implicit.yml
@@ -32,8 +32,7 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
-            raw=$(git branch -r --contains ${{ github.ref_name }})
-            branch=${raw/origin\/}
+            branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           pip install "pandas>=1.2.0,<1.4.0dev0"
           pip install "NVTabular@git+https://github.com/NVIDIA-Merlin/NVTabular.git@$branch"

--- a/.github/workflows/implicit.yml
+++ b/.github/workflows/implicit.yml
@@ -32,6 +32,7 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
+            git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release*:refs/remotes/origin/release*
             branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           pip install "pandas>=1.2.0,<1.4.0dev0"

--- a/.github/workflows/lightfm.yml
+++ b/.github/workflows/lightfm.yml
@@ -32,8 +32,7 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
-            raw=$(git branch -r --contains ${{ github.ref_name }})
-            branch=${raw/origin\/}
+            branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           pip install "pandas>=1.2.0,<1.4.0dev0"
           pip install "NVTabular@git+https://github.com/NVIDIA-Merlin/NVTabular.git@$branch"

--- a/.github/workflows/lightfm.yml
+++ b/.github/workflows/lightfm.yml
@@ -32,6 +32,7 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
+            git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release*:refs/remotes/origin/release*
             branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           pip install "pandas>=1.2.0,<1.4.0dev0"

--- a/.github/workflows/pytorch.yml
+++ b/.github/workflows/pytorch.yml
@@ -33,6 +33,7 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
+            git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release*:refs/remotes/origin/release*
             branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           pip install "pandas>=1.2.0,<1.4.0dev0"

--- a/.github/workflows/pytorch.yml
+++ b/.github/workflows/pytorch.yml
@@ -1,3 +1,4 @@
+
 name: pytorch
 
 on:
@@ -32,8 +33,7 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
-            raw=$(git branch -r --contains ${{ github.ref_name }})
-            branch=${raw/origin\/}
+            branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           pip install "pandas>=1.2.0,<1.4.0dev0"
           pip install "NVTabular@git+https://github.com/NVIDIA-Merlin/NVTabular.git@$branch"

--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -38,8 +38,7 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
-            raw=$(git branch -r --contains ${{ github.ref_name }})
-            branch=${raw/origin\/}
+            branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           pip install "pandas>=1.2.0,<1.4.0dev0"
           pip install "NVTabular@git+https://github.com/NVIDIA-Merlin/NVTabular.git@$branch"
@@ -93,8 +92,7 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
-            raw=$(git branch -r --contains ${{ github.ref_name }})
-            branch=${raw/origin\/}
+            branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           pip install "pandas>=1.2.0,<1.4.0dev0"
           pip install "NVTabular@git+https://github.com/NVIDIA-Merlin/NVTabular.git@$branch"

--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -38,6 +38,7 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
+            git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release*:refs/remotes/origin/release*
             branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           pip install "pandas>=1.2.0,<1.4.0dev0"
@@ -92,6 +93,7 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
+            git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release*:refs/remotes/origin/release*
             branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           pip install "pandas>=1.2.0,<1.4.0dev0"

--- a/.github/workflows/xgboost.yml
+++ b/.github/workflows/xgboost.yml
@@ -32,8 +32,7 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
-            raw=$(git branch -r --contains ${{ github.ref_name }})
-            branch=${raw/origin\/}
+            branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           pip install "pandas>=1.2.0,<1.4.0dev0"
           pip install "NVTabular@git+https://github.com/NVIDIA-Merlin/NVTabular.git@$branch"

--- a/.github/workflows/xgboost.yml
+++ b/.github/workflows/xgboost.yml
@@ -32,6 +32,7 @@ jobs:
           branch=main
           if [[ $ref_type == "tag"* ]]
           then
+            git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release*:refs/remotes/origin/release*
             branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
           fi
           pip install "pandas>=1.2.0,<1.4.0dev0"


### PR DESCRIPTION
- Updates branch name logic for tag builds to handle leading whitespace.
  - `git branch -r --contains v0.11.0`, for example, returns `  origin/release-22.12`. The subsequent line in our workflow failed to remove the prefix `  origin/` because if doesn't currently handle this whitespace
    - using `--format "%(refname:short)"` to ensure we only get the branch name and not leading whitespace
  - another issue is that this tag was pointing at multiple branches, and the main branch was selected.
    - using `--list '*release*'` to ensure we select the release branch name. There is still an edge case where we could have the tag pointing at multiple release branches, but that seem less likely to happen.
- The package publish failed on the last release due to this leading whitespace.
  - https://github.com/NVIDIA-Merlin/models/actions/runs/3808697494