### PR TITLE
Add a `pytest.ini` file to register custom markers (e.g. `notebook`)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    notebook: mark a test as testing notebooks
+    version: mark a test as testing the version number

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,15 @@
 [pytest]
 markers =
-    notebook: mark a test as testing notebooks
-    version: mark a test as testing the version number
+    version: mark as testing the version number
+    notebook: mark as testing notebooks
+    example: mark as testing examples
+    datasets: mark as testing datasets
+    integration: mark as an integration test
+    unit: mark as a unit test
+    tensorflow: mark as requiring tensorflow
+    torch: mark as requiring torch
+    implicit: mark as requiring implicit
+    lightfm: mark as requiring lightfm
+    xgboost: mark as requiring xgboost
+    transformers: mark as requiring transformers
+    horovod: mark as requiring horovod


### PR DESCRIPTION
### Goals :soccer:
This should silence a bunch of repetitive warnings when the tests run.

### Implementation Details :construction:
Adds a `pytest.ini` file that registers the custom markers already in use.

### Testing Details :mag:
No functional change to the library, but should (not) show up on subsequent test runs.
