### PR TITLE
Increase tolerance in retrieval transformer test and set random seed

### DIFF
--- a/tests/unit/tf/transformers/test_block.py
+++ b/tests/unit/tf/transformers/test_block.py
@@ -3,6 +3,7 @@ import itertools
 import numpy as np
 import pytest
 import tensorflow as tf
+from tensorflow.keras.utils import set_random_seed
 from transformers import BertConfig
 
 import merlin.models.tf as mm
@@ -27,6 +28,8 @@ def test_import():
 
 @pytest.mark.parametrize("run_eagerly", [True])
 def test_retrieval_transformer(sequence_testing_data: Dataset, run_eagerly):
+    set_random_seed(42)
+
     sequence_testing_data.schema = sequence_testing_data.schema.select_by_tag(
         Tags.SEQUENCE
     ).select_by_tag(Tags.CATEGORICAL)
@@ -77,7 +80,7 @@ def test_retrieval_transformer(sequence_testing_data: Dataset, run_eagerly):
     assert list(item_embeddings.shape) == [51997, d_model]
     predicitons_2 = np.dot(query_embeddings, item_embeddings.T)
 
-    np.testing.assert_allclose(predictions, predicitons_2, atol=1e-7)
+    np.testing.assert_allclose(predictions, predicitons_2, atol=1e-6)
 
 
 def test_transformer_encoder():


### PR DESCRIPTION
### Goals :soccer:
Reduce flakiness in `tests/unit/tf/transformers/test_block.py::test_retrieval_transformer`.

### Implementation Details :construction:
The test fails quite often in the pre-release pipeline:
```
>       np.testing.assert_allclose(predictions, predicitons_2, atol=1e-7)
E       AssertionError: 
E       Not equal to tolerance rtol=1e-07, atol=1e-07
E       
E       Mismatched elements: 32133 / 5199700 (0.618%)
E       Max absolute difference: 9.0152025e-07
E       Max relative difference: 0.27157608
E        x: array([[-0.008857, -0.003986, -0.026853, ..., -0.02331 , -0.025297,
E                0.020051],
E              [ 0.049813,  0.02344 ,  0.020474, ...,  0.034797, -0.004637,...
E        y: array([[-0.008857, -0.003986, -0.026853, ..., -0.02331 , -0.025297,
E                0.020051],
E              [ 0.049813,  0.02344 ,  0.020474, ...,  0.034797, -0.004637,...

tests/unit/tf/transformers/test_block.py:81: AssertionError
```

This PR sets the random seed and increases the absolute tolerance to `1e-6` (based on the error log `Max absolute difference: 9.0152025e-07`) in hopes of reducing flakiness.
