### PR TITLE
Fixed DLRModel / DLRMBlock to accept bottom_block with dropout on top of MLPs

### DIFF
--- a/tests/unit/tf/models/test_ranking.py
+++ b/tests/unit/tf/models/test_ranking.py
@@ -49,7 +49,7 @@ def test_dlrm_model(music_streaming_data, run_eagerly, prediction_blocks):
     model = mm.DLRMModel(
         music_streaming_data.schema,
         embedding_dim=2,
-        bottom_block=mm.MLPBlock([2]),
+        bottom_block=mm.MLPBlock([5, 2], dropout=0.05),
         prediction_tasks=prediction_blocks,
     )
 


### PR DESCRIPTION
### Goals :soccer:
This PR fixes an error raised by `DLRModel` when we provide in `bottom_block=MLPBlock(..., dropout)` arg set. For example:

```python
model = mm.DLRMModel(
        schema,
        embedding_dim=10,
        bottom_block=mm.MLPBlock([64, 32], dropout=0.05),
        prediction_tasks=mm.BinaryOutput("click"),
    )
```
### Implementation Details :construction:
This PR fixes that by iterating over `bottom_block` layers and finding the last MLP layer to check fit its output dim matches embedding dim.

### Testing Details :mag:
The `test_dlrm_model` was updated to test `bottom_block=mm.MLPBlock([5, 2], dropout=0.05)`
