### PR TITLE
Fix/Simplify/Optimize the transformer API for causal and masked pre-training approach

### DIFF
--- a/examples/usecases/transformers-next-item-prediction.ipynb
+++ b/examples/usecases/transformers-next-item-prediction.ipynb
@@ -39,6 +39,8 @@
     "\n",
     "In this use case we will train a Transformer-based architecture for next-item prediction task.\n",
     "\n",
+    "**Note, the data for this notebook will be automatically downloaded to the folder specified in the cells below.**\n",
+    "\n",
     "We will use the [booking.com dataset](https://github.com/bookingcom/ml-dataset-mdt) to train a session-based model. The dataset contains 1,166,835 of anonymized hotel reservations in the train set and 378,667 in the test set. Each reservation is a part of a customer's trip (identified by `utrip_id`) which includes consecutive reservations.\n",
     "\n",
     "We will reshape the data to organize it into 'sessions'. Each session will be a full customer itinerary in chronological order. The goal will be to predict the city_id of the final reservation of each trip.\n",
@@ -62,7 +64,17 @@
    "id": "1d0b619b",
    "metadata": {},
    "source": [
-    "We will download the dataset using a functionality provided by merlin models. The dataset can be found on GitHub [here](https://github.com/bookingcom/ml-dataset-mdt)."
+    "We will download the dataset using a functionality provided by merlin models. The dataset can be found on GitHub [here](https://github.com/bookingcom/ml-dataset-mdt).\n",
+    "\n",
+    "**Read more about libraries used in the import statements below**\n",
+    "\n",
+    "- [get_lib](https://github.com/NVIDIA-Merlin/core/blob/main/merlin/core/dispatch.py)\n",
+    "- [get_booking](https://github.com/NVIDIA-Merlin/models/tree/main/merlin/datasets/ecommerce)\n",
+    "- [nvtabular](https://github.com/NVIDIA-Merlin/NVTabular/tree/main/nvtabular)\n",
+    "- [nvtabular ops](https://github.com/NVIDIA-Merlin/NVTabular/tree/main/nvtabular/ops)\n",
+    "- [schema tags](https://github.com/NVIDIA-Merlin/core/blob/main/merlin/schema/tags.py)\n",
+    "- [merlin models tensorflow](https://github.com/NVIDIA-Merlin/models/tree/main/merlin/models/tf)\n",
+    "- [get_booking](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/datasets/ecommerce/booking/dataset.py)"
    ]
   },
   {
@@ -75,20 +87,49 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/lib/python3/dist-packages/requests/__init__.py:89: RequestsDependencyWarning: urllib3 (1.26.12) or chardet (3.0.4) doesn't match a supported version!\n",
-      "  warnings.warn(\"urllib3 ({}) or chardet ({}) doesn't match a supported \"\n",
-      "2023-01-10 00:50:16.355919: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:991] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2023-01-10 00:50:16.356319: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:991] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2023-01-10 00:50:16.356459: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:991] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2023-01-10 00:50:16.557048: I tensorflow/core/platform/cpu_feature_guard.cc:194] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
+      "2023-02-08 13:16:58.296917: I tensorflow/core/platform/cpu_feature_guard.cc:194] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:Please fix your imports. Module tensorflow.python.training.tracking.data_structures has been moved to tensorflow.python.trackable.data_structures. The old module will be deleted in version 2.11.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-02-08 13:17:00.184118: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:996] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-02-08 13:17:00.184683: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:996] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-02-08 13:17:00.184852: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:996] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-02-08 13:17:00.528889: I tensorflow/core/platform/cpu_feature_guard.cc:194] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE3 SSE4.1 SSE4.2 AVX\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2023-01-10 00:50:16.557938: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:991] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2023-01-10 00:50:16.558122: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:991] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2023-01-10 00:50:16.558257: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:991] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2023-01-10 00:50:17.306814: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:991] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2023-01-10 00:50:17.307008: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:991] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2023-01-10 00:50:17.307146: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:991] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
-      "2023-01-10 00:50:17.307270: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1532] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 24576 MB memory:  -> device: 0, name: Quadro RTX 8000, pci bus id: 0000:08:00.0, compute capability: 7.5\n",
+      "2023-02-08 13:17:00.529995: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:996] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-02-08 13:17:00.530226: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:996] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-02-08 13:17:00.530390: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:996] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-02-08 13:17:01.603935: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:996] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-02-08 13:17:01.604163: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:996] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-02-08 13:17:01.604334: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:996] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero\n",
+      "2023-02-08 13:17:01.604470: I tensorflow/core/common_runtime/gpu/gpu_process_state.cc:222] Using CUDA malloc Async allocator for GPU: 0\n",
+      "2023-02-08 13:17:01.604549: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1637] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 24331 MB memory:  -> device: 0, name: NVIDIA RTX A6000, pci bus id: 0000:61:00.0, compute capability: 8.6\n",
+      "/usr/local/lib/python3.8/dist-packages/tqdm/auto.py:22: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training data import complete\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
       "/usr/local/lib/python3.8/dist-packages/merlin/schema/tags.py:148: UserWarning: Compound tags like Tags.USER_ID have been deprecated and will be removed in a future version. Please use the atomic versions of these tags, like [<Tags.USER: 'user'>, <Tags.ID: 'id'>].\n",
       "  warnings.warn(\n",
       "/usr/local/lib/python3.8/dist-packages/merlin/schema/tags.py:148: UserWarning: Compound tags like Tags.SESSION_ID have been deprecated and will be removed in a future version. Please use the atomic versions of these tags, like [<Tags.SESSION: 'session'>, <Tags.ID: 'id'>].\n",
@@ -99,18 +140,25 @@
     }
    ],
    "source": [
+    "# Resetting the TF memory allocation to not be 50% by default. \n",
+    "import os\n",
+    "os.environ[\"TF_GPU_ALLOCATOR\"]=\"cuda_malloc_async\"\n",
+    "\n",
     "from merlin.core.dispatch import get_lib\n",
     "from merlin.datasets.ecommerce import get_booking\n",
+    "\n",
     "import numpy as np\n",
     "\n",
     "from nvtabular import *\n",
     "from nvtabular import ops\n",
-    "from merlin.schema.tags import Tags\n",
     "\n",
+    "from merlin.schema.tags import Tags\n",
     "import merlin.models.tf as mm\n",
     "\n",
     "get_booking('/workspace/data')\n",
-    "train = get_lib().read_csv('/workspace/data/train_set.csv', parse_dates=['checkin', 'checkout'])"
+    "train = get_lib().read_csv('/workspace/data/train_set.csv', parse_dates=['checkin', 'checkout'])\n",
+    "\n",
+    "print('Training data import complete')"
    ]
   },
   {
@@ -128,125 +176,28 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>user_id</th>\n",
-       "      <th>checkin</th>\n",
-       "      <th>checkout</th>\n",
-       "      <th>city_id</th>\n",
-       "      <th>device_class</th>\n",
-       "      <th>affiliate_id</th>\n",
-       "      <th>booker_country</th>\n",
-       "      <th>hotel_country</th>\n",
-       "      <th>utrip_id</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1000027</td>\n",
-       "      <td>2016-08-13</td>\n",
-       "      <td>2016-08-14</td>\n",
-       "      <td>8183</td>\n",
-       "      <td>desktop</td>\n",
-       "      <td>7168</td>\n",
-       "      <td>Elbonia</td>\n",
-       "      <td>Gondal</td>\n",
-       "      <td>1000027_1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1000027</td>\n",
-       "      <td>2016-08-14</td>\n",
-       "      <td>2016-08-16</td>\n",
-       "      <td>15626</td>\n",
-       "      <td>desktop</td>\n",
-       "      <td>7168</td>\n",
-       "      <td>Elbonia</td>\n",
-       "      <td>Gondal</td>\n",
-       "      <td>1000027_1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>1000027</td>\n",
-       "      <td>2016-08-16</td>\n",
-       "      <td>2016-08-18</td>\n",
-       "      <td>60902</td>\n",
-       "      <td>desktop</td>\n",
-       "      <td>7168</td>\n",
-       "      <td>Elbonia</td>\n",
-       "      <td>Gondal</td>\n",
-       "      <td>1000027_1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>1000027</td>\n",
-       "      <td>2016-08-18</td>\n",
-       "      <td>2016-08-21</td>\n",
-       "      <td>30628</td>\n",
-       "      <td>desktop</td>\n",
-       "      <td>253</td>\n",
-       "      <td>Elbonia</td>\n",
-       "      <td>Gondal</td>\n",
-       "      <td>1000027_1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>1000033</td>\n",
-       "      <td>2016-04-09</td>\n",
-       "      <td>2016-04-11</td>\n",
-       "      <td>38677</td>\n",
-       "      <td>mobile</td>\n",
-       "      <td>359</td>\n",
-       "      <td>Gondal</td>\n",
-       "      <td>Cobra Island</td>\n",
-       "      <td>1000033_1</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   user_id    checkin   checkout  city_id device_class  affiliate_id  \\\n",
-       "0  1000027 2016-08-13 2016-08-14     8183      desktop          7168   \n",
-       "1  1000027 2016-08-14 2016-08-16    15626      desktop          7168   \n",
-       "2  1000027 2016-08-16 2016-08-18    60902      desktop          7168   \n",
-       "3  1000027 2016-08-18 2016-08-21    30628      desktop           253   \n",
-       "4  1000033 2016-04-09 2016-04-11    38677       mobile           359   \n",
-       "\n",
-       "  booker_country hotel_country   utrip_id  \n",
-       "0        Elbonia        Gondal  1000027_1  \n",
-       "1        Elbonia        Gondal  1000027_1  \n",
-       "2        Elbonia        Gondal  1000027_1  \n",
-       "3        Elbonia        Gondal  1000027_1  \n",
-       "4         Gondal  Cobra Island  1000033_1  "
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   user_id    checkin   checkout  city_id device_class  affiliate_id  \\\n",
+      "0  1000027 2016-08-13 2016-08-14     8183      desktop          7168   \n",
+      "1  1000027 2016-08-14 2016-08-16    15626      desktop          7168   \n",
+      "2  1000027 2016-08-16 2016-08-18    60902      desktop          7168   \n",
+      "3  1000027 2016-08-18 2016-08-21    30628      desktop           253   \n",
+      "4  1000033 2016-04-09 2016-04-11    38677       mobile           359   \n",
+      "\n",
+      "  booker_country hotel_country   utrip_id  \n",
+      "0        Elbonia        Gondal  1000027_1  \n",
+      "1        Elbonia        Gondal  1000027_1  \n",
+      "2        Elbonia        Gondal  1000027_1  \n",
+      "3        Elbonia        Gondal  1000027_1  \n",
+      "4         Gondal  Cobra Island  1000033_1  \n"
+     ]
     }
    ],
    "source": [
-    "train.head()"
+    "# When displaying cudf dataframes use print() or display(), otherwise Jupyter creates hidden copies.\n",
+    "print(train.head())"
    ]
   },
   {
@@ -258,7 +209,7 @@
     "\n",
     "We will train a transformer model that can work with sequences of variable length within a batch. This functionality is provided to us out of the box and doesn't require any changes to the architecture. Thanks to it we do not have to pad or trim our sequences to any particular length -- our model can make effective use of all of the data!\n",
     "\n",
-    "With one exception. For a masked language model that we will be training, we need to discard sequences that are shorter than two hops. This makes sense as there is nothing our model could learn if it was only presented with an itinerary with a single destination on it!\n",
+    "*With one exception.* For a masked language model that we will be training, we need to discard sequences that are shorter than two hops. This makes sense as there is nothing our model could learn if it was only presented with an itinerary with a single destination on it!\n",
     "\n",
     "Let us begin by splitting the data into a train and validation set based on trip ID.\n",
     "\n",
@@ -272,19 +223,17 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "217686"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of unique trips is : 217686\n"
+     ]
     }
    ],
    "source": [
+    "# Unique trip ids.\n",
     "utrip_ids = train.sample(frac=1).utrip_id.unique()\n",
-    "len(utrip_ids)"
+    "print('Number of unique trips is :', len(utrip_ids))"
    ]
   },
   {
@@ -320,7 +269,24 @@
     "\n",
     "We will combine trips into \"sessions\", discard trips that are too short and calculate total trip length.\n",
     "\n",
-    "We will use NVTabular for this work. It offers optimized tabular data preprocessing operators that run on the GPU. If you would like to learn more about the NVTabular library, please take a look [here](https://github.com/NVIDIA-Merlin/NVTabular)."
+    "We will use NVTabular for this work. It offers optimized tabular data preprocessing operators that run on the GPU. If you would like to learn more about the NVTabular library, please take a look [here](https://github.com/NVIDIA-Merlin/NVTabular).\n",
+    "\n",
+    "Read more about the [Merlin's Dataset API](https://github.com/NVIDIA-Merlin/core/blob/main/merlin/io/dataset.py)  \n",
+    "Read more about how [parquet files are read in and processed by Merlin](https://github.com/NVIDIA-Merlin/core/blob/main/merlin/io/parquet.py)  \n",
+    "Read more about [Tags](https://github.com/NVIDIA-Merlin/core/blob/main/merlin/schema/tags.py)  \n",
+    "- [schema_select_by_tag](https://github.com/NVIDIA-Merlin/core/blob/main/merlin/schema/schema.py)  \n",
+    "\n",
+    "Read more about [NVTabular Workflows](https://github.com/NVIDIA-Merlin/NVTabular/blob/main/nvtabular/workflow/workflow.py)  \n",
+    "- [fit_transform](https://github.com/NVIDIA-Merlin/NVTabular/blob/main/nvtabular/workflow/workflow.py)\n",
+    "- [transform](https://github.com/NVIDIA-Merlin/NVTabular/blob/main/nvtabular/workflow/workflow.py)  \n",
+    "\n",
+    "Read more about the [NVTabular Operators]()  \n",
+    "- [Categorify](https://github.com/NVIDIA-Merlin/NVTabular/blob/main/nvtabular/ops/categorify.py)\n",
+    "- [AddTags](https://github.com/NVIDIA-Merlin/NVTabular/blob/main/nvtabular/ops/add_metadata.py)\n",
+    "- [LambdaOp](https://github.com/NVIDIA-Merlin/NVTabular/blob/main/nvtabular/ops/lambdaop.py)\n",
+    "- [Rename](https://github.com/NVIDIA-Merlin/NVTabular/blob/main/nvtabular/ops/rename.py)\n",
+    "- [Filter](https://github.com/NVIDIA-Merlin/NVTabular/blob/main/nvtabular/ops/filter.py)\n",
+    "\n"
    ]
   },
   {
@@ -597,7 +563,7 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>city_id_list</td>\n",
-       "      <td>(Tags.ID, Tags.ITEM_ID, Tags.SEQUENCE, Tags.CA...</td>\n",
+       "      <td>(Tags.SEQUENCE, Tags.CATEGORICAL, Tags.ITEM_ID...</td>\n",
        "      <td>int64</td>\n",
        "      <td>True</td>\n",
        "      <td>True</td>\n",
@@ -615,7 +581,7 @@
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>booker_country_list</td>\n",
-       "      <td>(Tags.ITEM, Tags.SEQUENCE, Tags.CATEGORICAL)</td>\n",
+       "      <td>(Tags.CATEGORICAL, Tags.SEQUENCE, Tags.ITEM)</td>\n",
        "      <td>int64</td>\n",
        "      <td>True</td>\n",
        "      <td>True</td>\n",
@@ -633,7 +599,7 @@
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>hotel_country_list</td>\n",
-       "      <td>(Tags.ITEM, Tags.SEQUENCE, Tags.CATEGORICAL)</td>\n",
+       "      <td>(Tags.CATEGORICAL, Tags.SEQUENCE, Tags.ITEM)</td>\n",
        "      <td>int64</td>\n",
        "      <td>True</td>\n",
        "      <td>True</td>\n",
@@ -651,7 +617,7 @@
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>weekday_checkin_list</td>\n",
-       "      <td>(Tags.ITEM, Tags.SEQUENCE, Tags.CATEGORICAL)</td>\n",
+       "      <td>(Tags.CATEGORICAL, Tags.SEQUENCE, Tags.ITEM)</td>\n",
        "      <td>int64</td>\n",
        "      <td>True</td>\n",
        "      <td>True</td>\n",
@@ -669,7 +635,7 @@
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>weekday_checkout_list</td>\n",
-       "      <td>(Tags.ITEM, Tags.SEQUENCE, Tags.CATEGORICAL)</td>\n",
+       "      <td>(Tags.CATEGORICAL, Tags.SEQUENCE, Tags.ITEM)</td>\n",
        "      <td>int64</td>\n",
        "      <td>True</td>\n",
        "      <td>True</td>\n",
@@ -689,7 +655,7 @@
        "</div>"
       ],
       "text/plain": [
-       "[{'name': 'city_id_list', 'tags': {<Tags.ID: 'id'>, <Tags.ITEM_ID: 'item_id'>, <Tags.SEQUENCE: 'sequence'>, <Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM: 'item'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0, 'max_size': 0, 'start_index': 0, 'cat_path': './/categories/unique.city_id_list.parquet', 'domain': {'min': 0, 'max': 37202, 'name': 'city_id_list'}, 'embedding_sizes': {'cardinality': 37203, 'dimension': 512}}, 'dtype': dtype('int64'), 'is_list': True, 'is_ragged': True}, {'name': 'booker_country_list', 'tags': {<Tags.ITEM: 'item'>, <Tags.SEQUENCE: 'sequence'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0, 'max_size': 0, 'start_index': 0, 'cat_path': './/categories/unique.booker_country_list.parquet', 'domain': {'min': 0, 'max': 5, 'name': 'booker_country_list'}, 'embedding_sizes': {'cardinality': 6, 'dimension': 16}}, 'dtype': dtype('int64'), 'is_list': True, 'is_ragged': True}, {'name': 'hotel_country_list', 'tags': {<Tags.ITEM: 'item'>, <Tags.SEQUENCE: 'sequence'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0, 'max_size': 0, 'start_index': 0, 'cat_path': './/categories/unique.hotel_country_list.parquet', 'domain': {'min': 0, 'max': 194, 'name': 'hotel_country_list'}, 'embedding_sizes': {'cardinality': 195, 'dimension': 31}}, 'dtype': dtype('int64'), 'is_list': True, 'is_ragged': True}, {'name': 'weekday_checkin_list', 'tags': {<Tags.ITEM: 'item'>, <Tags.SEQUENCE: 'sequence'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0, 'max_size': 0, 'start_index': 0, 'cat_path': './/categories/unique.weekday_checkin_list.parquet', 'domain': {'min': 0, 'max': 7, 'name': 'weekday_checkin_list'}, 'embedding_sizes': {'cardinality': 8, 'dimension': 16}}, 'dtype': dtype('int64'), 'is_list': True, 'is_ragged': True}, {'name': 'weekday_checkout_list', 'tags': {<Tags.ITEM: 'item'>, <Tags.SEQUENCE: 'sequence'>, <Tags.CATEGORICAL: 'categorical'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0, 'max_size': 0, 'start_index': 0, 'cat_path': './/categories/unique.weekday_checkout_list.parquet', 'domain': {'min': 0, 'max': 7, 'name': 'weekday_checkout_list'}, 'embedding_sizes': {'cardinality': 8, 'dimension': 16}}, 'dtype': dtype('int64'), 'is_list': True, 'is_ragged': True}]"
+       "[{'name': 'city_id_list', 'tags': {<Tags.SEQUENCE: 'sequence'>, <Tags.CATEGORICAL: 'categorical'>, <Tags.ITEM_ID: 'item_id'>, <Tags.ITEM: 'item'>, <Tags.ID: 'id'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0, 'max_size': 0, 'start_index': 0, 'cat_path': './/categories/unique.city_id_list.parquet', 'domain': {'min': 0, 'max': 37202, 'name': 'city_id_list'}, 'embedding_sizes': {'cardinality': 37203, 'dimension': 512}}, 'dtype': dtype('int64'), 'is_list': True, 'is_ragged': True}, {'name': 'booker_country_list', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.SEQUENCE: 'sequence'>, <Tags.ITEM: 'item'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0, 'max_size': 0, 'start_index': 0, 'cat_path': './/categories/unique.booker_country_list.parquet', 'domain': {'min': 0, 'max': 5, 'name': 'booker_country_list'}, 'embedding_sizes': {'cardinality': 6, 'dimension': 16}}, 'dtype': dtype('int64'), 'is_list': True, 'is_ragged': True}, {'name': 'hotel_country_list', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.SEQUENCE: 'sequence'>, <Tags.ITEM: 'item'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0, 'max_size': 0, 'start_index': 0, 'cat_path': './/categories/unique.hotel_country_list.parquet', 'domain': {'min': 0, 'max': 194, 'name': 'hotel_country_list'}, 'embedding_sizes': {'cardinality': 195, 'dimension': 31}}, 'dtype': dtype('int64'), 'is_list': True, 'is_ragged': True}, {'name': 'weekday_checkin_list', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.SEQUENCE: 'sequence'>, <Tags.ITEM: 'item'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0, 'max_size': 0, 'start_index': 0, 'cat_path': './/categories/unique.weekday_checkin_list.parquet', 'domain': {'min': 0, 'max': 7, 'name': 'weekday_checkin_list'}, 'embedding_sizes': {'cardinality': 8, 'dimension': 16}}, 'dtype': dtype('int64'), 'is_list': True, 'is_ragged': True}, {'name': 'weekday_checkout_list', 'tags': {<Tags.CATEGORICAL: 'categorical'>, <Tags.SEQUENCE: 'sequence'>, <Tags.ITEM: 'item'>}, 'properties': {'num_buckets': None, 'freq_threshold': 0, 'max_size': 0, 'start_index': 0, 'cat_path': './/categories/unique.weekday_checkout_list.parquet', 'domain': {'min': 0, 'max': 7, 'name': 'weekday_checkout_list'}, 'embedding_sizes': {'cardinality': 8, 'dimension': 16}}, 'dtype': dtype('int64'), 'is_list': True, 'is_ragged': True}]"
       ]
      },
      "execution_count": 11,
