### PR TITLE
Enable pre-commit to check latest available versions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,6 +15,7 @@ jobs:
           python-version: '3.8'
           cache: 'pip'
           cache-dependency-path: '**/**.txt'
+          check-latest: true
       - name: Install black Jupyter
         run : |
           pip install black[jupyter]==22.3.0


### PR DESCRIPTION
Pre-commit hook on Github Actions CI is failing with:
```
          RuntimeError: The Poetry configuration is invalid:
            - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'
```
which is due to a broken release of `isort` and upgrading `isort` should fix the issue: https://stackoverflow.com/questions/75281731/pre-commit-fails-to-install-isort-5-10-1-with-error-runtimeerror-the-poetry-co.

This PR sets [check-latest](https://github.com/actions/setup-python/blob/3faddefb4c02470d61266571df739b19e3a006be/action.yml#L15-L17) option in order to enable pre-commit to check the latest versions.