### PR TITLE
Add Transformers4Rec repo test

### DIFF
--- a/.github/workflows/cpu-t4r.yml
+++ b/.github/workflows/cpu-t4r.yml
@@ -32,13 +32,10 @@ jobs:
     - name: Install and upgrade python packages
       run: |
         python -m pip install --upgrade pip setuptools==59.4.0 wheel tox
+    - name: Get Branch name
+      id: get-branch-name
+      uses: NVIDIA-Merlin/.github/actions/branch-name@main
     - name: Run tests
       run: |
-        ref_type=${{ github.ref_type }}
-        branch=main
-        if [[ $ref_type == "tag"* ]]
-        then
-          git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release*:refs/remotes/origin/release*
-          branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
-        fi
+        branch="${{ steps.get-branch-name.outputs.branch }}"
         GIT_COMMIT=`git rev-parse HEAD` tox -e py38-transformers4rec-cpu -- $branch

--- a/.github/workflows/cpu-t4r.yml
+++ b/.github/workflows/cpu-t4r.yml
@@ -1,4 +1,4 @@
-name: nvtabular
+name: transformers4rec
 
 on:
   workflow_dispatch:

--- a/.github/workflows/cpu-t4r.yml
+++ b/.github/workflows/cpu-t4r.yml
@@ -1,0 +1,44 @@
+name: nvtabular
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    tags:
+      - v*
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.8]
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+       fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Ubuntu packages
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y protobuf-compiler
+    - name: Install and upgrade python packages
+      run: |
+        python -m pip install --upgrade pip setuptools==59.4.0 wheel tox
+    - name: Run tests
+      run: |
+        ref_type=${{ github.ref_type }}
+        branch=main
+        if [[ $ref_type == "tag"* ]]
+        then
+          git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release*:refs/remotes/origin/release*
+          branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
+        fi
+        GIT_COMMIT=`git rev-parse HEAD` tox -e py38-transformers4rec-cpu -- $branch

--- a/tox.ini
+++ b/tox.ini
@@ -99,6 +99,22 @@ commands =
     python -m pip install .
     python -m pytest -m "not notebook" systems-{env:GIT_COMMIT}/tests/unit
 
+[testenv:py38-transformers4rec-cpu]
+passenv=GIT_COMMIT
+allowlist_externals = git
+deps =
+    -rrequirements/base.txt
+    -rrequirements/dev.txt
+commands =
+    ; the GIT_COMMIT env is the current commit of the core repo
+    git clone --depth 1 --branch {posargs:main} https://github.com/NVIDIA-Merlin/Transformers4Rec.git Transformers4Rec-{env:GIT_COMMIT}
+    python -m pip install --upgrade "./Transformers4Rec-{env:GIT_COMMIT}"
+    python -m pip install --upgrade -r "./Transformers4Rec-{env:GIT_COMMIT}/requirements/test.txt"
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git@{posargs:main}
+    python -m pip install .
+    python -m pytest Transformers4Rec-{env:GIT_COMMIT}/tests/unit
+
 [testenv:docs]
 ; Runs in: Github Actions
 ; Generates documentation with sphinx. There are other steps in the Github Actions workflow

--- a/tox.ini
+++ b/tox.ini
@@ -89,7 +89,7 @@ deps =
     -rrequirements/base.txt
     -rrequirements/dev.txt
 commands =
-    ; the GIT_COMMIT env is the current commit of the core repo
+    ; the GIT_COMMIT env is the current commit of the models repo
     git clone --depth 1 --branch {posargs:main} https://github.com/NVIDIA-Merlin/systems.git systems-{env:GIT_COMMIT}
     python -m pip install --upgrade "./systems-{env:GIT_COMMIT}"
     python -m pip install --upgrade -r "./systems-{env:GIT_COMMIT}/requirements/test-cpu.txt"
@@ -103,7 +103,7 @@ commands =
 passenv=GIT_COMMIT
 allowlist_externals = git
 commands =
-    ; the GIT_COMMIT env is the current commit of the core repo
+    ; the GIT_COMMIT env is the current commit of the models repo
     git clone --depth 1 --branch {posargs:main} https://github.com/NVIDIA-Merlin/Transformers4Rec.git Transformers4Rec-{env:GIT_COMMIT}
     python -m pip install --upgrade -r "./Transformers4Rec-{env:GIT_COMMIT}/requirements/test.txt"
     python -m pip install --upgrade "./Transformers4Rec-{env:GIT_COMMIT}"

--- a/tox.ini
+++ b/tox.ini
@@ -102,17 +102,14 @@ commands =
 [testenv:py38-transformers4rec-cpu]
 passenv=GIT_COMMIT
 allowlist_externals = git
-deps =
-    -rrequirements/base.txt
-    -rrequirements/dev.txt
 commands =
     ; the GIT_COMMIT env is the current commit of the core repo
     git clone --depth 1 --branch {posargs:main} https://github.com/NVIDIA-Merlin/Transformers4Rec.git Transformers4Rec-{env:GIT_COMMIT}
-    python -m pip install --upgrade "./Transformers4Rec-{env:GIT_COMMIT}"
     python -m pip install --upgrade -r "./Transformers4Rec-{env:GIT_COMMIT}/requirements/test.txt"
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
-    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git@{posargs:main}
-    python -m pip install .
+    python -m pip install --upgrade "./Transformers4Rec-{env:GIT_COMMIT}"
+    python -m pip install --no-deps git+https://github.com/NVIDIA-Merlin/core.git@{posargs:main}
+    python -m pip install --no-deps git+https://github.com/NVIDIA-Merlin/dataloader.git@{posargs:main}
+    python -m pip install --no-deps .
     python -m pytest Transformers4Rec-{env:GIT_COMMIT}/tests/unit
 
 [testenv:docs]


### PR DESCRIPTION
This PR adds Github actions that run the unit tests in `transformers4rec`. The motivation for adding these tests is to detect if changes in Dataloader could potentially break T4Rec since T4Rec now depends on Models. These downstream repo tests are similar to [how they are set up in Core](https://github.com/NVIDIA-Merlin/core/blob/45617769166f17aeec3d455fd1a1a7a83653d259/tox.ini).