@@ -768,7 +734,24 @@
     "To summarize, Masked Language Modeling is implemented by using two blocks in combination:\n",
     "\n",
     "* `SequenceMaskRandom()` - Used as a pre for model.fit(), it randomly selects items from the sequence to be masked for prediction as targets, by using Keras masking.\n",
-    "* `ReplaceMaskedEmbeddings()` - Used as a pre for a `TransformerBlock`, it replaces the input embeddings at masked positions for prediction by a dummy trainable embedding, to avoid leakage of the targets."
+    "* `ReplaceMaskedEmbeddings()` - Used as a pre for a `TransformerBlock`, it replaces the input embeddings at masked positions for prediction by a dummy trainable embedding, to avoid leakage of the targets.\n",
+    "\n",
+    "\n",
+    "**Read more about the apis used to construct models** \n",
+    "- [blocks](https://github.com/NVIDIA-Merlin/models/tree/main/merlin/models/tf/blocks)\n",
+    "- [MLPBlock](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/blocks/mlp.py)\n",
+    "- [InputBlockV2](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/inputs/base.py)\n",
+    "- [Embeddings](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/inputs/embedding.py)\n",
+    "- [XLNetBlock](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/transformers/block.py)\n",
+    "- [ReplaceMaskedEmbeddings](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/transforms/sequence.py)\n",
+    "- [CategoricalOutput](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/outputs/classification.py)\n",
+    "- [.schema.select_by_name](https://github.com/NVIDIA-Merlin/core/blob/main/merlin/schema/schema.py)\n",
+    "- [.schema.select_by_tag](https://github.com/NVIDIA-Merlin/core/blob/main/merlin/schema/schema.py)\n",
+    "- [model.compile()](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/models/base.py)\n",
+    "- [model.fit()](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/models/base.py)\n",
+    "- [model.evaluate()](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/models/base.py)\n",
+    "- [mm.SequenceMaskRandom](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/transforms/sequence.py)\n",
+    "- [mm.SequenceMaskLast](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/transforms/sequence.py)"
    ]
   },
   {
@@ -822,7 +805,11 @@
      "output_type": "stream",
      "text": [
       "/usr/local/lib/python3.8/dist-packages/merlin/schema/tags.py:148: UserWarning: Compound tags like Tags.ITEM_ID have been deprecated and will be removed in a future version. Please use the atomic versions of these tags, like [<Tags.ITEM: 'item'>, <Tags.ID: 'id'>].\n",
-      "  warnings.warn(\n"
+      "  warnings.warn(\n",
+      "/usr/local/lib/python3.8/dist-packages/keras/initializers/initializers_v2.py:120: UserWarning: The initializer TruncatedNormal is unseeded and being called multiple times, which will return identical values  each time (even if the initializer is unseeded). Please update your code to provide a seed to the initializer, or avoid using the same initalizer instance more than once.\n",
+      "  warnings.warn(\n",
+      "2023-02-08 13:17:18.083919: I tensorflow/stream_executor/cuda/cuda_blas.cc:1633] TensorFloat-32 will be used for the matrix multiplication. This will only be logged once.\n",
+      "2023-02-08 13:17:18.254522: I tensorflow/stream_executor/cuda/cuda_dnn.cc:424] Loaded cuDNN version 8700\n"
      ]
     },
     {
@@ -836,14 +823,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-10 00:50:29.840560: I tensorflow/stream_executor/cuda/cuda_dnn.cc:424] Loaded cuDNN version 8500\n"
+      "/usr/local/lib/python3.8/dist-packages/merlin/schema/tags.py:148: UserWarning: Compound tags like Tags.ITEM_ID have been deprecated and will be removed in a future version. Please use the atomic versions of these tags, like [<Tags.ITEM: 'item'>, <Tags.ID: 'id'>].\n",
+      "  warnings.warn(\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WARNING:tensorflow:Gradients do not exist for variables ['model/mask_emb:0', 'transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer/layer_._0/rel_attn/seg_embed:0', 'transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss. If you're using `model.compile()`, did you forget to provide a `loss`argument?\n"
+      "WARNING:tensorflow:Gradients do not exist for variables ['model/mask_emb:0', 'transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer/layer_._0/rel_attn/seg_embed:0', 'transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss. If you're using `model.compile()`, did you forget to provide a `loss` argument?\n"
      ]
     },
     {
@@ -862,37 +850,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WARNING:tensorflow:Gradients do not exist for variables ['model/mask_emb:0', 'transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer/layer_._0/rel_attn/seg_embed:0', 'transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss. If you're using `model.compile()`, did you forget to provide a `loss`argument?\n"
+      "WARNING:tensorflow:Gradients do not exist for variables ['model/mask_emb:0', 'transformer/layer_._0/rel_attn/r_s_bias:0', 'transformer/layer_._0/rel_attn/seg_embed:0', 'transformer/layer_._1/rel_attn/r_s_bias:0', 'transformer/layer_._1/rel_attn/seg_embed:0'] when minimizing the loss. If you're using `model.compile()`, did you forget to provide a `loss` argument?\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-10 00:50:37.152856: W tensorflow/core/grappler/optimizers/loop_optimizer.cc:907] Skipping loop optimization for Merge node with control input: model/xl_net_block/replace_masked_embeddings/RaggedWhere/Assert/AssertGuard/branch_executed/_95\n",
-      "/usr/local/lib/python3.8/dist-packages/merlin/schema/tags.py:148: UserWarning: Compound tags like Tags.ITEM_ID have been deprecated and will be removed in a future version. Please use the atomic versions of these tags, like [<Tags.ITEM: 'item'>, <Tags.ID: 'id'>].\n",
-      "  warnings.warn(\n"
+      "2023-02-08 13:17:26.931275: W tensorflow/core/grappler/optimizers/loop_optimizer.cc:907] Skipping loop optimization for Merge node with control input: model/xl_net_block/replace_masked_embeddings/RaggedWhere/Assert/AssertGuard/branch_executed/_99\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2720/2720 [==============================] - 109s 36ms/step - loss: 1.0064 - recall_at_10: 0.0558 - mrr_at_10: 0.0235 - ndcg_at_10: 0.0311 - map_at_10: 0.0235 - precision_at_10: 0.0056 - regularization_loss: 0.0000e+00 - loss_batch: 1.0064\n",
+      "2720/2720 [==============================] - 112s 35ms/step - loss: 1.0077 - recall_at_10: 0.0725 - mrr_at_10: 0.0307 - ndcg_at_10: 0.0405 - map_at_10: 0.0307 - precision_at_10: 0.0073 - regularization_loss: 0.0000e+00 - loss_batch: 1.0077\n",
       "Epoch 2/5\n",
-      "2720/2720 [==============================] - 103s 36ms/step - loss: 0.8317 - recall_at_10: 0.1065 - mrr_at_10: 0.0488 - ndcg_at_10: 0.0624 - map_at_10: 0.0488 - precision_at_10: 0.0106 - regularization_loss: 0.0000e+00 - loss_batch: 0.8317\n",
+      "2720/2720 [==============================] - 104s 35ms/step - loss: 0.8326 - recall_at_10: 0.1148 - mrr_at_10: 0.0518 - ndcg_at_10: 0.0666 - map_at_10: 0.0518 - precision_at_10: 0.0115 - regularization_loss: 0.0000e+00 - loss_batch: 0.8327\n",
       "Epoch 3/5\n",
-      "2720/2720 [==============================] - 103s 36ms/step - loss: 0.7718 - recall_at_10: 0.1307 - mrr_at_10: 0.0606 - ndcg_at_10: 0.0771 - map_at_10: 0.0606 - precision_at_10: 0.0131 - regularization_loss: 0.0000e+00 - loss_batch: 0.7718\n",
+      "2720/2720 [==============================] - 104s 35ms/step - loss: 0.7727 - recall_at_10: 0.1392 - mrr_at_10: 0.0638 - ndcg_at_10: 0.0816 - map_at_10: 0.0638 - precision_at_10: 0.0139 - regularization_loss: 0.0000e+00 - loss_batch: 0.7728\n",
       "Epoch 4/5\n",
-      "2720/2720 [==============================] - 103s 36ms/step - loss: 0.7368 - recall_at_10: 0.1454 - mrr_at_10: 0.0680 - ndcg_at_10: 0.0862 - map_at_10: 0.0680 - precision_at_10: 0.0145 - regularization_loss: 0.0000e+00 - loss_batch: 0.7368\n",
+      "2720/2720 [==============================] - 106s 36ms/step - loss: 0.7374 - recall_at_10: 0.1575 - mrr_at_10: 0.0734 - ndcg_at_10: 0.0932 - map_at_10: 0.0734 - precision_at_10: 0.0157 - regularization_loss: 0.0000e+00 - loss_batch: 0.7374\n",
       "Epoch 5/5\n",
-      "2720/2720 [==============================] - 103s 36ms/step - loss: 0.7203 - recall_at_10: 0.1520 - mrr_at_10: 0.0710 - ndcg_at_10: 0.0901 - map_at_10: 0.0710 - precision_at_10: 0.0152 - regularization_loss: 0.0000e+00 - loss_batch: 0.7204\n"
+      "2720/2720 [==============================] - 105s 36ms/step - loss: 0.7196 - recall_at_10: 0.1657 - mrr_at_10: 0.0779 - ndcg_at_10: 0.0986 - map_at_10: 0.0779 - precision_at_10: 0.0166 - regularization_loss: 0.0000e+00 - loss_batch: 0.7196\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<keras.callbacks.History at 0x7f7e65771430>"
+       "<keras.callbacks.History at 0x7f87b09699a0>"
       ]
      },
      "execution_count": 14,
