### PR TITLE
New design of the transformer API 

### DIFF
--- a/examples/usecases/transformers-next-item-prediction.ipynb
+++ b/examples/usecases/transformers-next-item-prediction.ipynb
@@ -673,6 +673,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0a87439c",
+   "metadata": {},
+   "source": [
+    "Align the schema of train and validation datasets with the model's schema"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b90424a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_set_processed.schema = seq_schema\n",
+    "validation_set_processed.schema = seq_schema"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "8d422833",
    "metadata": {},
    "source": [

--- a/examples/usecases/transformers-next-item-prediction.ipynb
+++ b/examples/usecases/transformers-next-item-prediction.ipynb
@@ -724,7 +724,7 @@
    "id": "0a460e4c",
    "metadata": {},
    "source": [
-    "For the transformer portion of our model, we will use the `XLNet` architecture. Additionally, we are passing `mm.ReplaceMaskedEmbeddings()` as our `pre` block. We will be training a masked language model and this parameter is responsible for the masking of our sequences."
+    "For the transformer portion of our model, we will use the `XLNet` architecture."
    ]
   },
   {
@@ -732,12 +732,12 @@
    "id": "23bf02dc",
    "metadata": {},
    "source": [
-    "Later, when we run the `fit` method on our model, we will specify the `masking_probability` of `0.3`. Through the combination of these parameters, our model will train on sequences where any given timestep will be masked with a probability of 0.3 and it will be our model's training task to infer the target value for that step!\n",
+    "Later, when we run the `fit` method on our model, we will specify the `masking_probability` of `0.3` and link it to the transformer block defined in out model. Through the combination of these parameters, our model will train on sequences where any given timestep will be masked with a probability of 0.3 and it will be our model's training task to infer the target value for that step!\n",
     "\n",
-    "To summarize, Masked Language Modeling is implemented by using two blocks in combination:\n",
+    "To summarize, Masked Language Modeling is implemented by:\n",
     "\n",
-    "* `SequenceMaskRandom()` - Used as a pre for model.fit(), it randomly selects items from the sequence to be masked for prediction as targets, by using Keras masking.\n",
-    "* `ReplaceMaskedEmbeddings()` - Used as a pre for a `TransformerBlock`, it replaces the input embeddings at masked positions for prediction by a dummy trainable embedding, to avoid leakage of the targets.\n",
+    "* `SequenceMaskRandom()` - Used as a pre for model.fit(), it randomly selects items from the sequence to be masked for prediction as targets, by using Keras masking. This block also adds the necessary configuration to the specified `transformer` block so as it\n",
+    "is pre-configured with the necessary layers needed to prepare the inputs to the HuggingFace transformer layer and to post-process its outputs. For example, one pre-processing operation is to replace the input embeddings at masked positions for prediction by a dummy trainable embedding, to avoid leakage of the targets.\n",
     "\n",
     "\n",
     "**Read more about the apis used to construct models** \n",
@@ -746,7 +746,6 @@
     "- [InputBlockV2](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/inputs/base.py)\n",
     "- [Embeddings](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/inputs/embedding.py)\n",
     "- [XLNetBlock](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/transformers/block.py)\n",
-    "- [ReplaceMaskedEmbeddings](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/transforms/sequence.py)\n",
     "- [CategoricalOutput](https://github.com/NVIDIA-Merlin/models/blob/main/merlin/models/tf/outputs/classification.py)\n",
     "- [.schema.select_by_name](https://github.com/NVIDIA-Merlin/core/blob/main/merlin/schema/schema.py)\n",
     "- [.schema.select_by_tag](https://github.com/NVIDIA-Merlin/core/blob/main/merlin/schema/schema.py)\n",
@@ -770,6 +769,7 @@
     "                activation='relu',\n",
     "                no_activation_last_layer=True,\n",
     "            )\n",
+    "transformer_block = mm.XLNetBlock(d_model=dmodel, n_head=4, n_layer=2)\n",
     "model = mm.Model(\n",
     "    mm.InputBlockV2(\n",
     "        seq_schema,\n",
@@ -778,10 +778,7 @@
     "        ),\n",
     "    ),\n",
     "    mlp_block,\n",
-    "    mm.XLNetBlock(d_model=dmodel, n_head=4, n_layer=2, \n",
-    "                  pre=mm.ReplaceMaskedEmbeddings(),\n",
-    "                  post=\"inference_hidden_state\",\n",
-    "                 ),\n",
+    "    transformer_block,\n",
     "    mm.CategoricalOutput(\n",
     "        train_set_processed.schema.select_by_name(target),\n",
     "        default_loss=\"categorical_crossentropy\",\n",
@@ -891,7 +888,7 @@
    ],
    "source": [
     "model.compile(run_eagerly=False, optimizer='adam', loss=\"categorical_crossentropy\")\n",
-    "model.fit(train_set_processed, batch_size=64, epochs=5, pre=mm.SequenceMaskRandom(schema=seq_schema, target=target, masking_prob=0.3))"
+    "model.fit(train_set_processed, batch_size=64, epochs=5, pre=mm.SequenceMaskRandom(schema=seq_schema, target=target, masking_prob=0.3, transformer=transformer_block))"
    ]
   },
   {
@@ -960,7 +957,7 @@
     "model.evaluate(\n",
     "    validation_set_processed,\n",
     "    batch_size=128,\n",
-    "    pre=mm.SequenceMaskLast(schema=seq_schema, target=target),\n",
+    "    pre=mm.SequenceMaskLast(schema=validation_set_processed.schema, target=target, transformer=transformer_block),\n",
     "    return_dict=True\n",
     ")"
    ]
@@ -1000,7 +997,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -1313,7 +1313,7 @@ class BaseModel(tf.keras.Model):
             self._reset_compile_cache()
             self.train_pre = pre
             if isinstance(self.train_pre, SequenceTransform):
-                self.train_pre.on_train_begin()
+                self.train_pre.configure_for_train()
 
         out = super().fit(**fit_kwargs)
 
@@ -1401,7 +1401,7 @@ class BaseModel(tf.keras.Model):
             self._reset_compile_cache()
             self.test_pre = pre
             if isinstance(self.test_pre, SequenceTransform):
-                self.test_pre.on_test_begin()
+                self.test_pre.configure_for_test()
 
         out = super().evaluate(
             x,

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -50,8 +50,8 @@ from merlin.models.tf.models.utils import parse_prediction_blocks
 from merlin.models.tf.outputs.base import ModelOutput, ModelOutputType
 from merlin.models.tf.outputs.contrastive import ContrastiveOutput
 from merlin.models.tf.prediction_tasks.base import ParallelPredictionBlock, PredictionTask
+from merlin.models.tf.transforms.features import PrepareFeatures, expected_input_cols_from_schema
 from merlin.models.tf.transforms.sequence import SequenceTransform
-from merlin.models.tf.transforms.tensor import PrepareFeatures, expected_input_cols_from_schema
 from merlin.models.tf.typing import TabularData
 from merlin.models.tf.utils.search_utils import find_all_instances_in_layers
 from merlin.models.tf.utils.tf_utils import (
@@ -1035,7 +1035,8 @@ class BaseModel(tf.keras.Model):
         targets: Optional[Union[TensorLike, Dict[str, TensorLike]]],
         sample_weights: Optional[Union[TensorLike, Dict[str, TensorLike]]],
     ):
-        """Adjusts the predictions and targets to ensure compatibility with most Keras losses and metrics.
+        """Adjusts the predictions and targets to ensure compatibility with 
+        most Keras losses and metrics.
 
         If the predictions are ragged tensors, `_adjust_ragged_predictions_and_targets` is called,
         otherwise `_adjust_dense_predictions_and_targets` is called.

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -1035,7 +1035,7 @@ class BaseModel(tf.keras.Model):
         targets: Optional[Union[TensorLike, Dict[str, TensorLike]]],
         sample_weights: Optional[Union[TensorLike, Dict[str, TensorLike]]],
     ):
-        """Adjusts the predictions and targets to ensure compatibility with 
+        """Adjusts the predictions and targets to ensure compatibility with
         most Keras losses and metrics.
 
         If the predictions are ragged tensors, `_adjust_ragged_predictions_and_targets` is called,

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -905,6 +905,8 @@ class BaseModel(tf.keras.Model):
             # Copies the mask from the targets to the predictions
             # because Keras considers the prediction mask in loss
             # and metrics computation
+            if isinstance(target._keras_mask, tf.RaggedTensor):
+                target._keras_mask = target._keras_mask.to_tensor()
             prediction._keras_mask = target._keras_mask
 
         # Ensuring targets and preds have the same dtype

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -50,7 +50,8 @@ from merlin.models.tf.models.utils import parse_prediction_blocks
 from merlin.models.tf.outputs.base import ModelOutput, ModelOutputType
 from merlin.models.tf.outputs.contrastive import ContrastiveOutput
 from merlin.models.tf.prediction_tasks.base import ParallelPredictionBlock, PredictionTask
-from merlin.models.tf.transforms.features import PrepareFeatures, expected_input_cols_from_schema
+from merlin.models.tf.transforms.sequence import SequenceTransform
+from merlin.models.tf.transforms.tensor import PrepareFeatures, expected_input_cols_from_schema
 from merlin.models.tf.typing import TabularData
 from merlin.models.tf.utils.search_utils import find_all_instances_in_layers
 from merlin.models.tf.utils.tf_utils import (
@@ -815,64 +816,214 @@ class BaseModel(tf.keras.Model):
 
         return Prediction(predictions, targets, sample_weights)
 
+    def _extract_masked_predictions(self, prediction: TensorLike):
+        """Extracts the prediction scores corresponding to masked positions (targets).
+
+        This method assumes that the input predictions tensor is 3-D and contains a mask
+        indicating the positions of the targets. It requires that the mask information has
+        exactly one masked position per input sequence. The method returns a 2-D dense tensor
+        containing the prediction score corresponding to each masked position.
+
+        Parameters
+        ----------
+        prediction : TensorLike
+            A 3-D dense tensor of predictions, with a mask indicating the positions of the targets.
+
+        Returns
+        -------
+        tf.Tensor
+            A 2-D dense tensor of prediction scores, with one score per input.
+
+        Raises
+        ------
+        ValueError
+            If the mask does not have exactly one masked position per input sequence.
+        """
+        num_preds_per_example = tf.reduce_sum(tf.cast(prediction._keras_mask, tf.int32), axis=-1)
+        with tf.control_dependencies(
+            [
+                tf.debugging.assert_equal(
+                    num_preds_per_example,
+                    1,
+                    message="If targets are scalars (1-D) and predictions are"
+                    " sequential (3-D), the predictions mask should contain"
+                    " one masked position per example",
+                )
+            ]
+        ):
+            return tf.boolean_mask(prediction, prediction._keras_mask)
+
+    def _adjust_dense_predictions_and_targets(
+        self,
+        prediction: tf.Tensor,
+        target: TensorLike,
+    ):
+        """Adjusts the dense predictions tensor and the target tensor to ensure
+        compatibility with most Keras losses and metrics.
+
+        This method applies the following transformations to the target and prediction tensors:
+        - Converts ragged targets and their masks to dense format.
+        - Copies the target mask to the prediction mask, if defined.
+        - If predictions are sequential (3-D) and targets are scalar (1-D), extracts the predictions
+        at target positions using the predictions mask.
+        - One-hot encodes targets if their rank is one less than the rank of predictions.
+        - Ensures that targets have the same shape and dtype as predictions.
+
+        Parameters
+        ----------
+        prediction : tf.Tensor
+            The prediction tensor as a dense tensor.
+        target : TensorLike
+            The target tensor that can be either a dense or ragged tensor.
+
+        Returns:
+        --------
+            A tuple of the adjusted prediction and target tensors, with the same dtype and shape.
+        """
+        if isinstance(target, tf.RaggedTensor):
+            # Converts ragged targets (and ragged mask) to dense
+            dense_target_mask = None
+            if getattr(target, "_keras_mask", None) is not None:
+                dense_target_mask = target._keras_mask.to_tensor()
+            target = target.to_tensor()
+            if dense_target_mask is not None:
+                target._keras_mask = dense_target_mask
+
+        if prediction.shape.ndims == 2:
+            # Removes the mask information as the sequence is summarized into
+            # a single vector.
+            prediction._keras_mask = None
+
+        elif getattr(target, "_keras_mask", None) is not None:
+            # Copies the mask from the targets to the predictions
+            # because Keras considers the prediction mask in loss
+            # and metrics computation
+            prediction._keras_mask = target._keras_mask
+
+        # Ensuring targets and preds have the same dtype
+        target = tf.cast(target, prediction.dtype)
+
+        # If targets are scalars (1-D) and predictions are sequential (3-D),
+        # extract predictions at target position because Keras expects
+        # predictions and targets to have the same shape.
+        if getattr(prediction, "_keras_mask", None) is not None:
+            rank_check = tf.logical_and(
+                tf.equal(tf.rank(target), 1),
+                tf.equal(tf.rank(prediction), 3),
+            )
+            prediction = tf.cond(
+                rank_check, lambda: self._extract_masked_predictions(prediction), lambda: prediction
+            )
+
+        # Ensuring targets are one-hot encoded if they are not
+        target = tf.cond(
+            tf.rank(target) == tf.rank(prediction) - 1,
+            lambda: tf.one_hot(
+                tf.cast(target, tf.int32),
+                tf.shape(prediction)[-1],
+                dtype=prediction.dtype,
+            ),
+            lambda: target,
+        )
+        # Makes target shape equal to the predictions tensor, as shape is lost after tf.cond
+        target = tf.reshape(target, tf.shape(prediction))
+
+        return prediction, target
+
+    def _adjust_ragged_predictions_and_targets(
+        self,
+        prediction: tf.RaggedTensor,
+        target: TensorLike,
+    ):
+        """Adjusts the predictions (ragged tensor) and targets to ensure
+        compatibility with most Keras losses and metrics.
+
+        This methods applies the following transformations to the target and prediction tensors:
+        - Select ragged targets based on the mask information, if defined.
+        - Remove mask information from the ragged targets and predictions.
+        - One-hot encode targets if their rank is one less than the rank of predictions.
+        - Ensure that targets have the same shape and dtype as predictions.
+
+        Parameters
+        ----------
+        prediction : tf.RaggedTensor
+            The prediction tensor as a ragged tensor.
+        target : TensorLike
+            The target tensor that can be either a dense or ragged tensor.
+
+        Returns
+        -------
+        Tuple[tf.Tensor, tf.Tensor]
+            A tuple containing the adjusted prediction and target tensors.
+        """
+        if isinstance(target, tf.RaggedTensor) and getattr(target, "_keras_mask", None) is not None:
+            # Select targets at masked positions and return
+            # a ragged tensor.
+            target = tf.ragged.boolean_mask(
+                target.with_row_splits_dtype(target.dtype), target._keras_mask
+            )
+
+        # Ensuring targets and preds have the same dtype
+        target = tf.cast(target, prediction.dtype)
+
+        # Take the flat values of predictions and targets as Keras
+        # losses does not support RaggedVariantTensor on GPU:
+        prediction = prediction.flat_values
+        if isinstance(target, tf.RaggedTensor):
+            target = target.flat_values
+
+        # Ensuring targets are one-hot encoded if they are not
+        def _reshape_ragged():
+            # Makes target shape equal to the predictions tensor,
+            # as shape information is lost in graph mode execution of tf.cond()
+            target_reshape = tf.reshape(target, tf.shape(prediction))
+            if isinstance(prediction, tf.RaggedTensor):
+                return tf.RaggedTensor.from_row_splits(
+                    target_reshape.values, tf.cast(target_reshape.row_splits, tf.int64)
+                )
+            return target_reshape
+
+        target = tf.cond(
+            tf.rank(target) == tf.rank(prediction) - 1,
+            lambda: tf.one_hot(
+                tf.cast(target, tf.int32),
+                tf.shape(prediction)[-1],
+                dtype=prediction.dtype,
+            ),
+            _reshape_ragged,
+        )
+
+        return prediction, target
+
     def adjust_predictions_and_targets(
         self,
         predictions: Dict[str, TensorLike],
-        targets: Optional[Union[tf.Tensor, Dict[str, tf.Tensor]]],
+        targets: Optional[Union[TensorLike, Dict[str, TensorLike]]],
     ):
-        """Adjusts the predctions and targets, doing the following transformations
-        if the target is provided:
-        - Converts ragged targets (and their masks) to dense, so that they are compatible
-        with most losses and metrics
-        - Copies the targets mask to predictions mask, if defined
-        - One-hot encode targets if their tf.rank(targets) == tf.rank(predictions)-1
-        - Ensures targets has the same shape and dtype as predicitnos
+        """Adjusts the predictions and targets to ensure compatibility with most Keras losses and metrics.
+
+        If the predictions are ragged tensors, `_adjust_ragged_predictions_and_targets` is called,
+        otherwise `_adjust_dense_predictions_and_targets` is called.
 
         Parameters
         ----------
         predictions : Dict[str, TensorLike]
-            A dict with predictions for the tasks
+            A dictionary with predictions for the tasks.
         targets : Optional[Union[tf.Tensor, Dict[str, tf.Tensor]]]
-            A dict with targets for the tasks
+            A dictionary with targets for the tasks, or None if targets are not provided.
         """
         if targets is None:
             return
 
         for k in targets:
-            # Convert ragged targets (and ragged mask) to dense
-            if isinstance(targets[k], tf.RaggedTensor):
-                dense_target_mask = None
-                if getattr(targets[k], "_keras_mask", None) is not None:
-                    dense_target_mask = targets[k]._keras_mask.to_tensor()
-                targets[k] = targets[k].to_tensor()
-                if dense_target_mask is not None:
-                    targets[k]._keras_mask = dense_target_mask
-
-            if getattr(targets[k], "_keras_mask", None) is not None:
-                # Copies the mask from the targets to the predictions
-                # because Keras considers the prediction mask in loss
-                # and metrics computation
-                predictions[k]._keras_mask = targets[k]._keras_mask
-
-            # Ensuring targets and preds have the same dtype
-            targets[k] = tf.cast(targets[k], predictions[k].dtype)
-
-            # Ensuring targets are one-hot encoded if they are not
-            condition = tf.logical_and(
-                tf.logical_and(tf.rank(targets[k]) > 0, tf.shape(targets[k])[-1] == 1),
-                tf.shape(predictions[k])[-1] > 1,
-            )
-            targets[k] = tf.cond(
-                condition,
-                lambda: tf.one_hot(
-                    tf.cast(targets[k], tf.int32),
-                    tf.shape(predictions[k])[-1],
-                    dtype=predictions[k].dtype,
-                ),
-                lambda: targets[k],
-            )
-            # Makes target shape equal to the predictions tensor, as shape is lost after tf.cond
-            targets[k] = tf.reshape(targets[k], tf.shape(predictions[k]))
+            if isinstance(predictions[k], tf.RaggedTensor):
+                predictions[k], targets[k] = self._adjust_ragged_predictions_and_targets(
+                    predictions[k], targets[k]
+                )
+            else:
+                predictions[k], targets[k] = self._adjust_dense_predictions_and_targets(
+                    predictions[k], targets[k]
+                )
 
     def train_step(self, data):
         """Custom train step using the `compute_loss` method."""
@@ -1161,6 +1312,8 @@ class BaseModel(tf.keras.Model):
         if pre:
             self._reset_compile_cache()
             self.train_pre = pre
+            if isinstance(self.train_pre, SequenceTransform):
+                self.train_pre.on_train_begin()
 
         out = super().fit(**fit_kwargs)
 
@@ -1247,6 +1400,8 @@ class BaseModel(tf.keras.Model):
         if pre:
             self._reset_compile_cache()
             self.test_pre = pre
+            if isinstance(self.test_pre, SequenceTransform):
+                self.test_pre.on_test_begin()
 
         out = super().evaluate(
             x,

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -780,7 +780,7 @@ class BaseModel(tf.keras.Model):
                 predictions[task.task_name] = task_x
                 sample_weights[task.task_name] = task_sample_weight
 
-            self.adjust_predictions_and_targets(predictions, targets)
+            self.adjust_predictions_and_targets(predictions, targets, sample_weights)
 
             if len(predictions) == 1 and len(targets) == 1:
                 predictions = list(predictions.values())[0]
@@ -812,7 +812,7 @@ class BaseModel(tf.keras.Model):
             predictions[task.full_name] = task_x
             sample_weights[task.full_name] = task_sample_weight
 
-        self.adjust_predictions_and_targets(predictions, targets)
+        self.adjust_predictions_and_targets(predictions, targets, sample_weights)
 
         return Prediction(predictions, targets, sample_weights)
 
@@ -857,9 +857,10 @@ class BaseModel(tf.keras.Model):
         self,
         prediction: tf.Tensor,
         target: TensorLike,
+        sample_weight: TensorLike,
     ):
-        """Adjusts the dense predictions tensor and the target tensor to ensure
-        compatibility with most Keras losses and metrics.
+        """Adjusts the dense predictions tensor, the target tensor and sample_weight tensor
+        to ensure compatibility with most Keras losses and metrics.
 
         This method applies the following transformations to the target and prediction tensors:
         - Converts ragged targets and their masks to dense format.
@@ -875,10 +876,13 @@ class BaseModel(tf.keras.Model):
             The prediction tensor as a dense tensor.
         target : TensorLike
             The target tensor that can be either a dense or ragged tensor.
+        sample_weight : TensorLike
+            The sample weight tensor that can be either a dense or ragged tensor.
 
         Returns:
         --------
-            A tuple of the adjusted prediction and target tensors, with the same dtype and shape.
+            A tuple of the adjusted prediction, target, and sample_weight tensors,
+            with the same dtype and shape.
         """
         if isinstance(target, tf.RaggedTensor):
             # Converts ragged targets (and ragged mask) to dense
@@ -888,6 +892,9 @@ class BaseModel(tf.keras.Model):
             target = target.to_tensor()
             if dense_target_mask is not None:
                 target._keras_mask = dense_target_mask
+
+        if isinstance(sample_weight, tf.RaggedTensor):
+            sample_weight = sample_weight.to_tensor()
 
         if prediction.shape.ndims == 2:
             # Removes the mask information as the sequence is summarized into
@@ -928,15 +935,16 @@ class BaseModel(tf.keras.Model):
         # Makes target shape equal to the predictions tensor, as shape is lost after tf.cond
         target = tf.reshape(target, tf.shape(prediction))
 
-        return prediction, target
+        return prediction, target, sample_weight
 
     def _adjust_ragged_predictions_and_targets(
         self,
         prediction: tf.RaggedTensor,
         target: TensorLike,
+        sample_weight: TensorLike,
     ):
-        """Adjusts the predictions (ragged tensor) and targets to ensure
-        compatibility with most Keras losses and metrics.
+        """Adjusts the prediction (ragged tensor), target and sample weight
+        to ensure compatibility with most Keras losses and metrics.
 
         This methods applies the following transformations to the target and prediction tensors:
         - Select ragged targets based on the mask information, if defined.
@@ -950,27 +958,51 @@ class BaseModel(tf.keras.Model):
             The prediction tensor as a ragged tensor.
         target : TensorLike
             The target tensor that can be either a dense or ragged tensor.
+        sample_weight : TensorLike
+            The sample weight tensor that can be either a dense or ragged tensor.
 
         Returns
         -------
         Tuple[tf.Tensor, tf.Tensor]
-            A tuple containing the adjusted prediction and target tensors.
+            A tuple containing the adjusted prediction, target and sample_weight tensors.
         """
-        if isinstance(target, tf.RaggedTensor) and getattr(target, "_keras_mask", None) is not None:
+        target_mask = None
+        if getattr(target, "_keras_mask", None) is not None:
+            target_mask = target._keras_mask
+
+        if isinstance(target, tf.RaggedTensor) and target_mask is not None:
             # Select targets at masked positions and return
             # a ragged tensor.
             target = tf.ragged.boolean_mask(
-                target, target._keras_mask.with_row_splits_dtype(target.row_splits.dtype)
+                target, target_mask.with_row_splits_dtype(target.row_splits.dtype)
             )
 
         # Ensuring targets and preds have the same dtype
         target = tf.cast(target, prediction.dtype)
 
-        # Take the flat values of predictions and targets as Keras
+        # Align sample_weight with the ragged target tensor
+        if isinstance(target, tf.RaggedTensor) and sample_weight is not None:
+            if isinstance(sample_weight, tf.RaggedTensor):
+                # sample_weight is a 2-D tensor, weights in the same sequence are different
+                if target_mask is not None:
+                    # Select sample weights at masked positions and return a ragged tensor.
+                    sample_weight = tf.ragged.boolean_mask(
+                        sample_weight,
+                        target_mask.with_row_splits_dtype(sample_weight.row_splits.dtype),
+                    )
+            else:
+                # sample_weight is a 1-D tensor, one weight value per sequence
+                # repeat the weight value for each masked target position
+                row_lengths = tf.constant(target.row_lengths(), dtype=tf.int64)
+                sample_weight = tf.repeat(sample_weight, row_lengths)
+
+        # Take the flat values of predictions, targets and sample weihts as Keras
         # losses does not support RaggedVariantTensor on GPU:
         prediction = prediction.flat_values
         if isinstance(target, tf.RaggedTensor):
             target = target.flat_values
+        if isinstance(sample_weight, tf.RaggedTensor):
+            sample_weight = sample_weight.flat_values
 
         # Ensuring targets are one-hot encoded if they are not
         def _reshape_ragged():
@@ -993,12 +1025,13 @@ class BaseModel(tf.keras.Model):
             _reshape_ragged,
         )
 
-        return prediction, target
+        return prediction, target, sample_weight
 
     def adjust_predictions_and_targets(
         self,
         predictions: Dict[str, TensorLike],
         targets: Optional[Union[TensorLike, Dict[str, TensorLike]]],
+        sample_weights: Optional[Union[TensorLike, Dict[str, TensorLike]]],
     ):
         """Adjusts the predictions and targets to ensure compatibility with most Keras losses and metrics.
 
@@ -1011,18 +1044,30 @@ class BaseModel(tf.keras.Model):
             A dictionary with predictions for the tasks.
         targets : Optional[Union[tf.Tensor, Dict[str, tf.Tensor]]]
             A dictionary with targets for the tasks, or None if targets are not provided.
+        sample_weights : Optional[Union[tf.Tensor, Dict[str, tf.Tensor]]]
+            A dictionary with sample weights for the tasks,
+            or None if sample_weights are not provided.
+
         """
         if targets is None:
             return
 
         for k in targets:
             if isinstance(predictions[k], tf.RaggedTensor):
-                predictions[k], targets[k] = self._adjust_ragged_predictions_and_targets(
-                    predictions[k], targets[k]
+                (
+                    predictions[k],
+                    targets[k],
+                    sample_weights[k],
+                ) = self._adjust_ragged_predictions_and_targets(
+                    predictions[k], targets[k], sample_weights[k]
                 )
             else:
-                predictions[k], targets[k] = self._adjust_dense_predictions_and_targets(
-                    predictions[k], targets[k]
+                (
+                    predictions[k],
+                    targets[k],
+                    sample_weights[k],
+                ) = self._adjust_dense_predictions_and_targets(
+                    predictions[k], targets[k], sample_weights[k]
                 )
 
     def train_step(self, data):

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -960,7 +960,7 @@ class BaseModel(tf.keras.Model):
             # Select targets at masked positions and return
             # a ragged tensor.
             target = tf.ragged.boolean_mask(
-                target.with_row_splits_dtype(target.dtype), target._keras_mask
+                target, target._keras_mask.with_row_splits_dtype(target.row_splits.dtype)
             )
 
         # Ensuring targets and preds have the same dtype

--- a/merlin/models/tf/outputs/classification.py
+++ b/merlin/models/tf/outputs/classification.py
@@ -328,9 +328,14 @@ class EmbeddingTablePrediction(Layer):
         return super().build(input_shape)
 
     def call(self, inputs, training=False, **kwargs) -> tf.Tensor:
+        is_ragged = isinstance(inputs, tf.RaggedTensor)
+        if is_ragged:
+            original_inputs = inputs
+            inputs = inputs.flat_values
         logits = tf.matmul(inputs, self.table.table.embeddings, transpose_b=True)
         logits = tf.nn.bias_add(logits, self.bias)
-
+        if is_ragged:
+            logits = original_inputs.with_flat_values(logits)
         return logits
 
     @property

--- a/merlin/models/tf/transforms/sequence.py
+++ b/merlin/models/tf/transforms/sequence.py
@@ -358,7 +358,7 @@ class SequencePredictLast(SequenceTransform):
 
         # Shifts the target column to be the next item of corresponding input column
         new_target = tf.squeeze(inputs[self.target_name][:, -1:].to_tensor(), axis=1)
-        
+
         if targets is None:
             targets = dict({self.target_name: new_target})
         elif isinstance(targets, dict):

--- a/merlin/models/tf/transforms/sequence.py
+++ b/merlin/models/tf/transforms/sequence.py
@@ -21,15 +21,11 @@ from tensorflow.keras.backend import random_bernoulli
 from merlin.models.tf.core import combinators
 from merlin.models.tf.core.base import Block, BlockType, PredictionOutput
 from merlin.models.tf.core.combinators import TabularBlock
-from merlin.models.tf.transformers.block import TransformerBlock
-from merlin.models.tf.transformers.transforms import (
-    TransformerInferenceHiddenState,
-    TransformerOutputToRagged,
-)
 from merlin.models.tf.transforms.features import PrepareFeatures
 from merlin.models.tf.typing import TabularData
 from merlin.models.tf.utils import tf_utils
 from merlin.models.utils import schema_utils
+from merlin.models.utils.dependencies import is_transformers_available
 from merlin.schema import ColumnSchema, Schema, Tags
 
 
@@ -104,7 +100,7 @@ class SequenceTransform(TabularBlock):
         schema: Schema,
         target: Union[str, Tags, ColumnSchema],
         pre: Optional[BlockType] = None,
-        transformer: Optional[TransformerBlock] = None,
+        transformer=None,
         **kwargs,
     ):
         _pre = PrepareFeatures(schema)
@@ -293,6 +289,13 @@ class SequencePredictNext(SequenceTransform):
         to align with the SequencePredictNext outputs.
         """
         if self.transformer is not None:
+            if not is_transformers_available():
+                raise ImportError("HuggingFace library `transformers` is required")
+            from merlin.models.tf.transformers.transforms import (
+                TransformerInferenceHiddenState,
+                TransformerOutputToRagged,
+            )
+
             # set the tansformer block with the correct masking block
             self.transformer.masking_post = combinators.SequentialBlock(
                 [TransformerOutputToRagged(), TransformerInferenceHiddenState()]
@@ -737,6 +740,13 @@ class SequenceMaskRandom(SequenceTargetAsInput):
         to align with the SequencePredictNext outputs.
         """
         if self.transformer is not None:
+            if not is_transformers_available():
+                raise ImportError("HuggingFace library `transformers` is required")
+            from merlin.models.tf.transformers.transforms import (
+                TransformerInferenceHiddenState,
+                TransformerOutputToRagged,
+            )
+
             # set the tansformer block with the correct masking blocks
             self.transformer.masking_post = combinators.SequentialBlock(
                 [TransformerOutputToRagged(), TransformerInferenceHiddenState()]
@@ -858,6 +868,13 @@ class SequenceMaskLast(SequenceTargetAsInput):
         to align with the SequencePredictNext outputs.
         """
         if self.transformer is not None:
+            if not is_transformers_available():
+                raise ImportError("HuggingFace library `transformers` is required")
+            from merlin.models.tf.transformers.transforms import (
+                TransformerInferenceHiddenState,
+                TransformerOutputToRagged,
+            )
+
             # set the tansformer block with the correct masking blocks
             self.transformer.masking_post = combinators.SequentialBlock(
                 [TransformerOutputToRagged(), TransformerInferenceHiddenState()]

--- a/merlin/models/tf/transforms/sequence.py
+++ b/merlin/models/tf/transforms/sequence.py
@@ -27,7 +27,6 @@ from merlin.models.tf.transformers.transforms import (
     TransformerOutputToRagged,
 )
 from merlin.models.tf.transforms.features import PrepareFeatures
-from merlin.models.tf.transforms.tensor import ListToRagged
 from merlin.models.tf.typing import TabularData
 from merlin.models.tf.utils import tf_utils
 from merlin.models.utils import schema_utils
@@ -358,7 +357,8 @@ class SequencePredictLast(SequenceTransform):
         self._check_seq_inputs_targets(inputs)
 
         # Shifts the target column to be the next item of corresponding input column
-        new_target = tf.squeeze(inputs[self.target_name][:, -1:], axis=1)
+        new_target = tf.squeeze(inputs[self.target_name][:, -1:].to_tensor(), axis=1)
+        
         if targets is None:
             targets = dict({self.target_name: new_target})
         elif isinstance(targets, dict):

--- a/merlin/models/tf/transforms/sequence.py
+++ b/merlin/models/tf/transforms/sequence.py
@@ -273,7 +273,10 @@ class SequencePredictNext(SequenceTransform):
 
     def compute_mask(self, inputs, mask=None):
         new_item_id_seq = inputs[self.target_name][:, :-1]
-        self.target_mask = tf.sequence_mask(new_item_id_seq.row_lengths(1))
+        self.target_mask = tf.RaggedTensor.from_row_lengths(
+            values=tf.ones_like(new_item_id_seq.flat_values, dtype=tf.bool),
+            row_lengths=new_item_id_seq.row_lengths(),
+        )
         targets_mask = dict({self.target_name: self.target_mask})
         inputs_mask = dict()
         for k, v in inputs.items():

--- a/merlin/models/tf/transforms/sequence.py
+++ b/merlin/models/tf/transforms/sequence.py
@@ -272,10 +272,12 @@ class SequencePredictNext(SequenceTransform):
 
     def compute_mask(self, inputs, mask=None):
         new_item_id_seq = inputs[self.target_name][:, :-1]
-        self.target_mask = tf.RaggedTensor.from_row_lengths(
+        target_mask = tf.RaggedTensor.from_row_lengths(
             values=tf.ones_like(new_item_id_seq.flat_values, dtype=tf.bool),
             row_lengths=new_item_id_seq.row_lengths(),
         )
+        self.target_mask = tf.squeeze(target_mask, axis=-1)
+
         targets_mask = dict({self.target_name: self.target_mask})
         inputs_mask = dict()
         for k, v in inputs.items():
@@ -357,8 +359,7 @@ class SequencePredictLast(SequenceTransform):
         self._check_seq_inputs_targets(inputs)
 
         # Shifts the target column to be the next item of corresponding input column
-        new_target = tf.squeeze(inputs[self.target_name][:, -1:].to_tensor(), axis=1)
-
+        new_target = tf.squeeze(inputs[self.target_name][:, -1:], axis=1)
         if targets is None:
             targets = dict({self.target_name: new_target})
         elif isinstance(targets, dict):

--- a/merlin/models/tf/transforms/sequence.py
+++ b/merlin/models/tf/transforms/sequence.py
@@ -473,7 +473,7 @@ class SequencePredictRandom(SequenceTransform):
         positions_matrix = tf.tile(
             tf.expand_dims(tf.range(0, max_length, dtype=tf.int32), 0), [batch_size, 1]
         )
-        input_mask = positions_matrix < random_targets_indices
+        self.random_mask = positions_matrix < random_targets_indices
         target_mask = positions_matrix == random_targets_indices
 
         new_target = tf.squeeze(
@@ -489,11 +489,47 @@ class SequencePredictRandom(SequenceTransform):
         new_inputs = dict()
         for k, v in inputs.items():
             if k in self.schema.column_names:
-                new_inputs[k] = tf.ragged.boolean_mask(v, input_mask)
+                new_inputs[k] = tf.ragged.boolean_mask(v, self.random_mask)
             else:
                 new_inputs[k] = v
 
         return (new_inputs, targets)
+
+    def compute_mask(self, inputs, mask=None):
+        new_item_id_seq = tf.ragged.boolean_mask(inputs[self.target_name], self.random_mask)
+
+        self.target_mask = self._generate_target_mask(new_item_id_seq)
+        inputs_mask = dict()
+        for k, v in inputs.items():
+            if k in self.schema.column_names:
+                inputs_mask[k] = self.target_mask
+            else:
+                inputs_mask[k] = None
+
+        return (inputs_mask, self.target_mask)
+
+    def _generate_target_mask(self, ids_seq: tf.RaggedTensor) -> tf.RaggedTensor:
+        """Returns a bool ragged tensor with the last positions of the sequence masked
+
+        Parameters
+        ----------
+        ids_seq : tf.RaggedTensor
+            Sequence of ids, which are used to infer how many values
+            each sequence contains
+
+        Returns
+        -------
+        tf.RaggedTensor
+            Mask tensor, with True at the last positions
+        """
+        row_lengths = ids_seq.row_lengths(1)
+        max_seq_length = tf.cast(tf.reduce_max(row_lengths), tf.int32)
+
+        padding_mask = tf.sequence_mask(row_lengths)
+        targets_mask = tf.ragged.boolean_mask(
+            tf.cast(tf.one_hot(row_lengths - 1, max_seq_length), tf.bool), padding_mask
+        )
+        return targets_mask
 
 
 @Block.registry.register_with_multiple_names("seq_target_as_input")

--- a/merlin/models/tf/transforms/sequence.py
+++ b/merlin/models/tf/transforms/sequence.py
@@ -201,13 +201,13 @@ class SequenceTransform(TabularBlock):
         target = config.pop("target")
         return cls(schema, target, **config)
 
-    def on_train_begin(self):
+    def configure_for_train(self):
         """Method called by the model.fit() to set additional model's
         configuration before calling keras parent class `fit()`
         """
         pass
 
-    def on_test_begin(self):
+    def configure_for_test(self):
         """Method called by the model.evaluate() to check any custom model's
         configuration before calling keras parent class `evaluate()`
         """
@@ -283,7 +283,7 @@ class SequencePredictNext(SequenceTransform):
                 inputs_mask[k] = None
         return (inputs_mask, targets_mask)
 
-    def on_train_begin(self):
+    def configure_for_train(self):
         """Method called by the model.fit() to set the specialized
         `masking_post` and `masking_pre` needed by the TransformerBlock
         to align with the SequencePredictNext outputs.
@@ -297,7 +297,7 @@ class SequencePredictNext(SequenceTransform):
                 [SequenceCausalLastInference(), ExtractMaskFromTargets()]
             )
 
-    def on_test_begin(self):
+    def configure_for_test(self):
         """Method called by the model.evaluate() to check that the
         `masking_post` and `masking_pre` set in the TransformerBlock
         are aligned with the evaluation strategy of SequencePredictNext
@@ -691,7 +691,7 @@ class SequenceMaskRandom(SequenceTargetAsInput):
         masking_prob = config.pop("masking_prob")
         return cls(schema, target, masking_prob, **config)
 
-    def on_train_begin(self):
+    def configure_for_train(self):
         """Method called by the model.fit() to set the specialized
         `masking_post` and `masking_pre` needed by the TransformerBlock
         to align with the SequencePredictNext outputs.
@@ -705,7 +705,7 @@ class SequenceMaskRandom(SequenceTargetAsInput):
                 [SequenceMaskLastInference(), ExtractMaskFromTargets(), ReplaceMaskedEmbeddings()]
             )
 
-    def on_test_begin(self):
+    def configure_for_test(self):
         """Method called by the model.evaluate() to check that the
         `masking_pre` set in the TransformerBlock is aligned with
         the evaluation strategy of SequenceMaskRandom
@@ -812,7 +812,7 @@ class SequenceMaskLast(SequenceTargetAsInput):
         target = config.pop("target")
         return cls(schema, target, **config)
 
-    def on_train_begin(self):
+    def configure_for_train(self):
         """Method called by the model.fit() to set the specialized
         `masking_post` and `masking_pre` needed by the TransformerBlock
         to align with the SequencePredictNext outputs.
@@ -826,7 +826,7 @@ class SequenceMaskLast(SequenceTargetAsInput):
                 [SequenceMaskLastInference(), ExtractMaskFromTargets(), ReplaceMaskedEmbeddings()]
             )
 
-    def on_test_begin(self):
+    def configure_for_test(self):
         """Method called by the model.evaluate() to check that the
         `masking_pre` set in the TransformerBlock is aligned with
         the evaluation strategy of SequenceMaskRandom
@@ -910,7 +910,7 @@ class ReplaceMaskedEmbeddings(Block):
     Masked Language Modeling (BERT-like).
 
     To support masked training approach in Transformer-based model,
-    SequenceMaskRandom and SequenceLastRandom implements `on_train_begin` method
+    SequenceMaskRandom and SequenceLastRandom implements `configure_for_train` method
     that sets `ReplaceMaskedEmbeddings` as part of the `masking_pre` of
     the transformer block.
     """

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -506,9 +506,7 @@ def check_inputs_mask_compatible_shape(
        with the extra dimension typically related to the embeddings dimension.
     """
     result = False
-    if type(inputs) == type(mask) and (
-        inputs.shape.as_list()[: len(inputs.shape) - 1] == mask.shape.as_list()
-    ):
+    if type(inputs) == type(mask) and (inputs.shape.as_list()[:-1] == mask.shape.as_list()):
         if isinstance(inputs, tf.RaggedTensor):
             result = tf.reduce_all(
                 tf.cast(inputs.row_lengths(), tf.int32) == tf.cast(mask.row_lengths(), tf.int32)

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -481,7 +481,7 @@ def list_col_to_ragged(values: tf.Tensor, offsets: tf.Tensor):
     if offsets.dtype.is_floating:
         offsets = tf.cast(offsets, tf.int32)
 
-    return tf.RaggedTensor.from_row_lengths(values, row_lengths)
+    return tf.RaggedTensor.from_row_splits(values, offsets)
 
 
 def check_inputs_mask_compatible_shape(

--- a/tests/unit/tf/transformers/test_block.py
+++ b/tests/unit/tf/transformers/test_block.py
@@ -230,7 +230,6 @@ def classification_loader(sequence_testing_data: Dataset):
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_transformer_with_predict_random(sequence_testing_data: Dataset, run_eagerly):
-
     seq_schema = sequence_testing_data.schema.select_by_tag(Tags.SEQUENCE).select_by_tag(
         Tags.CATEGORICAL
     )

--- a/tests/unit/tf/transformers/test_block.py
+++ b/tests/unit/tf/transformers/test_block.py
@@ -237,12 +237,10 @@ def test_transformer_with_causal_language_modeling(sequence_testing_data: Datase
     target = target_schema.column_names[0]
 
     sequence_testing_data.schema = seq_schema + target_schema
-
-    predict_next = mm.SequencePredictNext(schema=seq_schema, target=target)
-    loader = Loader(sequence_testing_data, batch_size=8, shuffle=False)
     model_schema = sequence_testing_data.schema
 
     transformer_input_dim = 48
+    transformer_block = GPT2Block(d_model=transformer_input_dim, n_head=8, n_layer=2)
     model = mm.Model(
         mm.InputBlockV2(
             model_schema,
@@ -251,24 +249,36 @@ def test_transformer_with_causal_language_modeling(sequence_testing_data: Datase
             ),
         ),
         mm.MLPBlock([transformer_input_dim]),
-        GPT2Block(d_model=transformer_input_dim, n_head=8, n_layer=2),
+        transformer_block,
         mm.CategoricalOutput(
             model_schema.select_by_name(target), default_loss="categorical_crossentropy"
         ),
     )
 
-    batch = next(iter(loader))[0]
-    outputs = model(batch)
-    assert list(outputs.shape) == [8, 4, 51997]
+    predict_next = mm.SequencePredictNext(
+        schema=seq_schema, target=target, transformer=transformer_block
+    )
+    loader = Loader(sequence_testing_data, batch_size=8, shuffle=False)
+
     testing_utils.model_test(
         model, loader, run_eagerly=run_eagerly, reload_model=True, fit_kwargs={"pre": predict_next}
     )
+
+    batch = next(iter(loader))[0]
+    outputs = model(batch)
+    assert list(outputs.shape) == [8, 51997]
 
     metrics = model.evaluate(loader, batch_size=8, steps=1, return_dict=True, pre=predict_next)
     assert len(metrics) > 0
 
     predictions = model.predict(loader, batch_size=8, steps=1)
-    assert predictions.shape == (8, 4, 51997)
+    assert predictions.shape == (8, 51997)
+
+    predict_last = mm.SequencePredictLast(
+        schema=seq_schema, target=target, transformer=transformer_block
+    )
+    metrics = model.evaluate(loader, batch_size=8, steps=1, return_dict=True, pre=predict_last)
+    assert len(metrics) > 0
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
@@ -283,6 +293,7 @@ def test_transformer_with_masked_language_modeling(sequence_testing_data: Datase
 
     loader = Loader(sequence_testing_data, batch_size=8, shuffle=False)
     transformer_input_dim = 48
+    transformer_block = XLNetBlock(d_model=transformer_input_dim, n_head=8, n_layer=2)
     model = mm.Model(
         mm.InputBlockV2(
             seq_schema,
@@ -291,19 +302,15 @@ def test_transformer_with_masked_language_modeling(sequence_testing_data: Datase
             ),
         ),
         mm.MLPBlock([transformer_input_dim]),
-        XLNetBlock(
-            d_model=transformer_input_dim,
-            n_head=8,
-            n_layer=2,
-            pre=mm.SequentialBlock([mm.SequenceMaskLastInference(), mm.ReplaceMaskedEmbeddings()]),
-            post="inference_hidden_state",
-        ),
+        transformer_block,
         mm.CategoricalOutput(
             seq_schema.select_by_name(target),
             default_loss="categorical_crossentropy",
         ),
     )
-    seq_mask_random = mm.SequenceMaskRandom(schema=seq_schema, target=target, masking_prob=0.3)
+    seq_mask_random = mm.SequenceMaskRandom(
+        schema=seq_schema, target=target, masking_prob=0.3, transformer=transformer_block
+    )
 
     inputs, targets = loader.peek()
 
@@ -317,7 +324,9 @@ def test_transformer_with_masked_language_modeling(sequence_testing_data: Datase
         fit_kwargs={"pre": seq_mask_random},
     )
 
-    seq_mask_last = mm.SequenceMaskLast(schema=seq_schema, target=target)
+    seq_mask_last = mm.SequenceMaskLast(
+        schema=seq_schema, target=target, transformer=transformer_block
+    )
     metrics = model.evaluate(loader, batch_size=8, steps=1, return_dict=True, pre=seq_mask_last)
     assert len(metrics) > 0
 
@@ -340,6 +349,7 @@ def test_transformer_with_masked_language_modeling_check_eval_masked(
     loader = Loader(sequence_testing_data, batch_size=8, shuffle=False)
 
     transformer_input_dim = 48
+    transformer_block = BertBlock(d_model=transformer_input_dim, n_head=8, n_layer=2)
     model = mm.Model(
         mm.InputBlockV2(
             seq_schema,
@@ -348,19 +358,15 @@ def test_transformer_with_masked_language_modeling_check_eval_masked(
             ),
         ),
         mm.MLPBlock([transformer_input_dim]),
-        XLNetBlock(
-            d_model=transformer_input_dim, n_head=8, n_layer=2, pre=mm.ReplaceMaskedEmbeddings()
-        ),
+        transformer_block,
         mm.CategoricalOutput(
             seq_schema.select_by_name(target),
             default_loss="categorical_crossentropy",
         ),
     )
-    seq_mask_random = mm.SequenceMaskRandom(schema=seq_schema, target=target, masking_prob=0.3)
-
-    inputs = itertools.islice(iter(loader), 1)
-    outputs = model.predict(inputs, pre=seq_mask_random)
-    assert list(outputs.shape) == [8, 4, 51997]
+    seq_mask_random = mm.SequenceMaskRandom(
+        schema=seq_schema, target=target, masking_prob=0.3, transformer=transformer_block
+    )
 
     testing_utils.model_test(
         model,
@@ -370,6 +376,10 @@ def test_transformer_with_masked_language_modeling_check_eval_masked(
         fit_kwargs={"pre": seq_mask_random},
         metrics=[mm.RecallAt(5000), mm.NDCGAt(5000, seed=4)],
     )
+
+    inputs = itertools.islice(iter(loader), 1)
+    outputs = model.predict(inputs, pre=seq_mask_random)
+    assert list(outputs.shape) == [8, 51997]
 
     # This transform only extracts targets, but without applying mask
     seq_target_as_input_no_mask = mm.SequenceTargetAsInput(schema=seq_schema, target=target)
@@ -429,18 +439,13 @@ def test_transformer_model_with_masking_and_broadcast_to_sequence(
 
     dmodel = 32
     mlp_block = mm.MLPBlock([128, dmodel], activation="relu")
-
-    dense_block = mm.SequentialBlock(
-        input_block,
-        mlp_block,
-        mm.GPT2Block(
-            d_model=dmodel,
-            n_head=4,
-            n_layer=2,
-            pre=mm.ReplaceMaskedEmbeddings(),
-            post="inference_hidden_state",
-        ),
+    transformer_block = mm.GPT2Block(
+        d_model=dmodel,
+        n_head=4,
+        n_layer=2,
     )
+
+    dense_block = mm.SequentialBlock(input_block, mlp_block, transformer_block)
 
     mlp_block2 = mm.MLPBlock([128, dmodel], activation="relu")
 
@@ -449,7 +454,9 @@ def test_transformer_model_with_masking_and_broadcast_to_sequence(
     )
     model = mm.Model(dense_block, mlp_block2, prediction_task)
 
-    fit_pre = mm.SequenceMaskRandom(schema=seq_schema, target=target, masking_prob=0.3)
+    fit_pre = mm.SequenceMaskRandom(
+        schema=seq_schema, target=target, masking_prob=0.3, transformer=transformer_block
+    )
     testing_utils.model_test(
         model,
         sequence_testing_data,

--- a/tests/unit/tf/transforms/test_sequence.py
+++ b/tests/unit/tf/transforms/test_sequence.py
@@ -195,6 +195,7 @@ def test_seq_mask_random_replace_embeddings(
     sequence_testing_data: Dataset, dense: bool, target_as_dict: bool
 ):
     from merlin.models.tf.transforms.sequence import ExtractMaskFromTargets
+
     sequence_testing_data.schema = sequence_testing_data.schema.select_by_tag(
         Tags.SEQUENCE
     ).select_by_name(["item_id_seq", "categories"])

--- a/tests/unit/tf/transforms/test_sequence.py
+++ b/tests/unit/tf/transforms/test_sequence.py
@@ -195,11 +195,9 @@ def test_seq_mask_random_replace_embeddings(
     sequence_testing_data: Dataset, dense: bool, target_as_dict: bool
 ):
     from merlin.models.tf.transforms.sequence import ExtractMaskFromTargets
-
-    seq_schema = sequence_testing_data.schema.select_by_tag(Tags.SEQUENCE).select_by_name(
-        ["item_id_seq", "categories"]
-    )
-
+    sequence_testing_data.schema = sequence_testing_data.schema.select_by_tag(
+        Tags.SEQUENCE
+    ).select_by_name(["item_id_seq", "categories"])
     target = sequence_testing_data.schema.select_by_tag(Tags.ITEM_ID).column_names[0]
     predict_masked = mm.SequenceMaskRandom(
         schema=sequence_testing_data.schema, target=target, masking_prob=0.3


### PR DESCRIPTION
Fixes #918 
Fixes #1024 
Fixes #1025
Fixes #1026

- This work was necessary for the GTC tutorial 2023  and is fixing issues related to Causal LM and at the same time simplifying the high-level transformer API. 

- The new API for defining a transformer-based model is defined as follows:

```
    transformer_input_dim = 48
    transformer_block = BertBlock(d_model=transformer_input_dim, n_head=8, n_layer=2)
    model = mm.Model(
        mm.InputBlockV2(...),
        transformer_block,
        mm.CategoricalOutput(...),
    )
    seq_mask_random = mm.SequenceMaskRandom(
        schema=seq_schema, target=target, masking_prob=0.3, transformer=transformer_block
    )
    model.compile(...)
    model.fit(..., pre=seq_mask_random)
```

* I created this doc for more details about the Merlin Transformer API and the proposed changes: https://docs.google.com/document/d/1auNJCOPFjyVxlhx4eUUthpMLm-rva0jC-lo0ChSZWzI/edit#

### Goals :soccer:


This PR aims to address the following limitations in the current Transformer API:

- [x] 1. **Inference for CausalLM is not supported**: the model returns scores for all positions in the input sequence but we are only interested on the last position at inference time.
- [x] 2. **CLM only supports the transform SequencePredictNext**: We cannot train or evaluate a CLM model on the last item of the sequence only (i.e using SequencePredictLast)
- [x] 3. **Specialized and complex API**: the support of masking and inference is done via specialized Merlin Blocks (`ReplaceMaskedEmbeddings`, `SequenceMaskLastInference`). So the user should be familiar with all these custom blocks to correctly define and train a transformer-based model with CLM or MLM approach.
- [x] 4. **Output of the model is a padded dense tensor of scores**: As the HuggingFace transformer layer is requiring a dense input. We are converting the ragged inputs to dense (by 0-padding to the maximum length seen in the given batch) right before calling the HF layer. The ops that follow this block are then applied to the padded dense tensor. This means that we compute the logit scores for all positions (even the padded ones) and which can be costly (such in the weight tying multiplication between the hidden representation all items embeddings).

### Implementation Details :construction:

- [x] Add Inference support to a transformer-based model trained with CLM: i.e. select the prediction score of the last non-padded position.
- [x] Support evaluating a transformer-based model trained with CLM (trained with SequencePredictNext) on the last item in the sequence (i.e using SequencePredictLast).
- [x] Simplify the transformer API by abstracting the definition of the `masking_pre` and `masking_post` blocks using the `pre` transform set in the `fit()` method.
- [x] Optimize the predictions generation of transformer-based model: Convert the dense tensor returned by the transformer layer to a `tf.RaggedTensor` so that all the logic happening after the transformer block (MLP projections, softmax layer...) is applied only on actual positions.
- [x] Add masking support for `SequencePredictNext` and `SequencePredictLast`
- [x] Add checks to ensure the SequenceTransform used in evaluate() is aligned with the `masking_pre` used to train the transformer model. 
- [x] Implement the following specialized blocks (needed for CLM and MLM support): 
    *  `SequenceCausalLastInference` to generate a mask indicating the last non-padded position of each input sequence at inference time. 
    * `ExtractMaskFromTargets` to move the logic defined in `ReplaceMaskedEmbeddings` and which consists of inferring the mask information based on targets. 
    * `TransformerOutputToRagged` to convert the output of the transformer layer to Ragged based on the mask information. 
- [x] Update the example notebooks 


### Testing Details :mag:
- Update `test_transformer_with_masked_language_modeling` and `test_transformer_with_causal_language_modeling` to account for the changes. 
- Update the 