### PR TITLE
Save and load LightFM model and schemas

### DIFF
--- a/merlin/models/io.py
+++ b/merlin/models/io.py
@@ -17,7 +17,6 @@ import os
 import pathlib
 from typing import Optional, Union
 
-from merlin.models.api import MerlinModel
 from merlin.models.utils.schema_utils import schema_to_tensorflow_metadata_json
 from merlin.schema import Schema
 
@@ -26,7 +25,6 @@ _MERLIN_METADATA_DIR_NAME = ".merlin"
 
 def save_merlin_metadata(
     export_path: Union[str, os.PathLike],
-    model: MerlinModel,
     input_schema: Optional[Schema],
     output_schema: Optional[Schema],
 ) -> None:

--- a/merlin/models/lightfm/__init__.py
+++ b/merlin/models/lightfm/__init__.py
@@ -14,12 +14,24 @@
 # limitations under the License.
 #
 import multiprocessing
+import os
+import pickle
+from pathlib import Path
+from typing import Optional, Union
 
 import lightfm
 import lightfm.evaluation
 
 from merlin.io import Dataset
-from merlin.models.utils.dataset import dataset_to_coo
+from merlin.models.io import save_merlin_metadata
+from merlin.models.utils.dataset import (
+    dataset_to_coo,
+    item_id_column_name,
+    target_column_name,
+    user_id_column_name,
+)
+from merlin.models.utils.schema_utils import schema_to_tensorflow_metadata_json
+from merlin.schema import Schema
 
 
 class LightFM:
@@ -41,12 +53,35 @@ class LightFM:
 
         # evaluate the model given the validation set
         print(model.evaluate(valid))
+
+        # save the model
+        model.save("/path/to/dir")
+
+        # reload the model
+        model = LightFM.load("/path/to/dir")
     """
 
-    def __init__(self, *args, epochs=10, num_threads=0, **kwargs):
+    def __init__(
+        self,
+        *args,
+        epochs: int = 10,
+        num_threads: int = 0,
+        schema: Optional[Schema] = None,
+        target_column: Optional[str] = None,
+        **kwargs,
+    ):
         self.lightfm_model = lightfm.LightFM(*args, **kwargs)
         self.epochs = epochs
         self.num_threads = num_threads or multiprocessing.cpu_count()
+        self.schema = schema
+        self.target_column = target_column
+        self._select_features_and_column_from_schema()
+
+    def _select_features_and_column_from_schema(self):
+        if self.schema:
+            self.user_id_column = user_id_column_name(self.schema)
+            self.item_id_column = item_id_column_name(self.schema)
+            self.target_column = self.target_column or target_column_name(self.schema)
 
     def fit(self, train: Dataset):
         """Trains the lightfm model
@@ -59,7 +94,11 @@ class LightFM:
             If there is a column tagged as Tags.TARGET we will also use that for the values,
             otherwise will be set to 1
         """
-        data = dataset_to_coo(train).tocsr()
+        if not self.schema:
+            self.schema = train.schema
+            self._select_features_and_column_from_schema()
+
+        data = dataset_to_coo(train, target_column=self.target_column).tocsr()
         self.lightfm_model.fit(data, epochs=self.epochs, num_threads=self.num_threads)
         self.train_data = data
 
@@ -77,7 +116,7 @@ class LightFM:
             How many items to return per prediction
         """
 
-        test = dataset_to_coo(test_dataset).tocsr()
+        test = dataset_to_coo(test_dataset, target_column=self.target_column).tocsr()
 
         # lightfm needs the test set to have the same dimensionality as the train set
         test.resize(self.train_data.shape)