@@ -939,27 +925,27 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-10 00:59:14.752516: W tensorflow/core/grappler/optimizers/loop_optimizer.cc:907] Skipping loop optimization for Merge node with control input: model/xl_net_block/replace_masked_embeddings/RaggedWhere/Assert/AssertGuard/branch_executed/_74\n"
+      "2023-02-08 13:26:13.229779: W tensorflow/core/grappler/optimizers/loop_optimizer.cc:907] Skipping loop optimization for Merge node with control input: model/xl_net_block/replace_masked_embeddings/RaggedWhere/Assert/AssertGuard/branch_executed/_74\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "340/340 [==============================] - 21s 52ms/step - loss: 0.3304 - recall_at_10: 0.5542 - mrr_at_10: 0.3066 - ndcg_at_10: 0.3655 - map_at_10: 0.3066 - precision_at_10: 0.0554 - regularization_loss: 0.0000e+00 - loss_batch: 0.3302\n"
+      "340/340 [==============================] - 19s 44ms/step - loss: 0.3306 - recall_at_10: 0.5549 - mrr_at_10: 0.3080 - ndcg_at_10: 0.3668 - map_at_10: 0.3080 - precision_at_10: 0.0555 - regularization_loss: 0.0000e+00 - loss_batch: 0.3304\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'loss': 0.33035674691200256,\n",
-       " 'recall_at_10': 0.5542407035827637,\n",
-       " 'mrr_at_10': 0.3065614700317383,\n",
-       " 'ndcg_at_10': 0.3654871881008148,\n",
-       " 'map_at_10': 0.3065614700317383,\n",
-       " 'precision_at_10': 0.05542406067252159,\n",
+       "{'loss': 0.3305854797363281,\n",
+       " 'recall_at_10': 0.5549300312995911,\n",
+       " 'mrr_at_10': 0.3080165982246399,\n",
+       " 'ndcg_at_10': 0.36679476499557495,\n",
+       " 'map_at_10': 0.3080165982246399,\n",
+       " 'precision_at_10': 0.05549299716949463,\n",
        " 'regularization_loss': 0.0,\n",
