### PR TITLE
Use globally insatlled installed packages for GPU tests

### DIFF
--- a/merlin/models/utils/dependencies.py
+++ b/merlin/models/utils/dependencies.py
@@ -47,3 +47,14 @@ def is_transformers_available() -> bool:
     except ImportError:
         transformers = None
     return transformers is not None
+
+
+def is_cudf_available() -> bool:
+    try:
+        import cudf
+    except ImportError:
+        cudf = None
+    return cudf is not None
+
+
+assert is_cudf_available() is True

--- a/merlin/models/utils/dependencies.py
+++ b/merlin/models/utils/dependencies.py
@@ -47,14 +47,3 @@ def is_transformers_available() -> bool:
     except ImportError:
         transformers = None
     return transformers is not None
-
-
-def is_cudf_available() -> bool:
-    try:
-        import cudf
-    except ImportError:
-        cudf = None
-    return cudf is not None
-
-
-assert is_cudf_available() is True

--- a/tests/unit/lightfm/test_lightfm.py
+++ b/tests/unit/lightfm/test_lightfm.py
@@ -62,7 +62,7 @@ def test_reload_no_target_column(tmpdir):
     model = LightFM(learning_rate=0.05, loss="warp", epochs=10)
     model.fit(train)
 
-    _ = model.evaluate(valid)
+    _ = model.evaluate(valid, k=10)
 
     model_dir = Path(tmpdir) / "lightfm_model"
 
@@ -88,7 +88,7 @@ def test_reload_with_target_column(tmpdir):
     model = LightFM(learning_rate=0.05, loss="warp", epochs=10)
     model.fit(train)
 
-    _ = model.evaluate(valid)
+    _ = model.evaluate(valid, k=10)
 
     model_dir = Path(tmpdir) / "lightfm_model"
 

--- a/tests/unit/lightfm/test_lightfm.py
+++ b/tests/unit/lightfm/test_lightfm.py
@@ -62,8 +62,6 @@ def test_reload_no_target_column(tmpdir):
     model = LightFM(learning_rate=0.05, loss="warp", epochs=10)
     model.fit(train)
 
-    _ = model.evaluate(valid, k=10)
-
     model_dir = Path(tmpdir) / "lightfm_model"
 
     model.save(model_dir)
@@ -87,8 +85,6 @@ def test_reload_with_target_column(tmpdir):
 
     model = LightFM(learning_rate=0.05, loss="warp", epochs=10)
     model.fit(train)
-
-    _ = model.evaluate(valid, k=10)
 
     model_dir = Path(tmpdir) / "lightfm_model"
 

--- a/tests/unit/tf/horovod/__init__.py
+++ b/tests/unit/tf/horovod/__init__.py
@@ -15,4 +15,4 @@
 #
 import pytest
 
-pytest.importorskip("horovod")
+pytest.importorskip("horovod.tensorflow")

--- a/tox.ini
+++ b/tox.ini
@@ -12,18 +12,19 @@ commands =
 [testenv:py38-gpu]
 ; Runs in: Github Actions
 ; Runs GPU-based tests.
-deps =
-    -rrequirements/test.txt
+; deps =
+;     -rrequirements/test.txt
 setenv =
     TF_GPU_ALLOCATOR=cuda_malloc_async
 sitepackages=true
 passenv =
     CUDA_VISIBLE_DEVICES
 commands =
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git@{posargs:main}
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/nvtabular.git@{posargs:main}
-    python -m pytest --cov-report term --cov merlin -rxs tests/unit/
+    ; python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
+    ; python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git@{posargs:main}
+    ; python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/nvtabular.git@{posargs:main}
+    echo $CUDA_VISIBLE_DEVICES
+    CUDA_VISIBLE_DEVICES=CUDA_VISIBLE_DEVICES python -m pytest --cov-report term --cov merlin -rxs tests/unit/
 
 [testenv:py38-horovod-cpu]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     -rrequirements/test.txt
 setenv =
     TF_GPU_ALLOCATOR=cuda_malloc_async
+sitepackages=true
 passenv =
     CUDA_VISIBLE_DEVICES
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -15,16 +15,14 @@ commands =
 ; deps =
 ;     -rrequirements/test.txt
 setenv =
+    CUDA_VISIBLE_DEVICES=0
     TF_GPU_ALLOCATOR=cuda_malloc_async
 sitepackages=true
-passenv =
-    CUDA_VISIBLE_DEVICES
 commands =
-    ; python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
-    ; python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git@{posargs:main}
-    ; python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/nvtabular.git@{posargs:main}
-    echo $CUDA_VISIBLE_DEVICES
-    CUDA_VISIBLE_DEVICES=CUDA_VISIBLE_DEVICES python -m pytest --cov-report term --cov merlin -rxs tests/unit/
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git@{posargs:main}
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/nvtabular.git@{posargs:main}
+    python -m pytest --cov-report term --cov merlin -rxs tests/unit/
 
 [testenv:py38-horovod-cpu]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,8 @@ commands =
 [testenv:py38-gpu]
 ; Runs in: Github Actions
 ; Runs GPU-based tests.
-; deps =
-;     -rrequirements/test.txt
+deps =
+    -rrequirements/test.txt
 setenv =
     CUDA_VISIBLE_DEVICES=0
     TF_GPU_ALLOCATOR=cuda_malloc_async


### PR DESCRIPTION
For GPU tests, we should use globally installed packages as we don't install cudf, cupy, etc. in the test environment. By setting `sitepackages=true` in tox, tox will use the packages in the CI container if not available in the environment. We had `sitepackages=true` before but it got dropped at some point. This PR restores `sitepackages=true` in the tox test `py38-gpu`.