### PR TITLE
add a new word to ignore_codespell_words

### DIFF
--- a/ci/ignore_codespell_words.txt
+++ b/ci/ignore_codespell_words.txt
@@ -2,3 +2,4 @@ als
 coo
 childrens
 te
+initalizer


### PR DESCRIPTION
This [PR](https://github.com/NVIDIA-Merlin/models/pull/975) is blocked by codespell  error bcs of automatic output coming from a cell it is not something we typed, it is output of `model.fit()` automatic keras msg.. it complains about  the  word `initalizer` printed out in this automatic msg. To unblock the PR I am adding the word `initalizer` in the `ci/ignore_codespell_words.txt`.