### PR TITLE
Skip SOK tests if SOK is not installed

### DIFF
--- a/merlin/models/tf/utils/testing_utils.py
+++ b/merlin/models/tf/utils/testing_utils.py
@@ -471,6 +471,7 @@ def loader_for_last_item_prediction(sequence_testing_data: merlin.io.Dataset, to
         def compute_output_schema(self, input_schema):
             return input_schema
 
+        @tf.function
         def __call__(self, inputs, targets=None):
             inputs = prepare_features(inputs)
 

--- a/tests/unit/tf/horovod/test_embedding.py
+++ b/tests/unit/tf/horovod/test_embedding.py
@@ -1,3 +1,5 @@
+import importlib
+
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -8,6 +10,7 @@ from merlin.schema import ColumnSchema, Tags
 
 
 @pytest.mark.skipif(not HAS_GPU, reason="No GPU available")
+@pytest.mark.skipif(importlib.util.find_spec("sparse_operation_kit") is None, reason="needs sok")
 class TestSOKEmbedding:
     sample_column_schema = ColumnSchema(
         "item_id",


### PR DESCRIPTION
Follow-up to #863 

This PR proposes to skip unit tests for `SOKEmbedding` if SOK is not installed.