### PR TITLE
Adds Support to embedding sequence_combiner for dense tensors

### DIFF
--- a/merlin/datasets/ecommerce/booking/transformed/schema.pbtxt
+++ b/merlin/datasets/ecommerce/booking/transformed/schema.pbtxt
@@ -65,7 +65,7 @@ feature {
 feature {
   name: "booker_country"
   value_count {
-    min: 1
+    min: 4
     max: 48
   }
   type: INT
@@ -86,7 +86,7 @@ feature {
 feature {
   name: "hotel_country"
   value_count {
-    min: 1
+    min: 4
     max: 48
   }
   type: INT
@@ -107,7 +107,7 @@ feature {
 feature {
   name: "month"
   value_count {
-    min: 1
+    min: 4
     max: 48
   }
   type: INT
@@ -128,7 +128,7 @@ feature {
 feature {
   name: "is_weekend"
   value_count {
-    min: 1
+    min: 4
     max: 48
   }
   type: INT
@@ -149,7 +149,7 @@ feature {
 feature {
   name: "weekday_checkin"
   value_count {
-    min: 1
+    min: 4
     max: 48
   }
   type: INT
@@ -170,7 +170,7 @@ feature {
 feature {
   name: "weekday_checkout"
   value_count {
-    min: 1
+    min: 4
     max: 48
   }
   type: INT
@@ -191,7 +191,7 @@ feature {
 feature {
   name: "city_id"
   value_count {
-    min: 1
+    min: 4
     max: 48
   }
   type: INT

--- a/merlin/datasets/entertainment/music_streaming/schema.json
+++ b/merlin/datasets/entertainment/music_streaming/schema.json
@@ -62,7 +62,7 @@
     {
       "name": "item_genres",
       "valueCount": {
-        "min": "1"
+        "min": "4"
       },
       "type": "INT",
       "intDomain": {
@@ -125,7 +125,7 @@
     {
       "name": "user_genres",
       "valueCount": {
-        "min": "1"
+        "min": "4"
       },
       "type": "INT",
       "intDomain": {

--- a/merlin/datasets/synthetic.py
+++ b/merlin/datasets/synthetic.py
@@ -56,7 +56,7 @@ def generate_data(
     input: Union[Schema, Path, str],
     num_rows: int,
     set_sizes: Sequence[float] = (1.0,),
-    min_session_length=4,
+    min_session_length=None,
     max_session_length=None,
     device="cpu",
 ) -> Union[merlin.io.Dataset, Tuple[merlin.io.Dataset, ...]]:

--- a/merlin/datasets/testing/sequence_testing/schema.json
+++ b/merlin/datasets/testing/sequence_testing/schema.json
@@ -26,7 +26,7 @@
       "name": "item_age_days_norm",
       "type": "FLOAT",
       "valueCount": {
-        "min": "1"
+        "min": "4"
       },
       "floatDomain": {
         "name": "item_age_days_norm",
@@ -45,7 +45,7 @@
       "name": "event_hour_sin",
       "type": "FLOAT",
       "valueCount": {
-        "min": "1"
+        "min": "4"
       },
       "floatDomain": {
         "name": "event_hour_sin",
@@ -63,7 +63,7 @@
       "name": "event_hour_cos",
       "type": "FLOAT",
       "valueCount": {
-        "min": "1"
+        "min": "4"
       },
       "floatDomain": {
         "name": "event_hour_cos",
@@ -81,7 +81,7 @@
       "name": "event_weekday_sin",
       "type": "FLOAT",
       "valueCount": {
-        "min": "1"
+        "min": "4"
       },
       "floatDomain": {
         "name": "event_weekday_sin",
@@ -99,7 +99,7 @@
       "name": "event_weekday_cos",
       "type": "FLOAT",
       "valueCount": {
-        "min": "1"
+        "min": "4"
       },
       "floatDomain": {
         "name": "event_weekday_cos",
@@ -117,7 +117,7 @@
       "name": "item_id_seq",
       "type": "INT",
       "valueCount": {
-        "min": "1"
+        "min": "4"
       },
       "intDomain": {
         "name": "item_id_seq",
@@ -137,7 +137,7 @@
     {
       "name": "categories",
       "valueCount": {
-        "min": "1"
+        "min": "4"
       },
       "type": "INT",
       "intDomain": {

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -414,10 +414,11 @@ class EmbeddingTable(EmbeddingTableBase):
             if inputs.shape.as_list()[-1] == 1:
                 inputs = tf.squeeze(inputs, axis=-1)
             out = call_layer(self.table, inputs, **kwargs)
-            if len(out.get_shape()) > 2 and isinstance(
-                self.sequence_combiner, tf.keras.layers.Layer
-            ):
-                out = call_layer(self.sequence_combiner, out, **kwargs)
+            if len(out.get_shape()) > 2 and self.sequence_combiner is not None:
+                if isinstance(self.sequence_combiner, tf.keras.layers.Layer):
+                    out = call_layer(self.sequence_combiner, out, **kwargs)
+                elif isinstance(self.sequence_combiner, str):
+                    out = process_str_sequence_combiner(out, self.sequence_combiner, **kwargs)
 
         if self.l2_batch_regularization_factor > 0:
             self.add_loss(self.l2_batch_regularization_factor * tf.reduce_sum(tf.square(out)))
@@ -919,6 +920,9 @@ class EmbeddingFeatures(TabularBlock):
                     val = tf.squeeze(val, axis=-1)
                 out = tf.gather(table_var, tf.cast(val, tf.int32))
 
+            if len(out.get_shape()) > 2 and table.combiner is not None:
+                out = process_str_sequence_combiner(out, table.combiner)
+
         if self._dtype_policy.compute_dtype != self._dtype_policy.variable_dtype:
             # Instead of casting the variable as in most layers, cast the output, as
             # this is mathematically equivalent but is faster.
@@ -1200,3 +1204,35 @@ def serialize_feature_config(feature_config: FeatureConfig) -> Dict[str, Any]:
         outputs[key] = feature_config_dict
 
     return outputs
+
+
+def process_str_sequence_combiner(
+    inputs: Union[tf.Tensor, tf.RaggedTensor], combiner: str, **kwargs
+) -> tf.Tensor:
+    """Process inputs with str sequence combiners ("mean" or "sum")
+
+    Parameters
+    ----------
+    inputs : Union[tf.Tensor, tf.RaggedTensor]
+        Input 3D tensor (batch size, seq length, embedding dim)
+    combiner : str
+        The combiner: "mean" or "sum"
+
+    Returns
+    -------
+    tf.Tensor
+        A 2D tensor with values combined on axis=1
+    """
+    if not combiner or len(inputs.get_shape()) <= 2:
+        return inputs
+    if combiner == "mean":
+        combiner = tf.keras.layers.Lambda(lambda x: tf.reduce_mean(x, axis=1))
+    elif combiner == "sum":
+        combiner = tf.keras.layers.Lambda(lambda x: tf.reduce_sum(x, axis=1))
+    else:
+        raise ValueError(
+            "Only 'mean' and 'sum' str combiners is implemented for dense"
+            " list/multi-hot embedded features. You can also"
+            " provide a tf.keras.layers.Layer instance as a sequence combiner."
+        )
+    return call_layer(combiner, inputs, **kwargs)

--- a/merlin/models/tf/transforms/features.py
+++ b/merlin/models/tf/transforms/features.py
@@ -175,13 +175,8 @@ class PrepareListFeatures(TabularBlock):
                             val = inputs[name]
                         elif isinstance(val, tf.SparseTensor):
                             val = tf.RaggedTensor.from_sparse(val)
-                        else:
-                            val = tf.RaggedTensor.from_tensor(val)
                     else:
-                        # TODO: Change this condition to check is_ragged after this PR
-                        # from Oliver is merged https://github.com/NVIDIA-Merlin/dataloader/pull/103
-                        # if col_schema_shape.is_ragged:
-                        if True:
+                        if col_schema_shape.is_ragged:
                             if f"{name}__values" not in inputs or f"{name}__offsets" not in inputs:
                                 raise ValueError(
                                     f"The ragged list feature '{name}' is expected to be "
@@ -1325,10 +1320,11 @@ def expected_input_cols_from_schema(schema: Schema, inputs: Optional[TabularData
     schema = schema.remove_by_tag(Tags.TARGET)
     expected_features = []
     for name in schema.column_names:
-        # TODO: Change this condition to check is_ragged after this PR
-        # from Oliver is merged https://github.com/NVIDIA-Merlin/dataloader/pull/103
-        # if schema[name].shape.is_list and schema[name].shape.is_ragged ...
-        if schema[name].shape.is_list and (inputs is None or name not in inputs):
+        if (
+            schema[name].shape.is_list
+            and schema[name].shape.is_ragged
+            and (inputs is None or name not in inputs)
+        ):
             expected_features.extend([f"{name}__values", f"{name}__offsets"])
         else:
             expected_features.append(name)

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -65,16 +65,16 @@ def calculate_batch_size_from_inputs(inputs):
 
 
 def calculate_batch_size_from_input_shapes(input_shapes):
-    non_list_features = list(
+    non_ragged_features = list(
         [k for k in input_shapes if not k.endswith("__values") and not k.endswith("__offsets")]
     )
-    if len(non_list_features) > 0:
-        batch_size = input_shapes[non_list_features[0]][0]
+    if len(non_ragged_features) > 0:
+        batch_size = input_shapes[non_ragged_features[0]][0]
         return batch_size
 
-    list_features_offsets = list([k for k in input_shapes if k.endswith("__offsets")])
-    if len(list_features_offsets) > 0:
-        batch_size = input_shapes[list_features_offsets[0]][0]
+    ragged_features_offsets = list([k for k in input_shapes if k.endswith("__offsets")])
+    if len(ragged_features_offsets) > 0:
+        batch_size = input_shapes[ragged_features_offsets[0]][0]
         if batch_size is not None:
             batch_size -= 1
         return batch_size

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -84,6 +84,12 @@ class TestEmbeddingTable:
                 tf.sparse.from_dense(tf.constant([[[1], [2], [3]]])),
                 [1, 16],
             ),
+            (
+                16,
+                {"sequence_combiner": "mean"},
+                tf.constant([[[1], [2], [3]], [[4], [5], [6]]]),
+                [2, 16],
+            ),
             (12, {}, {"item_id": tf.constant([[1]])}, {"item_id": [1, 12]}),
         ],
     )


### PR DESCRIPTION
### Goals :soccer:
- The `EmbeddingTable` accepts `sequence_combiner` that reduces the 2nd dim (`axis=1`) of 3D embeddings (batch size, seq. lenght, embedding size). When `sequence_combiner` was a `str`, it was applying the combiner just for `tf.RaggedTensor` and `tf.SparseTensor`, but not for `tf.Tensor`. This PR fix this issue

### Implementation Details :construction:
- This PR ensures that `"mean"` and `"sum"` sequence combiners are supported also for `tf.Tensor` (by using `tf.keras.layers.Lambda()`).
- It also updates `EmbeddingFeatures`, which is our old API for embedding features
- I changed the `generate_data()` test fixture and some test dataset schemas to make sine tests pass

### Testing Details :mag:
- `TestEmbeddingTable.test_layer` was changed to include a case where a 3D tf.Tensor is provided and `sequence_combiner == "mean"`
