### PR TITLE
Save and load Implicit model and schemas

### DIFF
--- a/merlin/models/implicit/__init__.py
+++ b/merlin/models/implicit/__init__.py
@@ -57,6 +57,12 @@ class ImplicitModelAdaptor:
         # evaluate the model given the validation set
         # prints out {'precision@10': 0.3895182175113377, 'map@10': 0.2609445966914911, ...} etc
         print(model.evaluate(valid))
+
+        # save the model
+        model.save("/path/to/dir")
+
+        # reload the model
+        model = AlternatingLeastSquares.load("/path/to/dir")
     """
 
     def __init__(self, implicit_model, schema: Optional[Schema] = None):
@@ -127,6 +133,7 @@ class ImplicitModelAdaptor:
     def save(self, path: Union[str, os.PathLike]) -> None:
         """Saves the model to export_path using pickle, along with merlin
         model metadata.
+
         Parameters
         ----------
         path: Union[str, os.PathLike]
@@ -162,6 +169,7 @@ class ImplicitModelAdaptor:
         path: Union[str, os.PathLike],
     ):
         """Load the model from a directory where a model has been saved.
+
         Parameters
         ----------
         path: Union[str, os.PathLike]
@@ -187,10 +195,22 @@ class ImplicitModelAdaptor:
 
 
 class AlternatingLeastSquares(ImplicitModelAdaptor):
-    def __init__(self, *args, schema=None, **kwargs):
+    def __init__(self, *args, schema: Optional[Schema] = None, **kwargs):
+        """
+        Parameters
+        ----------
+        schema: Optional[merlin.schema.Schema]
+            The schema of the data that will be used to train and evaluate the model.
+        """
         super().__init__(implicit.als.AlternatingLeastSquares(*args, **kwargs), schema=schema)
 
 
 class BayesianPersonalizedRanking(ImplicitModelAdaptor):
-    def __init__(self, *args, schema=None, **kwargs):
+    def __init__(self, *args, schema: Optional[Schema] = None, **kwargs):
+        """
+        Parameters
+        ----------
+        schema: Optional[merlin.schema.Schema]
+            The schema of the data that will be used to train and evaluate the model.
+        """
         super().__init__(implicit.bpr.BayesianPersonalizedRanking(*args, **kwargs), schema=schema)

--- a/merlin/models/implicit/__init__.py
+++ b/merlin/models/implicit/__init__.py
@@ -131,8 +131,7 @@ class ImplicitModelAdaptor:
         return self.implicit_model.recommend(userids, None, filter_already_liked_items=False, N=k)
 
     def save(self, path: Union[str, os.PathLike]) -> None:
-        """Saves the model to export_path using pickle, along with merlin
-        model metadata.
+        """Saves the model to directory 'path', along with merlin model metadata.
 
         Parameters
         ----------

--- a/merlin/models/lightfm/__init__.py
+++ b/merlin/models/lightfm/__init__.py
@@ -20,9 +20,9 @@ import pickle
 from pathlib import Path
 from typing import Optional, Union
 
-import lightfm
 import lightfm.evaluation
 
+import lightfm
 from merlin.io import Dataset
 from merlin.models.io import save_merlin_metadata
 from merlin.models.utils.dataset import (

--- a/merlin/models/lightfm/__init__.py
+++ b/merlin/models/lightfm/__init__.py
@@ -20,9 +20,9 @@ import pickle
 from pathlib import Path
 from typing import Optional, Union
 
+import lightfm
 import lightfm.evaluation
 
-import lightfm
 from merlin.io import Dataset
 from merlin.models.io import save_merlin_metadata
 from merlin.models.utils.dataset import (

--- a/tests/unit/implicit/test_implicit.py
+++ b/tests/unit/implicit/test_implicit.py
@@ -13,9 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pathlib import Path
 
+import numpy as np
+
+from merlin.datasets.synthetic import generate_data
 from merlin.io import Dataset
-from merlin.models.implicit import AlternatingLeastSquares
+from merlin.models.implicit import AlternatingLeastSquares, BayesianPersonalizedRanking
 from merlin.schema import Tags
 
 
@@ -27,3 +31,53 @@ def test_alternating_least_squares(music_streaming_data: Dataset):
     metrics = model.evaluate(music_streaming_data)
 
     assert all(metric >= 0 for metric in metrics.values())
+
+    model.predict(music_streaming_data)
+
+
+def test_bayesian_personalized_ranking(music_streaming_data: Dataset):
+    music_streaming_data.schema = music_streaming_data.schema.remove_by_tag(Tags.TARGET)
+
+    model = BayesianPersonalizedRanking(factors=128, iterations=15, regularization=0.01)
+    model.fit(music_streaming_data)
+    metrics = model.evaluate(music_streaming_data)
+
+    assert all(metric >= 0 for metric in metrics.values())
+
+    model.predict(music_streaming_data)
+
+
+def test_reload_alternating_least_squares(music_streaming_data: Dataset, tmpdir):
+    train, valid = generate_data("music-streaming", 100, (0.95, 0.05))
+    train.schema = train.schema.excluding_by_name(["play_percentage", "like"])
+    valid.schema = valid.schema.excluding_by_name(["play_percentage", "like"])
+
+    model = AlternatingLeastSquares(factors=128, iterations=15, regularization=0.01)
+    model.fit(train)
+
+    model_dir = Path(tmpdir) / "implicit_model"
+
+    model.save(model_dir)
+    reloaded = AlternatingLeastSquares.load(model_dir)
+
+    np.testing.assert_array_almost_equal(model.predict(valid), reloaded.predict(valid))
+
+    assert reloaded.schema == model.schema
+
+
+def test_reload_bayesian_personalized_ranking(music_streaming_data: Dataset, tmpdir):
+    train, valid = generate_data("music-streaming", 100, (0.95, 0.05))
+    train.schema = train.schema.excluding_by_name(["play_percentage", "like"])
+    valid.schema = valid.schema.excluding_by_name(["play_percentage", "like"])
+
+    model = BayesianPersonalizedRanking(factors=128, iterations=15, regularization=0.01)
+    model.fit(train)
+
+    model_dir = Path(tmpdir) / "implicit_model"
+
+    model.save(model_dir)
+    reloaded = BayesianPersonalizedRanking.load(model_dir)
+
+    np.testing.assert_array_almost_equal(model.predict(valid), reloaded.predict(valid))
+
+    assert reloaded.schema == model.schema

--- a/tests/unit/tf/outputs/test_classification.py
+++ b/tests/unit/tf/outputs/test_classification.py
@@ -128,6 +128,7 @@ def _next_item_loader(sequence_testing_data: Dataset):
         def compute_output_schema(self, input_schema):
             return input_schema
 
+        @tf.function
         def __call__(self, inputs, targets):
             inputs = mm.ListToRagged()(inputs)
             items = inputs["item_id_seq"]


### PR DESCRIPTION
Partially addresses https://github.com/NVIDIA-Merlin/Merlin/issues/825.

### Goals :soccer:
Enable Implicit to save and load the model and schemas.

### Implementation Details :construction:
- Adds `save()` that saves the Implicit object by using its `load()` method. It also outputs input and output schemas along with the model.
- Adds `load()` that can load the saved model and schema back into memory.

### Testing Details :mag:
Added unit tests to `tests/unit/lightfm/test_implicit.py`.