-       " 'loss_batch': 0.28873005509376526}"
+       " 'loss_batch': 0.28271856904029846}"
       ]
      },
      "execution_count": 15,

--- a/merlin/models/tf/core/encoder.py
+++ b/merlin/models/tf/core/encoder.py
@@ -29,7 +29,7 @@ from merlin.models.tf.inputs.base import InputBlockV2
 from merlin.models.tf.inputs.embedding import CombinerType, EmbeddingTable
 from merlin.models.tf.models.base import BaseModel, get_output_schema
 from merlin.models.tf.outputs.topk import TopKOutput
-from merlin.models.tf.transforms.tensor import ProcessList
+from merlin.models.tf.transforms.tensor import PrepareFeatures
 from merlin.models.tf.utils import tf_utils
 from merlin.schema import ColumnSchema, Schema, Tags
 
@@ -73,7 +73,7 @@ class Encoder(tf.keras.Model):
         self.blocks = [input_block] + list(blocks) if blocks else [input_block]
         self.pre = pre
         self.post = post
-        self.process_list = ProcessList(self._schema)
+        self.prepare_features = PrepareFeatures(self._schema)
 
     def encode(
         self,
@@ -163,7 +163,7 @@ class Encoder(tf.keras.Model):
         return combinators.call_sequentially(
             list(self.to_call),
             inputs=inputs,
-            features=self.process_list(inputs),
+            features=self.prepare_features(inputs),
             targets=targets,
             training=training,
             testing=testing,

--- a/merlin/models/tf/inputs/base.py
+++ b/merlin/models/tf/inputs/base.py
@@ -31,7 +31,7 @@ from merlin.models.tf.inputs.embedding import (
     Embeddings,
     SequenceEmbeddingFeatures,
 )
-from merlin.models.tf.transforms.tensor import ListToDense, ProcessList
+from merlin.models.tf.transforms.tensor import ListToDense, PrepareFeatures
 from merlin.schema import Schema, Tags, TagsType
 
 LOG = logging.getLogger("merlin-models")
@@ -325,7 +325,7 @@ def InputBlockV2(
     if not parsed:
         raise ValueError("No columns selected for the input block")
 
-    _pre = ProcessList(schema)
+    _pre = PrepareFeatures(schema)
     if pre:
         _pre = _pre.connect(pre)
 

--- a/merlin/models/tf/inputs/continuous.py
+++ b/merlin/models/tf/inputs/continuous.py
@@ -47,6 +47,7 @@ class Continuous(Filter):
     ):
         if inputs is None:
             inputs = Tags.CONTINUOUS
+        self.supports_masking = True
         super().__init__(inputs, **kwargs)
 
 

--- a/merlin/models/tf/loader.py
+++ b/merlin/models/tf/loader.py
@@ -369,7 +369,7 @@ def sample_batch(
     include_targets: bool = True,
     to_ragged: bool = False,
     to_dense: bool = False,
-    process_lists=False,
+    prepare_features=False,
 ):
     """Util function to generate a batch of input tensors from a merlin.io.Dataset instance
 
@@ -387,6 +387,11 @@ def sample_batch(
         Whether to convert the tuple of sparse tensors into ragged tensors, by default False.
     to_dense: bool
         Whether to convert the tuple of sparse tensors into dense tensors, by default False.
+    prepare_features: bool
+        Whether to prepare features from dataloader for the model, by default False.
+        If enabled, it converts multi-hot/list features to dense or ragged based on the schema.
+        It also ensures that scalar features are converted to 2D (batch size, 1).
+        P.s. The features are automatically prepared by InputBlockV2 if it is used
     Returns:
     -------
     batch: Dict[tf.tensor]
@@ -397,7 +402,7 @@ def sample_batch(
             "Sparse values cannot be converted to both ragged tensors and dense tensors"
         )
 
-    from merlin.models.tf.transforms.tensor import ListToDense, ListToRagged, ProcessList
+    from merlin.models.tf.transforms.tensor import ListToDense, ListToRagged, PrepareFeatures
 
     if isinstance(dataset_or_loader, Dataset):
         if not batch_size:
@@ -414,8 +419,8 @@ def sample_batch(
         inputs = ListToRagged()(inputs)
     elif to_dense:
         inputs = ListToDense()(inputs)
-    if process_lists:
-        inputs = ProcessList(loader.schema)(inputs)
+    if prepare_features:
+        inputs = PrepareFeatures(loader.schema)(inputs)
     if not include_targets:
         return inputs
     return inputs, targets

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -50,7 +50,8 @@ from merlin.models.tf.models.utils import parse_prediction_blocks
 from merlin.models.tf.outputs.base import ModelOutput, ModelOutputType
 from merlin.models.tf.outputs.contrastive import ContrastiveOutput
 from merlin.models.tf.prediction_tasks.base import ParallelPredictionBlock, PredictionTask
-from merlin.models.tf.transforms.tensor import ProcessList
+from merlin.models.tf.transforms.sequence import SequenceTransform
+from merlin.models.tf.transforms.tensor import PrepareFeatures
 from merlin.models.tf.typing import TabularData
 from merlin.models.tf.utils.search_utils import find_all_instances_in_layers
 from merlin.models.tf.utils.tf_utils import (
@@ -996,6 +997,8 @@ class BaseModel(tf.keras.Model):
                         )
 
             if getattr(self, "train_pre", None):
+                if isinstance(self.train_pre, SequenceTransform):
+                    self.train_pre.on_train_begin()
                 out = call_layer(self.train_pre, x, targets=y, features=x, training=True)
                 if isinstance(out, Prediction):
                     x, y = out.outputs, out.targets

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -1476,7 +1476,7 @@ class Model(BaseModel):
             ]
             self.schema = sum(input_block_schemas, Schema())
 
-        self.process_list = ProcessList(self.schema)
+        self.prepare_features = PrepareFeatures(self.schema)
         self._frozen_blocks = set()
 
     def save(
@@ -1543,7 +1543,7 @@ class Model(BaseModel):
                     f"\n\t{call_input_features.difference(model_input_features)}"
                 )
 
-            _ragged_inputs = self.process_list(inputs)
+            _ragged_inputs = self.prepare_features(inputs)
             feature_shapes = {k: v.shape for k, v in _ragged_inputs.items()}
             feature_dtypes = {k: v.dtype for k, v in _ragged_inputs.items()}
 
@@ -1565,7 +1565,7 @@ class Model(BaseModel):
         """
         last_layer = None
 
-        input_shape = self.process_list.compute_output_shape(input_shape)
+        input_shape = self.prepare_features.compute_output_shape(input_shape)
 
         if self.pre is not None:
             self.pre.build(input_shape)
@@ -1592,7 +1592,7 @@ class Model(BaseModel):
 
     def call(self, inputs, targets=None, training=False, testing=False, output_context=False):
         context = self._create_context(
-            self.process_list(inputs),
+            self.prepare_features(inputs),
             targets=targets,
             training=training,
             testing=testing,

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -822,6 +822,8 @@ class BaseModel(tf.keras.Model):
         - Converts ragged targets (and their masks) to dense, so that they are compatible
         with most losses and metrics
         - Copies the targets mask to predictions mask, if defined
+        - If predictions are sequential (3-D) and targets are scalar (1-D), use predictions
+        mask to extract the predictions at target positions.
         - One-hot encode targets if their tf.rank(targets) == tf.rank(predictions)-1
         - Ensures targets have the same shape and dtype as predictions
 

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -397,7 +397,7 @@ class BaseModel(tf.keras.Model):
             name="should_compute_train_metrics_for_batch",
             trainable=False,
             synchronization=tf.VariableSynchronization.NONE,
-            initial_value=lambda: False,
+            initial_value=lambda: True,
         )
 
         num_v1_blocks = len(self.prediction_tasks)
@@ -1087,7 +1087,6 @@ class BaseModel(tf.keras.Model):
 
         return self(x, training=False)
 
-    @tf.function
     def train_compute_metrics(self, outputs: PredictionOutput, compiled_metrics: MetricsContainer):
         """Returns metrics for the outputs of this step.
 
@@ -1096,9 +1095,11 @@ class BaseModel(tf.keras.Model):
         # Compiled_metrics as an argument here because it is re-defined by `model.compile()`
         # And checking `self.compiled_metrics` inside this function results in a reference to
         # a deleted version of `compiled_metrics` if the model is re-compiled.
-        if self._should_compute_train_metrics_for_batch:
-            return self.compute_metrics(outputs, compiled_metrics)
-        return self.metrics_results()
+        return tf.cond(
+            self._should_compute_train_metrics_for_batch,
+            lambda: self.compute_metrics(outputs, compiled_metrics),
+            lambda: self.metrics_results(),
+        )
 
     def compute_metrics(
         self,

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -825,9 +825,8 @@ class BaseModel(tf.keras.Model):
                 )
             ]
         ):
-            if isinstance(prediction, tf.Tensor):
-                return tf.boolean_mask(prediction, prediction._keras_mask)
-            return prediction
+
+            return tf.boolean_mask(prediction, prediction._keras_mask)
 
     def _adjust_dense_predictions_and_targets(
         self,
@@ -914,18 +913,6 @@ class BaseModel(tf.keras.Model):
 
         # Ensuring targets and preds have the same dtype
         target = tf.cast(target, prediction.dtype)
-
-        # If targets are scalars (1-D) and predictions are sequential (3-D),
-        # extract predictions at target position because Keras expects
-        # predictions and targets to have the same shape.
-        if getattr(prediction, "_keras_mask", None) is not None:
-            rank_check = tf.logical_and(
-                tf.equal(tf.rank(target), 1),
-                tf.equal(tf.rank(prediction), 3),
-            )
-            prediction = tf.cond(
-                rank_check, lambda: self._extract_masked_predictions(prediction), lambda: prediction
-            )
 
         # Take the flat values of predictions and targets as Keras
         # losses does not support RaggedVariantTensor on GPU:

--- a/merlin/models/tf/transformers/block.py
+++ b/merlin/models/tf/transformers/block.py
@@ -31,7 +31,10 @@ from transformers import (
 
 from merlin.models.tf.core import combinators
 from merlin.models.tf.core.base import Block, block_registry
-from merlin.models.tf.transformers.transforms import PrepareTransformerInputs
+from merlin.models.tf.transformers.transforms import (
+    PrepareTransformerInputs,
+    TransformerInferenceHiddenState,
+)
 from merlin.models.tf.utils.tf_utils import (
     maybe_deserialize_keras_objects,
     maybe_serialize_keras_objects,
@@ -99,6 +102,8 @@ class TransformerBlock(Block):
             transformer_post = block_registry.parse(transformer_post)
         self.transformer_post = transformer_post
 
+        self.inference_post = TransformerInferenceHiddenState()
+
         if isinstance(pre, str):
             pre = block_registry.parse(pre)
 
@@ -143,6 +148,7 @@ class TransformerBlock(Block):
     @property
     def to_call_post(self):
         yield self.transformer_post
+        yield self.inference_post
 
         if self.post:
             yield self.post

--- a/merlin/models/tf/transformers/transforms.py
+++ b/merlin/models/tf/transformers/transforms.py
@@ -81,7 +81,10 @@ class TransformerInferenceHiddenState(Layer):
             If inference, returns a 2-D tensor with the hidden states of
             the target position
         """
-        batch_size = tf.shape(inputs)[0]
+        if isinstance(inputs, tf.RaggedTensor):
+            batch_size = tf.shape(inputs.row_lengths())[0]
+        else:
+            batch_size = tf.shape(inputs)[0]
         if not training and not testing:
             if isinstance(inputs, tf.RaggedTensor):
                 inputs = inputs[:, -1:, :]
@@ -91,13 +94,13 @@ class TransformerInferenceHiddenState(Layer):
                 inputs = tf.reshape(
                     tf.boolean_mask(inputs, inputs._keras_mask), (-1, inputs.shape[-1])
                 )
-        tf.debugging.assert_equal(
-            tf.shape(inputs)[0],
-            batch_size,
-            f"The resulting tensor has {tf.shape(inputs)[0]} rows, which does not match"
-            f" the inputs batch-size {batch_size}. During inference only one position "
-            "candidate (the last one) should be masked per example",
-        )
+            tf.debugging.assert_equal(
+                tf.shape(inputs)[0],
+                batch_size,
+                f"The resulting tensor has {tf.shape(inputs)[0]} rows, which does not match"
+                f" the inputs batch-size {batch_size}. During inference only one position "
+                "candidate (the last one) should be masked per example",
+            )
         return inputs
 
 

--- a/merlin/models/tf/transforms/features.py
+++ b/merlin/models/tf/transforms/features.py
@@ -812,7 +812,7 @@ def reshape_categorical_input_tensor_for_encoding(
 
 
 @tf.keras.utils.register_keras_serializable(package="merlin.models")
-class BroadcastToSequence(tf.keras.layers.Layer):
+class BroadcastToSequence(Block):
     """Broadcast context features to match the timesteps of sequence features.
 
     This layer supports mask propagation. If the sequence features have a mask. The
@@ -833,77 +833,121 @@ class BroadcastToSequence(tf.keras.layers.Layer):
         self.sequence_schema = sequence_schema
 
     def call(self, inputs: TabularData) -> TabularData:
-        inputs = self._broadcast(inputs, inputs)
+        inputs = self._broadcast(inputs)
         return inputs
 
-    def _get_seq_features_shapes(self, inputs: TabularData):
-        inputs_sizes = {k: v.shape for k, v in inputs.items()}
+    def _check_sequence_features(self, inputs: TabularData):
+        sequence_features = self.sequence_schema.column_names
 
-        seq_features_shapes = dict()
-        for fname, fshape in inputs_sizes.items():
-            # Saves the shapes of sequential features
-            if fname in self.sequence_schema.column_names:
-                seq_features_shapes[fname] = tuple(fshape[:2])
+        if len(sequence_features) == 0:
+            return
+
+        not_found_seq_features = set(sequence_features).difference(set(inputs.keys()))
+        if len(not_found_seq_features) > 0:
+            raise ValueError(
+                f"Some sequential features were not found in the inputs: {not_found_seq_features}"
+            )
 
         sequence_length = None
         sequence_is_ragged = None
-        if len(seq_features_shapes) > 0:
-            for k, v in inputs.items():
-                if k in self.sequence_schema.column_names:
-                    if isinstance(v, tf.RaggedTensor):
-                        if sequence_is_ragged is False:
-                            raise ValueError(
-                                "sequence features must all be ragged or all dense, not both."
-                            )
-                        new_sequence_length = v.row_lengths()
-                        sequence_is_ragged = True
-                    else:
-                        if sequence_is_ragged is True:
-                            raise ValueError(
-                                "sequence features must all be ragged or all dense, not both."
-                            )
-                        new_sequence_length = [v.shape[1]]
-                        sequence_is_ragged = False
-
-                    # check sequences lengths match
-                    if sequence_length is not None:
-                        sequence_lengths_equal = tf.math.reduce_all(
-                            tf.equal(new_sequence_length, sequence_length)
+        for k, v in inputs.items():
+            if k in sequence_features:
+                if isinstance(v, tf.RaggedTensor):
+                    if sequence_is_ragged is False:
+                        raise ValueError(
+                            "Sequential features must all be ragged or all dense, not both."
                         )
-                        tf.Assert(
-                            sequence_lengths_equal,
-                            [
-                                "sequence features must share the same sequence lengths",
-                                (sequence_length, new_sequence_length),
-                            ],
+                    new_sequence_length = v.row_lengths()
+                    sequence_is_ragged = True
+                else:
+                    if sequence_is_ragged is True:
+                        raise ValueError(
+                            "Sequential features must all be ragged or all dense, not both."
                         )
-                    sequence_length = new_sequence_length
+                    new_sequence_length = [v.shape[1]]
+                    sequence_is_ragged = False
 
-        return seq_features_shapes, sequence_length
+                # check sequences lengths match
+                if sequence_length is not None:
+                    sequence_lengths_equal = tf.math.reduce_all(
+                        tf.equal(new_sequence_length, sequence_length)
+                    )
+                    tf.Assert(
+                        sequence_lengths_equal,
+                        [
+                            "Sequential features must share the same sequence lengths",
+                            (sequence_length, new_sequence_length),
+                        ],
+                    )
+                sequence_length = new_sequence_length
+
+    def _check_context_features(self, inputs: TabularData):
+        context_features = self.context_schema.column_names
+
+        if len(context_features) == 0:
+            return
+
+        not_found_seq_features = set(context_features).difference(set(inputs.keys()))
+        if len(not_found_seq_features) > 0:
+            raise ValueError(
+                f"Some contextual features were not found in the inputs: {not_found_seq_features}"
+            )
+
+        for k in context_features:
+            v = inputs[k]
+            if not isinstance(v, tf.Tensor):
+                raise ValueError(f"A contextual feature ({k}) should be a dense tf.Tensor")
+
+            if len(v.shape) >= 3:
+                raise ValueError(
+                    f"A contextual feature ({k}) should be a 1D or " "2D tf.Tensor: {v.shape}."
+                )
 
     @tf.function
-    def _broadcast(self, inputs, target):
-        seq_features_shapes, sequence_length = self._get_seq_features_shapes(inputs)
-        if len(seq_features_shapes) > 0:
-            non_seq_features = set(inputs.keys()).difference(set(seq_features_shapes.keys()))
-            non_seq_target = {}
-            for fname in non_seq_features:
-                if fname in self.context_schema.column_names:
-                    if target[fname] is None:
-                        continue
-                    if isinstance(sequence_length, tf.Tensor):
-                        non_seq_target[fname] = tf.RaggedTensor.from_row_lengths(
-                            tf.repeat(target[fname], sequence_length, axis=0), sequence_length
-                        )
-                    else:
-                        shape = target[fname].shape
-                        target_shape = shape[:1] + sequence_length + shape[1:]
-                        non_seq_target[fname] = tf.broadcast_to(
-                            tf.expand_dims(target[fname], 1), target_shape
-                        )
-            target = {**target, **non_seq_target}
+    def _broadcast(self, inputs):
+        self._check_sequence_features(inputs)
+        self._check_context_features(inputs)
 
-        return target
+        sequence_features = self.sequence_schema.column_names
+        context_features = self.context_schema.column_names
+
+        if len(sequence_features) == 0 and len(context_features) == 0:
+            return inputs
+
+        sequence_features_values = list(
+            [inputs[k] for k in sequence_features if inputs[k] is not None]
+        )
+        if len(sequence_features_values) == 0:
+            return inputs
+        template_seq_feature_value = sequence_features_values[0]
+
+        non_seq_target = {}
+        for fname in context_features:
+            if inputs[fname] is None:
+                continue
+
+            if isinstance(template_seq_feature_value, tf.RaggedTensor):
+                new_value = inputs[fname]
+                while len(new_value.shape) < len(template_seq_feature_value.shape):
+                    new_value = tf.expand_dims(new_value, 1)
+
+                # Here broadcast the context feature using the same shape
+                # of a 3D ragged sequential feature with compatible
+                # So that the context feature shape becomes (batch size, seq length, feature dim)
+                non_seq_target[fname] = (
+                    tf.ones_like(template_seq_feature_value[..., :1], dtype=new_value.dtype)
+                    * new_value
+                )
+            else:
+                shape = inputs[fname].shape
+                sequence_length = template_seq_feature_value.shape[1]
+                target_shape = shape[:1] + [sequence_length] + shape[1:]
+                non_seq_target[fname] = tf.broadcast_to(
+                    tf.expand_dims(inputs[fname], 1), target_shape
+                )
+        inputs = {**inputs, **non_seq_target}
+
+        return inputs
 
     def compute_output_shape(
         self, input_shape: Dict[str, tf.TensorShape]
@@ -912,6 +956,7 @@ class BroadcastToSequence(tf.keras.layers.Layer):
         for k in input_shape:
             if k in self.sequence_schema.column_names:
                 sequence_length = input_shape[k][1]
+                break
 
         context_shapes = {}
         for k in input_shape:
@@ -934,6 +979,7 @@ class BroadcastToSequence(tf.keras.layers.Layer):
         for k in mask:
             if mask[k] is not None and k in self.sequence_schema.column_names:
                 sequence_mask = mask[k]
+                break
 
         # no sequence mask found
         if sequence_mask is None:
@@ -945,9 +991,7 @@ class BroadcastToSequence(tf.keras.layers.Layer):
             if mask[k] is None and k in self.context_schema.column_names:
                 masks_context[k] = sequence_mask
 
-        masks_other = self._broadcast(inputs, mask)
-
-        new_mask = {**masks_other, **masks_context}
+        new_mask = {**mask, **masks_context}
 
         return new_mask
 

--- a/merlin/models/tf/transforms/sequence.py
+++ b/merlin/models/tf/transforms/sequence.py
@@ -324,6 +324,7 @@ class SequencePredictLast(SequenceTransform):
         so that the tensors sequences can be processed
     """
 
+    @tf.function
     def call(
         self, inputs: TabularData, targets=None, training=False, testing=False, **kwargs
     ) -> Tuple:

--- a/merlin/models/tf/transforms/tensor.py
+++ b/merlin/models/tf/transforms/tensor.py
@@ -66,7 +66,7 @@ class ListToRagged(TabularBlock):
 
 
 @tf.keras.utils.register_keras_serializable(package="merlin.models")
-class ProcessList(TabularBlock):
+class PrepareFeatures(TabularBlock):
     """Process all list (multi-hot/sequential) features.add()
 
     In NVTabular, list-columns are represented as a tuple of (values, offsets).

--- a/merlin/models/tf/transforms/tensor.py
+++ b/merlin/models/tf/transforms/tensor.py
@@ -84,7 +84,7 @@ class ProcessList(TabularBlock):
 
         for name, val in inputs.items():
             is_ragged = True
-            if name in self.schema:
+            if name in self.schema.column_names:
                 val_count = self.schema[name].properties.get("value_count")
                 if (
                     val_count
@@ -101,6 +101,13 @@ class ProcessList(TabularBlock):
             elif isinstance(val, tf.RaggedTensor):
                 ragged = val
             else:
+                # Expanding / setting last dim of non-list features to be 1D
+                if (
+                    name in self.schema.column_names
+                    and not self.schema[name].is_list
+                    and not self.schema[name].is_ragged
+                ):
+                    val = tf.reshape(val, (-1, 1))
                 outputs[name] = val
                 continue
 

--- a/merlin/models/tf/utils/testing_utils.py
+++ b/merlin/models/tf/utils/testing_utils.py
@@ -103,7 +103,7 @@ def model_test(
 
         assert isinstance(loaded_model, type(model))
 
-        x, y = sample_batch(dataloader, batch_size=50, to_ragged=False, process_lists=False)
+        x, y = sample_batch(dataloader, batch_size=50, to_ragged=False, prepare_features=False)
         batch = [(x, y)]
 
         model_preds = model.predict(iter(batch))

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -469,3 +469,29 @@ def list_col_to_ragged(col: Tuple[tf.Tensor, tf.Tensor]):
         row_lengths = tf.cast(row_lengths, tf.int32)
 
     return tf.RaggedTensor.from_row_lengths(values, row_lengths)
+
+
+def check_inputs_mask_compatible_shape(
+    inputs: Union[tf.Tensor, tf.RaggedTensor], mask: Union[tf.Tensor, tf.RaggedTensor]
+):
+    """Checks if the shape and the type of the input and mask tensors are compatible.
+    Parameters
+    ----------
+    inputs : Union[tf.Tensor, tf.RaggedTensor]
+        The input tensor, which can be either a dense or ragged tensor.
+    mask : Union[tf.Tensor, tf.RaggedTensor]
+        The mask tensor, which can be either a dense or ragged tensor.
+
+    Returns
+    -------
+    bool: True if the shape of the input and mask tensors are compatible, False otherwise.
+    """
+    result = False
+    if type(inputs) == type(mask) and (inputs.shape.as_list()[:-1] == mask.shape.as_list()):
+        if isinstance(inputs, tf.RaggedTensor):
+            result = tf.reduce_all(
+                tf.cast(inputs.row_lengths(), tf.int32) == tf.cast(mask.row_lengths(), tf.int32)
+            )
+        else:
+            result = True
+    return result

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -487,7 +487,9 @@ def check_inputs_mask_compatible_shape(
     bool: True if the shape of the input and mask tensors are compatible, False otherwise.
     """
     result = False
-    if type(inputs) == type(mask) and (inputs.shape.as_list()[:-1] == mask.shape.as_list()):
+    if type(inputs) == type(mask) and (
+        inputs.shape.as_list()[: len(mask.shape)] == mask.shape.as_list()
+    ):
         if isinstance(inputs, tf.RaggedTensor):
             result = tf.reduce_all(
                 tf.cast(inputs.row_lengths(), tf.int32) == tf.cast(mask.row_lengths(), tf.int32)

--- a/tests/unit/datasets/test_synthetic.py
+++ b/tests/unit/datasets/test_synthetic.py
@@ -46,7 +46,7 @@ def test_tf_tensors_generation_cpu():
 
     from merlin.models.tf import sample_batch
 
-    tensors, _ = sample_batch(data, batch_size=100, process_lists=False)
+    tensors, _ = sample_batch(data, batch_size=100)
     assert tensors["user_id"].shape == (100, 1)
     assert tensors["user_age"].dtype == tf.float64
     for name, val in filter_dict_by_schema(tensors, schema.select_by_tag(Tags.LIST)).items():
@@ -68,7 +68,7 @@ def test_sequence_data_length(generate_data_kwargs, expected_sequence_length):
 
     from merlin.models.tf import sample_batch
 
-    tensors, y = sample_batch(data, batch_size=1, process_lists=False)
+    tensors, y = sample_batch(data, batch_size=1)
 
     for col in ["item_id_seq", "categories"]:
         assert all(tensors[col][1] == expected_sequence_length)

--- a/tests/unit/tf/blocks/retrieval/test_two_tower.py
+++ b/tests/unit/tf/blocks/retrieval/test_two_tower.py
@@ -112,7 +112,7 @@ def test_two_tower_block_with_l2_norm_on_towers_outputs(testing_data: Dataset):
 
 def test_two_tower_block_tower_save(testing_data: Dataset, tmp_path):
     two_tower = ml.TwoTowerBlock(testing_data.schema, query_tower=ml.MLPBlock([64, 128]))
-    features, _ = ml.sample_batch(testing_data, batch_size=100, process_lists=False)
+    features, _ = ml.sample_batch(testing_data, batch_size=100)
     two_tower(features)
 
     query_tower = two_tower.query_block()

--- a/tests/unit/tf/blocks/test_interactions.py
+++ b/tests/unit/tf/blocks/test_interactions.py
@@ -87,7 +87,7 @@ def test_fm_block_with_multi_hot_categ_features(testing_data: Dataset):
         factors_dim=32,
     )
 
-    batch, _ = mm.sample_batch(testing_data, batch_size=16, process_lists=False)
+    batch, _ = mm.sample_batch(testing_data, batch_size=16)
 
     output = fm_block(batch)
     assert output.shape.as_list() == [16, 1]

--- a/tests/unit/tf/blocks/test_mlp.py
+++ b/tests/unit/tf/blocks/test_mlp.py
@@ -103,10 +103,10 @@ def test_mlp_model_with_sequential_features_and_combiner(
         model, loader, run_eagerly=run_eagerly, reload_model=True, fit_kwargs={"pre": predict_last}
     )
 
-    metrics = model.evaluate(loader, batch_size=8, steps=1, return_dict=True, pre=predict_last)
+    metrics = model.evaluate(loader, steps=1, return_dict=True, pre=predict_last)
     assert len(metrics) > 0
 
-    predictions = model.predict(loader, batch_size=8, steps=1)
+    predictions = model.predict(loader, steps=1)
     assert predictions.shape == (8, 51997)
 
 

--- a/tests/unit/tf/inputs/test_base.py
+++ b/tests/unit/tf/inputs/test_base.py
@@ -30,7 +30,7 @@ def test_concat_sequence(sequence_testing_data):
         ),
     )
 
-    inputs = mm.sample_batch(sequence_testing_data, 8, include_targets=False, process_lists=True)
+    inputs = mm.sample_batch(sequence_testing_data, 8, include_targets=False, prepare_features=True)
 
     outputs = seq_inputs(inputs)
 

--- a/tests/unit/tf/inputs/test_continuous.py
+++ b/tests/unit/tf/inputs/test_continuous.py
@@ -80,7 +80,7 @@ def test_continuous_features_ragged(sequence_testing_data: Dataset):
     inputs = ml.ContinuousFeatures.from_schema(
         schema, post=ml.BroadcastToSequence(context_schema, seq_schema), aggregation="concat"
     )
-    features, _ = ml.sample_batch(sequence_testing_data, batch_size=100, process_lists=True)
+    features, _ = ml.sample_batch(sequence_testing_data, batch_size=100, prepare_features=True)
     outputs = inputs(features)
 
     assert outputs.to_tensor().shape == (100, 4, 6)

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -220,6 +220,7 @@ class UpdateCountMetric(tf.keras.metrics.Metric):
             self.call_count.assign(tf.constant([0.0]))
 
 
+@pytest.mark.parametrize("run_eagerly", [True, False])
 @pytest.mark.parametrize(
     ["num_rows", "batch_size", "train_metrics_steps", "expected_steps", "expected_metrics_steps"],
     [
@@ -230,7 +231,7 @@ class UpdateCountMetric(tf.keras.metrics.Metric):
     ],
 )
 def test_train_metrics_steps(
-    num_rows, batch_size, train_metrics_steps, expected_steps, expected_metrics_steps
+    run_eagerly, num_rows, batch_size, train_metrics_steps, expected_steps, expected_metrics_steps
 ):
     dataset = generate_data("e-commerce", num_rows=num_rows)
     model = mm.Model(
@@ -239,7 +240,7 @@ def test_train_metrics_steps(
         mm.BinaryClassificationTask("click"),
     )
     model.compile(
-        run_eagerly=True,
+        run_eagerly=run_eagerly,
         optimizer="adam",
         metrics=[UpdateCountMetric()],
     )

--- a/tests/unit/tf/models/test_ranking.py
+++ b/tests/unit/tf/models/test_ranking.py
@@ -371,7 +371,7 @@ def test_wide_deep_model_wide_onehot_multihot_feature_interaction(ecommerce_data
         ),
     ]
 
-    batch, _ = mm.sample_batch(ml_dataset, batch_size=100, process_lists=False)
+    batch, _ = mm.sample_batch(ml_dataset, batch_size=100)
 
     output_wide_features = mm.ParallelBlock(wide_preprocessing_blocks)(batch)
     assert set(output_wide_features.keys()) == set(

--- a/tests/unit/tf/transforms/test_features.py
+++ b/tests/unit/tf/transforms/test_features.py
@@ -749,7 +749,7 @@ class TestBroadcastToSequence(tf.test.TestCase):
                 "s2": tf.constant([[[1, 2], [3, 4]], [[6, 3], [2, 3]]]),
             }
             layer(inputs)
-        assert "sequence features must share the same sequence lengths" in str(exc_info.value)
+        assert "Sequential features must share the same sequence lengths" in str(exc_info.value)
 
     def test_different_sequence_lengths_ragged(self):
         context_schema = Schema([ColumnSchema("c1")])
@@ -762,7 +762,7 @@ class TestBroadcastToSequence(tf.test.TestCase):
                 "s2": tf.ragged.constant([[[1, 2], [3, 4]], [[6, 3], [2, 3]]]),
             }
             layer(inputs)
