### PR TITLE
Refactory/fix of sampled softmax to add logQ correction

### DIFF
--- a/merlin/models/tf/models/retrieval.py
+++ b/merlin/models/tf/models/retrieval.py
@@ -579,6 +579,7 @@ def YoutubeDNNRetrievalModelV2(
             negative_samplers=PopularityBasedSamplerV2(
                 max_num_samples=num_sampled, max_id=num_classes - 1, min_id=min_sampled_id
             ),
+            logq_sampling_correction=True,
         )
 
     return RetrievalModelV2(query=query, output=outputs)

--- a/merlin/models/tf/transforms/bias.py
+++ b/merlin/models/tf/transforms/bias.py
@@ -82,7 +82,8 @@ class PopularityLogitsCorrection(Block):
     where `item_prob = item_freq_count / sum(item_freq_count)` is
     a probability distribution of the item frequency. In a nutshell,
     the logQ correction aims to increase the prediction scores (logits)
-    for infrequent items and decrease the ones for frequent items.
+    for infrequent items and decrease the ones for frequent items, so
+    that they are not much more penalized for being sampled more often.
 
     References
     ----------

--- a/tests/unit/tf/outputs/test_contrastive.py
+++ b/tests/unit/tf/outputs/test_contrastive.py
@@ -101,7 +101,7 @@ def test_two_tower_constrastive_with_logq_correction(ecommerce_data: Dataset):
 
 
 @pytest.mark.parametrize("run_eagerly", [True, False])
-def test_contrastive_output(ecommerce_data: Dataset, run_eagerly):
+def test_contrastive_output_with_sampled_softmax(ecommerce_data: Dataset, run_eagerly):
     schema = ecommerce_data.schema
     schema["item_category"] = schema["item_category"].with_tags(
         schema["item_category"].tags + "target"
@@ -112,7 +112,8 @@ def test_contrastive_output(ecommerce_data: Dataset, run_eagerly):
         mm.MLPBlock([8]),
         mm.ContrastiveOutput(
             schema["item_category"],
-            negative_samplers=PopularityBasedSamplerV2(max_id=100, max_num_samples=20),
+            negative_samplers=PopularityBasedSamplerV2(max_id=100, max_num_samples=20, min_id=1),
+            logq_sampling_correction=True,
         ),
     )
 


### PR DESCRIPTION
### Goals :soccer:
Sampled softmax is a popular technique to deal with multi-class classification with a very large number of classes.
It has been used to train retrieval models with contrastive learning by using a subset of candidate negative items during training, instead of using all other items as negatives. 
This PR adds the important logQ sampling correction proposed by sampled softmax, in order to better approximate it to the full softmax.

### Implementation Details :construction:
In general, sampled softmax was implemented before by using `ContrastiveOutput` as model output and the `PopularityBasedSamplerV2` as a sampler (like example below), that uses the log-uniform distribution to approximate the long-tail items frequency (assuming that categorical ids are sorted decreasingly by frequency).

```python
mm.ContrastiveOutput(
            schema["item_id"],
            negative_samplers=PopularityBasedSamplerV2(max_id=10000, max_num_samples=100),
        ),
```

However, the logQ correction was not implemented as proposed by sampled softmax, to fix the overpenalization of popular items as they are sampled more often as negatives. The logQ correction can be used by `PopularityLogitsCorrection`, but it requires providing the items frequency distribution. As our sampled softmax implemetation (`PopularityBasedSamplerV2` ) uses an approximated log-uniform distribution for sampling, I implemented the corresponding sampling probability of the positive and negative items to allow for the sampling correction (with replacement or not). You can use sampled softmax as in the folllowing example.

```python
mm.ContrastiveOutput(
            schema["item_id"],
            negative_samplers=PopularityBasedSamplerV2(max_id=10000, max_num_samples=100),
            logq_sampling_correction=True,
        ),
```

It was created a new `logq_sampling_correction=False` arg to the `ContrastiveOutput`, that should be set to True when the sampler supports returning the items' sampling probs (like `PopularityBasedSamplerV2` does). If it is used, then `PopularityLogitsCorrection` doesn't need to be used.

#### Summary of main API changes
- Changed `Candidate` to optionally store the sampling prob. of each item
- Changed the `CandidateSampler` abstract class to have a `with_sampling_probs(items)` method, that allows returning the probability of the provided items according to the sampler distribution.
- Changed the `PopularityBasedSamplerV2` to support both unique and not-unique samples, to compute its distribution in the constructor (get_sampling_distribution()) as it is based on an log-uniform approximation of items' long-tail frequency distribution
- Changed `ContrastiveOutput` to set the sampling probs for both positive and negative stores. Created the arg `logq_sampling_correction`, that if enabled subtracts the logQ sampled probs based on the `Candidate.sampling_prob`

### Testing Details :mag:
- Added the `test_contrastive_output_with_sampled_softmax` to test and showcase how sampled softmax can be used in Merlin Models
