### PR TITLE
fix gpu visibility with env passthrough

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ deps =
     -rrequirements/test.txt
 setenv =
     TF_GPU_ALLOCATOR=cuda_malloc_async
+passenv =
+    CUDA_VISIBLE_DEVICES
 commands =
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git@{posargs:main}


### PR DESCRIPTION
This PR ensures that any gpu visibility markers that are set in the environment are passed through to the tox execution environment. Ensures that we only use the desired gpus in a given environment.