-        assert "sequence features must share the same sequence lengths" in str(exc_info.value)
+        assert "Sequential features must share the same sequence lengths" in str(exc_info.value)
 
     def test_ragged_and_dense_features(self):
         context_schema = Schema([ColumnSchema("c1")])
@@ -775,7 +775,9 @@ class TestBroadcastToSequence(tf.test.TestCase):
                 "s2": tf.ragged.constant([[[1, 2], [3, 4]], [[6, 3], [2, 3]]]),
             }
             layer(inputs)
-        assert "sequence features must all be ragged or all dense, not both" in str(exc_info.value)
+        assert "Sequential features must all be ragged or all dense, not both" in str(
+            exc_info.value
+        )
 
     def test_mask_propagation(self):
         masking_layer = tf.keras.layers.Masking(mask_value=0)
@@ -815,7 +817,7 @@ class TestBroadcastToSequence(tf.test.TestCase):
         sequence_schema = Schema([ColumnSchema("b")])
 
         broadcast_layer = BroadcastToSequence(context_schema, sequence_schema)
-        model = mm.Model(broadcast_layer)
+        model = mm.Model(broadcast_layer, schema=context_schema + sequence_schema)
         outputs = model(partially_masked_inputs)
 
         self.assertAllEqual(outputs["a"]._keras_mask, tf.ragged.constant([[True], [False, True]]))
