### PR TITLE
Fixes lower train metrics when using Keras Masking (SequenceMaskRandom, SequenceMaskLast)

### DIFF
--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -978,7 +978,6 @@ class BaseModel(tf.keras.Model):
 
         return self(x, training=False)
 
-    @tf.function
     def train_compute_metrics(self, outputs: PredictionOutput, compiled_metrics: MetricsContainer):
         """Returns metrics for the outputs of this step.
 

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -986,9 +986,11 @@ class BaseModel(tf.keras.Model):
         # Compiled_metrics as an argument here because it is re-defined by `model.compile()`
         # And checking `self.compiled_metrics` inside this function results in a reference to
         # a deleted version of `compiled_metrics` if the model is re-compiled.
-        if self._should_compute_train_metrics_for_batch:
-            return self.compute_metrics(outputs, compiled_metrics)
-        return self.metrics_results()
+        return tf.cond(
+            self._should_compute_train_metrics_for_batch,
+            lambda: self.compute_metrics(outputs, compiled_metrics),
+            lambda: self.metrics_results(),
+        )
 
     def compute_metrics(
         self,

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -396,7 +396,7 @@ class BaseModel(tf.keras.Model):
             name="should_compute_train_metrics_for_batch",
             trainable=False,
             synchronization=tf.VariableSynchronization.NONE,
-            initial_value=lambda: False,
+            initial_value=lambda: True,
         )
 
         num_v1_blocks = len(self.prediction_tasks)

--- a/tests/unit/tf/models/test_base.py
+++ b/tests/unit/tf/models/test_base.py
@@ -220,6 +220,7 @@ class UpdateCountMetric(tf.keras.metrics.Metric):
             self.call_count.assign(tf.constant([0.0]))
 
 
+@pytest.mark.parametrize("run_eagerly", [True, False])
 @pytest.mark.parametrize(
     ["num_rows", "batch_size", "train_metrics_steps", "expected_steps", "expected_metrics_steps"],
     [
@@ -230,7 +231,7 @@ class UpdateCountMetric(tf.keras.metrics.Metric):
     ],
 )
 def test_train_metrics_steps(
-    num_rows, batch_size, train_metrics_steps, expected_steps, expected_metrics_steps
+    run_eagerly, num_rows, batch_size, train_metrics_steps, expected_steps, expected_metrics_steps
 ):
     dataset = generate_data("e-commerce", num_rows=num_rows)
     model = mm.Model(
@@ -239,7 +240,7 @@ def test_train_metrics_steps(
         mm.BinaryClassificationTask("click"),
     )
     model.compile(
-        run_eagerly=True,
+        run_eagerly=run_eagerly,
         optimizer="adam",
         metrics=[UpdateCountMetric()],
     )


### PR DESCRIPTION
Fixes #961 

### Goals :soccer:
This PR fix an issue that caused metrics obtained with `model.fit()` being much lower than the ones obtained with `model.evaluate()` when Keras Masking is used.
This bug was observed when comparing training and evaluation metrics of a Transformer example (as described in #961 ), which makes usage of Keras Masking (SequenceMaskRandom, SequenceMaskLast) to select items of the sequence for training / eval.

### Implementation Details :construction:
- After investigation, I found out that the issue was been caused by the `@tf.function` decorator we had in `model.train_compute_metrics()`. After replacing a condition inside that function by `tf.cond()`, it was possible to remove the `@tf.function` decorator and fix the error when using Keras Masking (i.e., setting `predictions._keras_mask`).

### Testing Details :mag:
- Included tests in graph mode for `test_train_metrics_steps`, to double check that the logic inside `model.train_compute_metrics()` that skips steps for computing metrics continue to working in eager and graph mode.