@@ -99,5 +138,45 @@ class LightFM:
         k: int
             The number of recommendations to generate for each user
         """
-        data = dataset_to_coo(dataset)
+        data = dataset_to_coo(dataset, target_column=self.target_column)
         return self.lightfm_model.predict(data.row, data.col)
+
+    def save(self, path: Union[str, os.PathLike]) -> None:
+        """Saves the model to export_path using pickle, along with merlin
+        model metadata.
+
+        Parameters
+        ----------
+        path: Union[str, os.PathLike]
+            Directory where the model will be saved.
+        """
+        export_dir = Path(path)
+        export_dir.mkdir(parents=True)
+
+        with open(export_dir / "lightfm_model.pkl", "wb") as f:
+            pickle.dump(self, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+        schema_to_tensorflow_metadata_json(self.schema, export_dir / "schema.json")
+        save_merlin_metadata(
+            export_dir,
+            self.schema.select_by_name([self.user_id_column, self.item_id_column]),
+            self.schema.select_by_name(self.target_column) if self.target_column else None,
+        )
+
+    @classmethod
+    def load(self, path: Union[str, os.PathLike]) -> "LightFM":
+        """Load the model from a directory where a model has been saved.
+
+        Parameters
+        ----------
+        path: Union[str, os.PathLike]
+            Path where a Merlin LightFM model has been saved.
+
+        Returns
+        -------
+        LightFM model instance.
+        """
+        load_dir = Path(path)
+        with open(load_dir / "lightfm_model.pkl", "rb") as f:
+            model = pickle.load(f)
+        return model

--- a/merlin/models/lightfm/__init__.py
+++ b/merlin/models/lightfm/__init__.py
@@ -26,9 +26,9 @@ from merlin.io import Dataset
 from merlin.models.io import save_merlin_metadata
 from merlin.models.utils.dataset import (
     dataset_to_coo,
-    item_id_column_name,
-    target_column_name,
-    user_id_column_name,
+    get_item_id_column_name,
+    get_target_column_name,
+    get_user_id_column_name,
 )
 from merlin.models.utils.schema_utils import schema_to_tensorflow_metadata_json
 from merlin.schema import Schema
@@ -79,9 +79,9 @@ class LightFM:
 
     def _select_features_and_column_from_schema(self):
         if self.schema:
-            self.user_id_column = user_id_column_name(self.schema)
-            self.item_id_column = item_id_column_name(self.schema)
-            self.target_column = self.target_column or target_column_name(self.schema)
+            self.user_id_column = get_user_id_column_name(self.schema)
+            self.item_id_column = get_item_id_column_name(self.schema)
+            self.target_column = self.target_column or get_target_column_name(self.schema)
 
     def fit(self, train: Dataset):
         """Trains the lightfm model

--- a/merlin/models/tf/core/encoder.py
+++ b/merlin/models/tf/core/encoder.py
@@ -238,7 +238,7 @@ class Encoder(tf.keras.Model):
         )
         input_schema = self.schema
         output_schema = get_output_schema(export_path)
-        save_merlin_metadata(export_path, self, input_schema, output_schema)
+        save_merlin_metadata(export_path, input_schema, output_schema)
 
     @property
     def to_call(self):

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -1400,7 +1400,7 @@ class Model(BaseModel):
         )
         input_schema = self.schema
         output_schema = get_output_schema(export_path)
-        save_merlin_metadata(export_path, self, input_schema, output_schema)
+        save_merlin_metadata(export_path, input_schema, output_schema)
 
     @classmethod
     def load(cls, export_path: Union[str, os.PathLike]) -> "Model":

--- a/merlin/models/xgb/__init__.py
+++ b/merlin/models/xgb/__init__.py
@@ -258,7 +258,6 @@ class XGBoost:
 
         save_merlin_metadata(
             export_dir,
-            self,
             self.schema.select_by_name(self.feature_columns),
             self.schema.select_by_name(self.target_columns),
         )

--- a/tests/unit/lightfm/test_lightfm.py
+++ b/tests/unit/lightfm/test_lightfm.py
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import numpy as np
 from pathlib import Path
+
+import numpy as np
 import pytest
 
 from merlin.datasets.synthetic import generate_data
 from merlin.models.lightfm import LightFM
 from merlin.schema import Tags
-
 
 np.random.seed(0)
 
@@ -39,7 +39,7 @@ def test_warp():
     assert metrics["auc"] > 0.01
 
 
-def test_warp():
+def test_multiple_targets_raise_error():
     train, _ = generate_data("music-streaming", 100, (0.95, 0.05))
 
     model = LightFM()
@@ -52,7 +52,6 @@ def test_warp():
         "Expected a single target column but found  ['click', 'play_percentage', 'like']"
     )
     assert error_message in str(excinfo.value)
-
 
 
 def test_reload_no_target_column(tmpdir):
@@ -75,7 +74,7 @@ def test_reload_no_target_column(tmpdir):
     assert reloaded.schema == model.schema
     assert reloaded.user_id_column == model.user_id_column
     assert reloaded.item_id_column == model.item_id_column
-    assert reloaded.target_column == model.target_column
+    assert reloaded.target_column is None
 
 
 def test_reload_with_target_column(tmpdir):
@@ -101,4 +100,4 @@ def test_reload_with_target_column(tmpdir):
     assert reloaded.schema == model.schema
     assert reloaded.user_id_column == model.user_id_column
     assert reloaded.item_id_column == model.item_id_column
-    assert reloaded.target_column == model.target_column
+    assert reloaded.target_column == "click"


### PR DESCRIPTION
Partially addresses https://github.com/NVIDIA-Merlin/Merlin/issues/825.

### Goals :soccer:
Enable LightFM to save and load the model and schemas.

### Implementation Details :construction:
- Adds `save()` that saves the LightFM object as a pickle. It also outputs input and output schemas along with the model.
- Adds `load()` that can load the saved model and schema back into memory.

### Testing Details :mag:
Added unit tests to `tests/unit/lightfm/test_lightfm.py`.