@@ -855,7 +857,42 @@ class TestBroadcastToSequence(tf.test.TestCase):
         outputs = broadcast_layer(inputs)
         self.assertAllEqual(outputs["sequence_embedding"].shape, tf.TensorShape([3, None, 2]))
         self.assertAllEqual(outputs["context_a"].shape, tf.TensorShape([3, None, 1]))
-        self.assertAllEqual(outputs["context_b"].shape, tf.TensorShape([3, None]))
+        self.assertAllEqual(outputs["context_b"].shape, tf.TensorShape([3, None, 1]))
+
+
+def test_broadcast_to_sequence_input_block(sequence_testing_data: Dataset):
+    schema = sequence_testing_data.schema
+    seq_schema = schema.select_by_name(["item_id_seq", "categories", "item_age_days_norm"])
+    context_schema = schema.select_by_name(["user_age", "user_country"])
+    sequence_testing_data.schema = seq_schema + context_schema
+
+    input_block = mm.InputBlockV2(
+        sequence_testing_data.schema,
+        embeddings=mm.Embeddings(
+            seq_schema.select_by_tag(Tags.CATEGORICAL)
+            + context_schema.select_by_tag(Tags.CATEGORICAL),
+            sequence_combiner=None,
+        ),
+        post=mm.BroadcastToSequence(context_schema, seq_schema),
+        aggregation=None,
+    )
+
+    batch = mm.sample_batch(
+        sequence_testing_data, batch_size=100, include_targets=False, to_ragged=True
+    )
+    input_batch = input_block(batch)
+    assert set(input_batch.keys()) == set(
+        ["item_id_seq", "categories", "item_age_days_norm", "user_age", "user_country"]
+    )
+    assert set([len(v.shape) for v in input_batch.values()]) == set([3])
+    assert set([tuple(list(v.shape)[:-1]) for v in input_batch.values()]) == set(
+        [tuple([100, None])]
+    )
+    assert list(input_batch["item_id_seq"].shape) == [100, None, 32]
+    assert list(input_batch["categories"].shape) == [100, None, 16]
+    assert list(input_batch["item_age_days_norm"].shape) == [100, None, 1]
+    assert list(input_batch["user_age"].shape) == [100, None, 1]
+    assert list(input_batch["user_country"].shape) == [100, None, 8]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/tf/transforms/test_negative_sampling.py
+++ b/tests/unit/tf/transforms/test_negative_sampling.py
@@ -185,7 +185,7 @@ class TestAddRandomNegativesToBatch:
         testing_utils.model_test(model, dataset, run_eagerly=run_eagerly, reload_model=True)
 
         batch_size = 10
