### PR TITLE
Fix BroadcastToSequence to enable context features in sequential models

### DIFF
--- a/merlin/models/tf/inputs/continuous.py
+++ b/merlin/models/tf/inputs/continuous.py
@@ -47,6 +47,7 @@ class Continuous(Filter):
     ):
         if inputs is None:
             inputs = Tags.CONTINUOUS
+        self.supports_masking = True
         super().__init__(inputs, **kwargs)
 
 

--- a/merlin/models/tf/transforms/sequence.py
+++ b/merlin/models/tf/transforms/sequence.py
@@ -20,7 +20,6 @@ from tensorflow.keras.backend import random_bernoulli
 
 from merlin.models.tf.core.base import Block, BlockType, PredictionOutput
 from merlin.models.tf.core.combinators import TabularBlock
-from merlin.models.tf.core.prediction import Prediction
 from merlin.models.tf.transforms.tensor import ListToRagged
 from merlin.models.tf.typing import TabularData
 from merlin.models.tf.utils import tf_utils
@@ -400,7 +399,7 @@ class SequenceTargetAsInput(SequenceTransform):
     @tf.function
     def call(
         self, inputs: TabularData, targets=None, training=False, testing=False, **kwargs
-    ) -> Prediction:
+    ) -> Tuple:
         self._check_seq_inputs_targets(inputs)
 
         new_target = tf.identity(inputs[self.target_name])
@@ -411,7 +410,7 @@ class SequenceTargetAsInput(SequenceTransform):
         else:
             raise ValueError("Targets should be None or a dict of tensors")
 
-        return Prediction(inputs, targets)
+        return (inputs, targets)
 
     @classmethod
     def from_config(cls, config):
@@ -480,13 +479,14 @@ class SequenceMaskRandom(SequenceTargetAsInput):
         self.target_mask = self._generate_target_mask(item_id_seq)
 
         inputs_mask = dict()
-        for k, v in inputs.items():
+        for k in inputs:
             if k in self.schema.column_names:
                 inputs_mask[k] = self.target_mask
             else:
                 inputs_mask[k] = None
 
