### PR TITLE
Wrap SequencePredictLast with tf.function

### DIFF
--- a/merlin/models/tf/transforms/sequence.py
+++ b/merlin/models/tf/transforms/sequence.py
@@ -269,6 +269,7 @@ class SequencePredictLast(SequenceTransform):
         so that the tensors sequences can be processed
     """
 
+    @tf.function
     def call(
         self, inputs: TabularData, targets=None, training=False, testing=False, **kwargs
     ) -> Tuple:

--- a/tests/unit/tf/blocks/test_mlp.py
+++ b/tests/unit/tf/blocks/test_mlp.py
@@ -103,10 +103,10 @@ def test_mlp_model_with_sequential_features_and_combiner(
         model, loader, run_eagerly=run_eagerly, reload_model=True, fit_kwargs={"pre": predict_last}
     )
 
-    metrics = model.evaluate(loader, batch_size=8, steps=1, return_dict=True, pre=predict_last)
+    metrics = model.evaluate(loader, steps=1, return_dict=True, pre=predict_last)
     assert len(metrics) > 0
 
-    predictions = model.predict(loader, batch_size=8, steps=1)
+    predictions = model.predict(loader, steps=1)
     assert predictions.shape == (8, 51997)
 
 


### PR DESCRIPTION
Similarly to #938, this PR adds `tf.function` to `SequencePredictLast` in order to reduce flakiness in `tests/unit/tf/blocks/test_mlp.py::test_mlp_model_with_sequential_features_and_combiner` due to [an issue with list columns in dataloader](https://github.com/NVIDIA-Merlin/dataloader/issues/74). This test is sometimes failing non-deterministically in the pre-release pipeline for 23.02 release.

### Testing Details :mag:
```
$ pytest --count=10 -x tests/unit/tf/blocks/test_mlp.py::test_mlp_model_with_sequential_features_and_combiner
=========================================== test session starts ============================================
platform linux -- Python 3.8.10, pytest-7.2.1, pluggy-1.0.0
rootdir: /code/models, configfile: pyproject.toml
plugins: repeat-0.9.1, anyio-3.6.2
collected 690 items / 670 deselected / 20 selected                                                         

tests/unit/tf/blocks/test_mlp.py ....................                                                [100%]

====================== 20 passed, 670 deselected, 121 warnings in 1554.77s (0:25:54) =======================
```