-        features, targets = mm.sample_batch(dataset, batch_size=batch_size, process_lists=True)
+        features, targets = mm.sample_batch(dataset, batch_size=batch_size, prepare_features=True)
 
         with_negatives = model(features, targets=targets, training=True)
         assert with_negatives.predictions.shape[0] >= 50

--- a/tests/unit/tf/transforms/test_sequence.py
+++ b/tests/unit/tf/transforms/test_sequence.py
@@ -207,6 +207,8 @@ def test_seq_predict_masked_serialize_deserialize(sequence_testing_data):
 def test_seq_mask_random_replace_embeddings(
     sequence_testing_data: Dataset, dense: bool, target_as_dict: bool
 ):
+    from merlin.models.tf.transforms.sequence import ExtractMaskFromTargets
+
     seq_schema = sequence_testing_data.schema.select_by_tag(Tags.SEQUENCE).select_by_name(
         ["item_id_seq", "categories"]
     )
@@ -233,7 +235,7 @@ def test_seq_mask_random_replace_embeddings(
         # Making targets different in dict, the valid one is "target2" which is 2D
         targets = {"target1": tf.ragged.constant([1, 2, 3, 4, 5, 6, 7, 8]), "target2": targets}
 
-    masked_embeddings = mm.ReplaceMaskedEmbeddings()
+    masked_embeddings = mm.SequentialBlock(ExtractMaskFromTargets(), mm.ReplaceMaskedEmbeddings())
     output = masked_embeddings(item_id_emb_seq, targets=targets, training=True)
 
     replaced_mask = tf.logical_not(tf.reduce_all(output == item_id_emb_seq, axis=2))
@@ -245,23 +247,27 @@ def test_seq_mask_random_replace_embeddings(
 
 
 def test_replace_masked_input_embeddings_no_target():
+    from merlin.models.tf.transforms.sequence import ExtractMaskFromTargets
+
     item_id_emb_seq = tf.random.uniform((8, 10), dtype=tf.float32)
     item_id_emb_seq._keras_mask = tf.cast(
         tf.random.uniform((8,), minval=0, maxval=2, dtype=tf.int32), tf.bool
     )
     targets = None
 
-    masked_embeddings = mm.ReplaceMaskedEmbeddings()
+    masked_embeddings = mm.SequentialBlock(ExtractMaskFromTargets(), mm.ReplaceMaskedEmbeddings())
     output = masked_embeddings(item_id_emb_seq, targets=targets, training=True)
     # Checks that no input embedding was replaced, as there was no masking defined
     tf.Assert(tf.logical_not(tf.reduce_all(output == item_id_emb_seq)), [])
 
 
 def test_not_replace_unmasked_sequence_embeddings():
+    from merlin.models.tf.transforms.sequence import ExtractMaskFromTargets
+
     item_id_emb_seq = tf.random.uniform((8, 10), dtype=tf.float32)
     targets = tf.random.uniform((8, 10), dtype=tf.float32)
 
-    masked_embeddings = mm.ReplaceMaskedEmbeddings()
+    masked_embeddings = mm.SequentialBlock(ExtractMaskFromTargets(), mm.ReplaceMaskedEmbeddings())
     output = masked_embeddings(item_id_emb_seq, targets=targets, training=True)
     # Checks that no input embedding was replaced, as there was no masking defined
     tf.Assert(tf.reduce_all(output == item_id_emb_seq), [])

--- a/tests/unit/tf/transforms/test_sequence.py
+++ b/tests/unit/tf/transforms/test_sequence.py
@@ -162,8 +162,7 @@ def test_seq_random_masking(sequence_testing_data: Dataset):
 
     batch, _ = mm.sample_batch(sequence_testing_data, batch_size=8, process_lists=False)
 
-    output = predict_masked(batch)
-    output_x, output_y = output.outputs, output.targets
+    output_x, output_y = predict_masked(batch)
     output_y = output_y[target]
 
     tf.Assert(tf.reduce_all(output_y == output_x[target]), [output_y, output_x[target]])
@@ -218,8 +217,7 @@ def test_seq_mask_random_replace_embeddings(
 
     batch, _ = mm.sample_batch(sequence_testing_data, batch_size=8, process_lists=False)
 
-    output = predict_masked(batch)
-    inputs, targets = output.outputs, output.targets
+    inputs, targets = predict_masked(batch)
     targets = targets[target]
 
     emb = tf.keras.layers.Embedding(1000, 16)

--- a/tests/unit/tf/transforms/test_sequence.py
+++ b/tests/unit/tf/transforms/test_sequence.py
@@ -26,15 +26,12 @@ from merlin.schema import Tags
 def test_seq_predict_next(sequence_testing_data: Dataset):
     seq_schema = sequence_testing_data.schema.select_by_tag(Tags.SEQUENCE)
     target = sequence_testing_data.schema.select_by_tag(Tags.ITEM_ID).column_names[0]
-    predict_next = mm.SequencePredictNext(schema=seq_schema, target=target, pre=mm.ListToRagged())
+    predict_next = mm.SequencePredictNext(schema=seq_schema, target=target)
 
-    batch, _ = mm.sample_batch(sequence_testing_data, batch_size=8, process_lists=False)
+    batch, _ = mm.sample_batch(sequence_testing_data, batch_size=8, prepare_features=True)
     output = predict_next(batch)
     output_x, output_y = output
     output_y = output_y[target]
-
-    as_ragged = mm.ListToRagged()
-    batch = as_ragged(batch)
 
     # Checks if sequential input features were truncated in the last position
     for k, v in batch.items():
@@ -55,13 +52,10 @@ def test_seq_predict_last(sequence_testing_data: Dataset):
     target = sequence_testing_data.schema.select_by_tag(Tags.ITEM_ID).column_names[0]
     predict_last = mm.SequencePredictLast(schema=seq_schema, target=target)
 
-    batch, _ = mm.sample_batch(sequence_testing_data, batch_size=8, process_lists=False)
+    batch, _ = mm.sample_batch(sequence_testing_data, batch_size=8, prepare_features=True)
     output = predict_last(batch)
     output_x, output_y = output
     output_y = output_y[target]
-
-    as_ragged = mm.ListToRagged()
-    batch = as_ragged(batch)
 
     # Checks if sequential input features were truncated in the last position
     for k, v in batch.items():
@@ -83,13 +77,11 @@ def test_seq_predict_random(sequence_testing_data: Dataset):
     target = sequence_testing_data.schema.select_by_tag(Tags.ITEM_ID).column_names[0]
     predict_random = mm.SequencePredictRandom(schema=seq_schema, target=target)
 
-    batch, _ = mm.sample_batch(sequence_testing_data, batch_size=8, process_lists=False)
+    batch, _ = mm.sample_batch(sequence_testing_data, batch_size=8, prepare_features=True)
     output = predict_random(batch)
     output_x, output_y = output
     output_y = output_y[target]
 
-    as_ragged = mm.ListToRagged()
-    batch = as_ragged(batch)
     batch_size = batch[target].shape[0]
 
     for k, v in batch.items():
@@ -108,7 +100,7 @@ def test_seq_predict_random(sequence_testing_data: Dataset):
             tf.Assert(tf.reduce_all(output_x[k] == v), [output_x[k], v])
 
     # Checks if the target has the right shape
-    tf.Assert(tf.reduce_all(tf.shape(output_y) == batch_size), [])
+    tf.Assert(tf.reduce_all(tf.shape(output_y) == tf.TensorShape((batch_size, 1))), [])
 
 
 def test_seq_predict_next_output_shape(sequence_testing_data):
@@ -160,7 +152,7 @@ def test_seq_random_masking(sequence_testing_data: Dataset):
     target = sequence_testing_data.schema.select_by_tag(Tags.ITEM_ID).column_names[0]
     predict_masked = mm.SequenceMaskRandom(schema=seq_schema, target=target, masking_prob=0.3)
 
-    batch, _ = mm.sample_batch(sequence_testing_data, batch_size=8, process_lists=False)
+    batch, _ = mm.sample_batch(sequence_testing_data, batch_size=8, prepare_features=True)
 
     output_x, output_y = predict_masked(batch)
     output_y = output_y[target]
@@ -170,9 +162,6 @@ def test_seq_random_masking(sequence_testing_data: Dataset):
     target_mask = output_y._keras_mask
 
     asserts_mlm_target_mask(target_mask)
-
-    as_ragged = mm.ListToRagged()
-    batch = as_ragged(batch)
 
     for k, v in batch.items():
         # Checking if inputs values didn't change
@@ -215,7 +204,7 @@ def test_seq_mask_random_replace_embeddings(
     target = sequence_testing_data.schema.select_by_tag(Tags.ITEM_ID).column_names[0]
     predict_masked = mm.SequenceMaskRandom(schema=seq_schema, target=target, masking_prob=0.3)
 
-    batch, _ = mm.sample_batch(sequence_testing_data, batch_size=8, process_lists=False)
+    batch, _ = mm.sample_batch(sequence_testing_data, batch_size=8, prepare_features=False)
 
     inputs, targets = predict_masked(batch)
     targets = targets[target]


### PR DESCRIPTION
Fixes #918 
- It is built on top of the 23.02 release branch to be able to merge it with the main branch of the tutorial image ( it will use the latest release container)

This PR aims to address the following limitations in the current Transformer API:

1. **Inference for CausalLM is not supported**: the model returns scores for all positions in the input sequence but we are only interested on the last position at inference time.
2. **CLM only supports the transform SequencePredictNext**: We cannot train or evaluate a CLM model on the last item of the sequence only (i.e using SequencePredictLast)
3. **Specialized and complex API**: the support of masking and inference is done via specialized Merlin Blocks (`ReplaceMaskedEmbeddings`, `SequenceMaskLastInference`). So the user should be familiar with all these custom blocks to correctly define and train a transformer-based model with CLM or MLM approach.
4. **Output of the model is a padded dense tensor of scores**: As the HuggingFace transformer layer is requiring a dense input. We are converting the ragged inputs to dense (by 0-padding to the maximum length seen in the given batch) right before calling the HF layer. The ops that follow this block are then applied to the padded dense tensor. This means that we compute the logit scores for all positions (even the padded ones) and which can be costly (such in the weight tying multiplication between the hidden representation all items embeddings).

- With this PR, you can train a transformer model with masked language modeling as follows: 
```
    model = mm.Model(
        mm.InputBlockV2(...),
        mm.MLPBlock([64]),
        XLNetBlock(
            d_model=64,
            n_head=8,
            n_layer=2,
            masking="masked",
        ),
        mm.CategoricalOutput(
            seq_schema.select_by_name(target),
            default_loss="categorical_crossentropy",
        ),
    )
    seq_mask_random = mm.SequenceMaskRandom(schema=seq_schema, target=target, masking_prob=0.3)
    model.compile(...)
    model.fit(..., pre=seq_mask_random)

```

* I created this doc for more details about the Merlin TransformerAPI: https://docs.google.com/document/d/1auNJCOPFjyVxlhx4eUUthpMLm-rva0jC-lo0ChSZWzI/edit#

### Goals :soccer:
- [x] Add Inference support to a transformer-based model trained with CLM: i.e. select the prediction score of the last non-padded position.  

- [x] Support evaluating a transformer-based model trained with CLM (trained with SequencePredictNext) on the last item in the sequence (i.e using SequencePredictLast). 

- [x] Simplify the transformer API by adding a string parameter `masking` to indicate whether we train with a `masked` or `causal` approach. 

- [x] Optimize the predictions generation of transformer-based model: Convert the dense tensor returned by the transformer layer to a `tf.RaggedTensor` so that all the logic happening after the transformer block (MLP projections, softmax layer...) is applied only on actual positions.

- [ ] Add checks to ensure the specified `masking` is used with the correct `pre` in fit/evaluate methods.

- [ ] Implement an RNNBlock to support training with SequencePredictNext but evaluate on last position only (SequencePredictLast)

- [ ] Create documentation about session-based models (RNN and Transformers).

- [ ] Update the example notebooks 

### Implementation Details :construction:

- Add a `masking` argument to the TransformerBlock class to abstract the custom blocks needed for training with `causal` of `masked` language modeling. 

- Add masking support for `SequencePredictNext` and `SequencePredictLast`

- Implement the following specialized blocks (needed for CLM and MLM support): 
    *  `SequenceCausalLastInference` to generate a mask indicating the last non-padded position of each input sequence at inference time. 
    * `ExtractMaskFromTargets` to move the logic defined in `ReplaceMaskedEmbeddings` and which consists of inferring the mask information based on targets. 
    * `TransformerOutputToRagged` to convert the output of the transformer layer to Ragged based on the mask information. 

- Added a new method in `_extract_masked_predictions` to extract predictions at target positions when targets are scalars (i.e 1-D).  This is needed to support evaluating a transformer model trained with CLM (i.e. SequencePredictNext) on the last item of the sequence only (i.e SequencePredictLast). 



### Testing Details :mag:
- Update `test_transformer_with_masked_language_modeling` and `test_transformer_with_causal_language_modeling` to account for the changes. 

## Dependency: 
https://github.com/NVIDIA-Merlin/models/pull/983