### PR TITLE
Makes ColumnBasedSampleWeight serializable

### DIFF
--- a/merlin/models/tf/utils/testing_utils.py
+++ b/merlin/models/tf/utils/testing_utils.py
@@ -112,14 +112,10 @@ def model_test(
         if isinstance(model_preds, dict):
             for task_name in model_preds:
                 tf.debugging.assert_near(
-                    model_preds[task_name],
-                    loaded_model_preds[task_name],
+                    model_preds[task_name], loaded_model_preds[task_name], atol=1e-5
                 )
         else:
-            tf.debugging.assert_near(
-                model_preds,
-                loaded_model_preds,
-            )
+            tf.debugging.assert_near(model_preds, loaded_model_preds, atol=1e-5)
 
         loaded_model.compile(run_eagerly=run_eagerly, optimizer=optimizer, **kwargs)
         loaded_model.fit(iter(batch))

--- a/tests/unit/tf/outputs/test_block.py
+++ b/tests/unit/tf/outputs/test_block.py
@@ -568,17 +568,17 @@ def test_column_based_sample_weight_with_multitask(
         ),
     }
 
-    model.compile(
-        optimizer="adam",
+    _, losses = testing_utils.model_test(
+        model,
+        music_streaming_data,
         run_eagerly=run_eagerly,
+        reload_model=True,
         loss_weights=loss_weights,
         weighted_metrics=weighted_metrics,
     )
 
-    metrics = model.train_step(mm.sample_batch(music_streaming_data, batch_size=50))
-
-    assert metrics["loss"] >= 0
-    assert set(metrics.keys()) == set(
+    assert losses.history["loss"][0] >= 0
+    assert set(losses.history.keys()) == set(
         [
             "loss",
             "loss_batch",
@@ -641,11 +641,15 @@ def test_mmoe_model(
         "like/binary_output": 3.0,
     }
 
-    model.compile(optimizer="adam", run_eagerly=run_eagerly, loss_weights=loss_weights)
+    _, losses = testing_utils.model_test(
+        model,
+        music_streaming_data,
+        run_eagerly=run_eagerly,
+        reload_model=True,
+        loss_weights=loss_weights,
+    )
 
-    metrics = model.train_step(mm.sample_batch(music_streaming_data, batch_size=50))
-
-    assert metrics["loss"] >= 0
+    assert losses.history["loss"][0] >= 0
 
     expected_metrics = [
         "loss",
@@ -670,17 +674,27 @@ def test_mmoe_model(
                 gate_metric_name = f"gate_{task}_weight_{i}"
                 expected_metrics.append(gate_metric_name)
 
-    assert set(metrics.keys()) == set(expected_metrics)
+    assert set(losses.history.keys()) == set(expected_metrics)
 
 
 @testing_utils.mark_run_eagerly_modes
 def test_mmoe_block_task_specific_sample_weight_and_weighted_metrics(
     music_streaming_data: Dataset, run_eagerly: bool
 ):
+    @tf.keras.utils.register_keras_serializable(package="merlin_models")
     class CustomSampleWeight(Block):
         def call(
-            self, inputs, targets=None, features=None, target_name=None, **kwargs
+            self,
+            inputs,
+            targets=None,
+            features=None,
+            target_name=None,
+            training=False,
+            testing=False,
+            **kwargs,
         ) -> mm.Prediction:
+            if not (training or testing) or targets is None:
+                return inputs
             return mm.Prediction(inputs, targets[target_name], sample_weight=targets["click"])
 
         def compute_output_shape(self, input_shape):
@@ -714,17 +728,18 @@ def test_mmoe_block_task_specific_sample_weight_and_weighted_metrics(
         ),
     }
 
-    model.compile(
-        optimizer="adam",
+    _, losses = testing_utils.model_test(
+        model,
+        music_streaming_data,
         run_eagerly=run_eagerly,
+        reload_model=True,
         loss_weights=loss_weights,
         weighted_metrics=weighted_metrics,
     )
 
-    metrics = model.train_step(mm.sample_batch(music_streaming_data, batch_size=50))
+    assert losses.history["loss"][0] >= 0
 
-    assert metrics["loss"] >= 0
-    assert set(metrics.keys()) == set(
+    assert set(losses.history.keys()) == set(
         [
             "loss",
             "loss_batch",
@@ -782,12 +797,20 @@ def test_mmoe_model_serialization(music_streaming_data: Dataset, run_eagerly: bo
     }
 
     model = mm.Model(inputs, mmoe, output_block)
-    model.compile(optimizer="adam", run_eagerly=run_eagerly, weighted_metrics=weighted_metrics)
 
-    loader = mm.Loader(music_streaming_data, batch_size=8, shuffle=False)
+    _, losses = testing_utils.model_test(
+        model,
+        music_streaming_data,
+        run_eagerly=run_eagerly,
+        reload_model=True,
+        weighted_metrics=weighted_metrics,
+    )
+
+    assert losses.history["loss"][0] >= 0
+
     testing_utils.model_test(
         model,
-        loader,
+        music_streaming_data,
         run_eagerly=run_eagerly,
         reload_model=True,
     )
@@ -810,12 +833,17 @@ def test_cgc_model(music_streaming_data: Dataset, run_eagerly: bool, task_blocks
         schema=schema,
     )
     model = mm.Model(inputs, cgc, output_block)
-    model.compile(optimizer="adam", run_eagerly=run_eagerly)
 
-    metrics = model.train_step(mm.sample_batch(music_streaming_data, batch_size=50))
+    _, losses = testing_utils.model_test(
+        model,
+        music_streaming_data,
+        run_eagerly=run_eagerly,
+        reload_model=True,
+    )
 
-    assert metrics["loss"] >= 0
-    assert set(metrics.keys()) == set(
+    assert losses.history["loss"][0] >= 0
+
+    assert set(losses.history.keys()) == set(
         [
             "loss",
             "loss_batch",
@@ -852,12 +880,15 @@ def test_ple_model(music_streaming_data: Dataset, run_eagerly: bool, task_blocks
         num_shared_experts=3,
     )
     model = mm.Model(inputs, ple, output_block)
-    model.compile(optimizer="adam", run_eagerly=run_eagerly)
+    _, losses = testing_utils.model_test(
+        model,
+        music_streaming_data,
+        run_eagerly=run_eagerly,
+        reload_model=True,
+    )
 
-    metrics = model.train_step(mm.sample_batch(music_streaming_data, batch_size=50))
-
-    assert metrics["loss"] >= 0
-    assert set(metrics.keys()) == set(
+    assert losses.history["loss"][0] >= 0
+    assert set(losses.history.keys()) == set(
         [
             "loss",
             "loss_batch",
@@ -891,12 +922,11 @@ def test_ple_model_serialization(music_streaming_data: Dataset, run_eagerly: boo
         gate_block=mm.MLPBlock([16]),
     )
     model = mm.Model(inputs, ple, output_block)
-    model.compile(optimizer="adam", run_eagerly=run_eagerly)
-
-    loader = mm.Loader(music_streaming_data, batch_size=8, shuffle=False)
-    testing_utils.model_test(
+    _, losses = testing_utils.model_test(
         model,
-        loader,
+        music_streaming_data,
         run_eagerly=run_eagerly,
         reload_model=True,
     )
+
+    assert losses.history["loss"][0] >= 0


### PR DESCRIPTION
### Goals :soccer:
This PR fix a serialization error when using `ColumnBasedSampleWeight` in the model.

### Implementation Details :construction:
- It makes `ColumnBasedSampleWeight` a serializable layer by defining get_config() and annotating the class to be serializable by Keras.
- When `model.save()` was called the `ColumnBasedSampleWeight.call()` was being called with args `training=True` and `targets=None`, which was causing an error as `targets` should always be provided if either `training=True` or `testing=True`. I had to change the logic to check if `targets is not None` to avoid an error when model is saved.

### Testing Details :mag:
- The unit tests on multi-task learning models (using  `ColumnBasedSampleWeight`  or not) were updated to ensure they are serializable.
