### PR TITLE
set random seed in implicit tests

### DIFF
--- a/tests/unit/implicit/test_implicit.py
+++ b/tests/unit/implicit/test_implicit.py
@@ -24,6 +24,7 @@ from merlin.schema import Tags
 
 
 def test_alternating_least_squares(music_streaming_data: Dataset):
+    np.random.seed(42)
     music_streaming_data.schema = music_streaming_data.schema.remove_by_tag(Tags.TARGET)
 
     model = AlternatingLeastSquares(factors=128, iterations=15, regularization=0.01)
@@ -36,6 +37,7 @@ def test_alternating_least_squares(music_streaming_data: Dataset):
 
 
 def test_bayesian_personalized_ranking(music_streaming_data: Dataset):
+    np.random.seed(42)
     music_streaming_data.schema = music_streaming_data.schema.remove_by_tag(Tags.TARGET)
 
     model = BayesianPersonalizedRanking(factors=128, iterations=15, regularization=0.01)
@@ -48,6 +50,7 @@ def test_bayesian_personalized_ranking(music_streaming_data: Dataset):
 
 
 def test_reload_alternating_least_squares(music_streaming_data: Dataset, tmpdir):
+    np.random.seed(42)
     train, valid = generate_data("music-streaming", 100, (0.95, 0.05))
     train.schema = train.schema.excluding_by_name(["play_percentage", "like"])
     valid.schema = valid.schema.excluding_by_name(["play_percentage", "like"])
@@ -66,6 +69,7 @@ def test_reload_alternating_least_squares(music_streaming_data: Dataset, tmpdir)
 
 
 def test_reload_bayesian_personalized_ranking(music_streaming_data: Dataset, tmpdir):
+    np.random.seed(42)
     train, valid = generate_data("music-streaming", 100, (0.95, 0.05))
     train.schema = train.schema.excluding_by_name(["play_percentage", "like"])
     valid.schema = valid.schema.excluding_by_name(["play_percentage", "like"])


### PR DESCRIPTION
This PR proposes to set the random seed in order to remove randomness in unit tests for Implicit. These tests, in particular `test_reload_bayesian_personalized_ranking`, sometimes fail non-deterministically, blocking release pipelines:
```
>       np.testing.assert_array_almost_equal(model.predict(valid), reloaded.predict(valid))

tests/unit/implicit/test_implicit.py:81: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
merlin/models/implicit/__init__.py:131: in predict
    return self.implicit_model.recommend(userids, None, filter_already_liked_items=False, N=k)
/usr/local/lib/python3.8/dist-packages/implicit/gpu/matrix_factorization_base.py:54: in recommend
    user_factors = self.user_factors[userid]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   IndexError: row id out of range for selecting items from matrix
```
which seems like a bug in the implicit library rather than something that can be fixed from our side.