-        return (inputs_mask, self.target_mask)
+        targets_mask = dict({self.target_name: self.target_mask})
+        return (inputs_mask, targets_mask)
 
     def _generate_target_mask(self, ids_seq: tf.RaggedTensor) -> tf.RaggedTensor:
         """Generates a target mask according to the defined probability and

--- a/merlin/models/tf/transforms/tensor.py
+++ b/merlin/models/tf/transforms/tensor.py
@@ -84,7 +84,7 @@ class ProcessList(TabularBlock):
 
         for name, val in inputs.items():
             is_ragged = True
-            if name in self.schema:
+            if name in self.schema.column_names:
                 val_count = self.schema[name].properties.get("value_count")
                 if (
                     val_count
@@ -102,7 +102,11 @@ class ProcessList(TabularBlock):
                 ragged = val
             else:
                 # Expanding / setting last dim of non-list features to be 1D
-                if not self.schema[name].is_list and not self.schema[name].is_ragged:
+                if (
+                    name in self.schema.column_names
+                    and not self.schema[name].is_list
+                    and not self.schema[name].is_ragged
+                ):
                     val = tf.reshape(val, (-1, 1))
                 outputs[name] = val
                 continue

--- a/merlin/models/tf/transforms/tensor.py
+++ b/merlin/models/tf/transforms/tensor.py
@@ -101,6 +101,9 @@ class ProcessList(TabularBlock):
             elif isinstance(val, tf.RaggedTensor):
                 ragged = val
             else:
+                # Expanding / setting last dim of non-list features to be 1D
+                if not self.schema[name].is_list and not self.schema[name].is_ragged:
+                    val = tf.reshape(val, (-1, 1))
                 outputs[name] = val
                 continue
 

--- a/tests/unit/tf/transformers/test_block.py
+++ b/tests/unit/tf/transformers/test_block.py
@@ -408,3 +408,57 @@ def test_transformer_with_masked_language_modeling_check_eval_masked(
     # Ensures metrics masking only last positions are different then the ones
     # considering all positions
     assert not _metrics_almost_equal(metrics_all_positions1, metrics_last_positions)
+
+
+@pytest.mark.parametrize("run_eagerly", [True, False])
+def test_transformer_model_with_masking_and_broadcast_to_sequence(
+    sequence_testing_data: Dataset, run_eagerly: bool
+):
+    schema = sequence_testing_data.schema
+    seq_schema = schema.select_by_name(["item_id_seq", "categories", "item_age_days_norm"])
+    context_schema = schema.select_by_name(["user_country", "user_age"])
+    sequence_testing_data.schema = seq_schema + context_schema
+
+    target = schema.select_by_tag(Tags.ITEM_ID).column_names[0]
+    item_id_name = schema.select_by_tag(Tags.ITEM_ID).first.properties["domain"]["name"]
+
+    input_block = mm.InputBlockV2(
+        sequence_testing_data.schema,
+        embeddings=mm.Embeddings(
+            seq_schema.select_by_tag(Tags.CATEGORICAL)
+            + context_schema.select_by_tag(Tags.CATEGORICAL),
+            sequence_combiner=None,
+        ),
+        post=mm.BroadcastToSequence(context_schema, seq_schema),
+    )
+
+    dmodel = 32
+    mlp_block = mm.MLPBlock([128, dmodel], activation="relu")
+
+    dense_block = mm.SequentialBlock(
+        input_block,
+        mlp_block,
+        mm.GPT2Block(
+            d_model=dmodel,
+            n_head=4,
+            n_layer=2,
+            pre=mm.ReplaceMaskedEmbeddings(),
+            post="inference_hidden_state",
+        ),
+    )
+
+    mlp_block2 = mm.MLPBlock([128, dmodel], activation="relu")
+
+    prediction_task = mm.CategoricalOutput(
+        to_call=input_block["categorical"][item_id_name],
+    )
+    model = mm.Model(dense_block, mlp_block2, prediction_task)
+
+    fit_pre = mm.SequenceMaskRandom(schema=seq_schema, target=target, masking_prob=0.3)
+    testing_utils.model_test(
+        model,
+        sequence_testing_data,
+        run_eagerly=run_eagerly,
+        reload_model=False,
+        fit_kwargs={"pre": fit_pre},
+    )

--- a/tests/unit/tf/transforms/test_features.py
+++ b/tests/unit/tf/transforms/test_features.py
@@ -885,7 +885,9 @@ def test_broadcast_to_sequence_input_block(sequence_testing_data: Dataset):
         ["item_id_seq", "categories", "item_age_days_norm", "user_age", "user_country"]
     )
     assert set([len(v.shape) for v in input_batch.values()]) == set([3])
-    assert set([v.shape[:-1] for v in input_batch.values()]) == set([tf.TensorShape([100, None])])
+    assert set([tuple(list(v.shape)[:-1]) for v in input_batch.values()]) == set(
+        [tuple([100, None])]
+    )
     assert list(input_batch["item_id_seq"].shape) == [100, None, 32]
     assert list(input_batch["categories"].shape) == [100, None, 16]
     assert list(input_batch["item_age_days_norm"].shape) == [100, None, 1]

--- a/tests/unit/tf/transforms/test_sequence.py
+++ b/tests/unit/tf/transforms/test_sequence.py
@@ -162,8 +162,7 @@ def test_seq_random_masking(sequence_testing_data: Dataset):
 
     batch, _ = mm.sample_batch(sequence_testing_data, batch_size=8, process_lists=False)
 
-    output = predict_masked(batch)
-    output_x, output_y = output.outputs, output.targets
+    output_x, output_y = predict_masked(batch)
     output_y = output_y[target]
 
     tf.Assert(tf.reduce_all(output_y == output_x[target]), [output_y, output_x[target]])
@@ -216,8 +215,7 @@ def test_seq_mask_random_replace_embeddings(
 
     batch, _ = mm.sample_batch(sequence_testing_data, batch_size=8, process_lists=False)
 
-    output = predict_masked(batch)
-    inputs, targets = output.outputs, output.targets
+    inputs, targets = predict_masked(batch)
     targets = targets[target]
 
     emb = tf.keras.layers.Embedding(1000, 16)


### PR DESCRIPTION
Fixes #989

### Goals :soccer:
This PR fixes `BroadcastToSequence`, which was not working properly in some cases

### Implementation Details :construction:
- `BroadcastToSequence` was not working in graph mode because the contextual features were being expanded to match the shape of sequential features using a logic like the following snippet, which was making the first dim (batch size) of the resulting tensor fixed, while the other sequential tensors had the first dim as None (bcs the batch size might vary).
```python
sequence_length = inputs["a_sequential_feature"].row_lengths()
broadcasted_contextual_feature = tf.RaggedTensor.from_row_lengths(
    tf.repeat(inputs["a_contextual_feature"], sequence_length, axis=0), 
    sequence_length 
)
```

The solution I found to keep the first dim of the expanded context feature tensor matching the other sequential features was using `tf.ones_like()` to create a (ragged) tensor matching the sequential feature shape and then multiply by the context feature (equivalent to repeat it), as the following example

```python
first_seq_feature_name = list(seq_features_shapes.keys())[0]
non_seq_target[fname] = tf.ones_like(
                            inputs[first_seq_feature_name][..., :1]
                         ) * tf.expand_dims(inputs["a_contextual_feature"], -1)
```

This PR also includes other fixes:
- `Continuous` block now forwards masking (`supports_masking=True`)
- `BroadcastToSequence` was refactored to separate the logic that checks if sequential and context features in the input match the schema, otherwise exceptions are raised now.
- In `BroadcastToSequence.compute_mask()`  I don't call `self._broadcast()` and the logic there was made simpler: the expanded contextual feature mask should match the sequential feature mask.
- The `SequenceTargetAsInput` now returns a `tuple` instead of a `Prediction`, so that Keras can better align the `inputs` and `targets` output from `call()` and `compute_mask()` of child classes.
- In `ProcessList`, reshaping scalar features (is_list=False,is_ragged=False) to be 2D (batch size, 1), as the last dim was None in graph mode and was causing issues when concatenating

### Testing Details :mag:
Have added new tests for testing `BroadcastToSequence` usage as a `post` of `InputBlockV2`, with both categorical and continuous context (non-sequential) features and also to test it in a Transformer model trained with masked language modeling.
