### PR TITLE
Fixes model.batch_predict() which was not working with ModelOuput

### DIFF
--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -2529,18 +2529,22 @@ def get_task_names_from_outputs(
         output_names = outputs.task_names
     elif isinstance(outputs, ParallelBlock):
         if all(isinstance(x, ModelOutput) for x in outputs.parallel_values):
-            output_names = [o.full_name for o in outputs.parallel_values]
+            output_names = [o.task_name for o in outputs.parallel_values]
         else:
             raise ValueError("The blocks within ParallelBlock must be ModelOutput.")
     elif isinstance(outputs, (list, tuple)):
         if all(isinstance(x, PredictionTask) for x in outputs):
             output_names = [o.task_name for o in outputs]  # type: ignore
         elif all(isinstance(x, ModelOutput) for x in outputs):
-            output_names = [o.full_name for o in outputs]  # type: ignore
+            output_names = [o.task_name for o in outputs]  # type: ignore
         else:
             raise ValueError(
                 "The blocks within the list/tuple must be ModelOutput or PredictionTask."
             )
+    elif isinstance(outputs, PredictionTask):
+        output_names = [outputs.task_name]
+    elif isinstance(outputs, ModelOutput):
+        output_names = [outputs.task_name]
     else:
-        raise ValueError("Invalid outputs")
+        raise ValueError("Invalid model outputs")
     return output_names

--- a/merlin/models/tf/outputs/base.py
+++ b/merlin/models/tf/outputs/base.py
@@ -76,7 +76,7 @@ class ModelOutput(Layer):
     ):
         logits_scaler = kwargs.pop("logits_scaler", None)
         self.target = target
-        self.full_name = self.task_name(self.target)
+        self.full_name = self.get_task_name(self.target)
 
         super().__init__(name=name or self.full_name, **kwargs)
         self.to_call = to_call
@@ -91,6 +91,10 @@ class ModelOutput(Layer):
             self.logits_temperature = logits_temperature
             if logits_temperature != 1.0:
                 self.logits_scaler = LogitsTemperatureScaler(logits_temperature)
+
+    @property
+    def task_name(self) -> str:
+        return self.full_name
 
     def build(self, input_shape=None):
         """Builds the PredictionBlock.
@@ -249,7 +253,7 @@ class ModelOutput(Layer):
         return config
 
     @classmethod
-    def task_name(cls, target_name):
+    def get_task_name(cls, target_name):
         base_name = to_snake_case(cls.__name__)
         return name_fn(target_name, base_name) if target_name else base_name
 

--- a/merlin/models/tf/outputs/block.py
+++ b/merlin/models/tf/outputs/block.py
@@ -113,7 +113,7 @@ def OutputBlock(
             else:
                 model_output_cls = CategoricalOutput
 
-        task_name = model_output_cls.task_name(col.name)
+        task_name = model_output_cls.get_task_name(col.name)
 
         if task_name in outputs:
             output_block = outputs[task_name]

--- a/merlin/models/tf/utils/batch_utils.py
+++ b/merlin/models/tf/utils/batch_utils.py
@@ -80,7 +80,7 @@ class TFModelEncode(ModelEncode):
         model.save(save_path)
 
         model_load_func = block_load_func if block_load_func else tf.keras.models.load_model
-        if not output_names:
+        if not output_names and isinstance(model, Model):
             try:
                 output_names = get_task_names_from_outputs(model.last)
             except ValueError:

--- a/merlin/models/tf/utils/batch_utils.py
+++ b/merlin/models/tf/utils/batch_utils.py
@@ -7,7 +7,7 @@ import tensorflow as tf
 from merlin.core.dispatch import DataFrameType, concat_columns, get_lib
 from merlin.models.tf.core.base import Block
 from merlin.models.tf.loader import Loader
-from merlin.models.tf.models.base import Model, RetrievalModel
+from merlin.models.tf.models.base import Model, RetrievalModel, get_task_names_from_outputs
 from merlin.models.utils.schema_utils import select_targets
 from merlin.schema import Schema, Tags
 
@@ -82,8 +82,8 @@ class TFModelEncode(ModelEncode):
         model_load_func = block_load_func if block_load_func else tf.keras.models.load_model
         if not output_names:
             try:
-                output_names = model.last.task_names
-            except AttributeError:
+                output_names = get_task_names_from_outputs(model.last)
+            except ValueError:
                 pass
         if not output_concat_func:
             if output_names and len(output_names) == 1:  # type: ignore

--- a/tests/unit/tf/utils/test_batch.py
+++ b/tests/unit/tf/utils/test_batch.py
@@ -6,12 +6,16 @@ from merlin.io import Dataset
 from merlin.models.tf.models.base import get_task_names_from_outputs
 
 
-@pytest.mark.parametrize("output_type", ["prediction_tasks_v1", "model_outputs_v2"])
+@pytest.mark.parametrize(
+    "output_type", ["prediction_tasks_v1", "model_outputs_v2-single", "model_outputs_v2-multiple"]
+)
 @pytest.mark.parametrize("run_eagerly", [True, False])
 def test_model_encode(ecommerce_data: Dataset, output_type: str, run_eagerly):
     if output_type == "prediction_tasks_v1":
         output_block = ml.PredictionTasks(ecommerce_data.schema)
-    elif output_type == "model_outputs_v2":
+    elif output_type == "model_outputs_v2-single":
+        output_block = ml.BinaryOutput("click")
+    elif output_type == "model_outputs_v2-multiple":
         output_block = ml.OutputBlock(ecommerce_data.schema)
     output_task_names = get_task_names_from_outputs(output_block)
 
@@ -26,7 +30,7 @@ def test_model_encode(ecommerce_data: Dataset, output_type: str, run_eagerly):
     data = model.batch_predict(ecommerce_data, batch_size=10)
     ddf = data.compute(scheduler="synchronous")
 
-    assert len(list(ddf.columns)) == 27
+    assert len(list(ddf.columns)) == 26 if output_type == "model_outputs_v2-single" else 27
     assert all([task in list(ddf.columns) for task in output_task_names])
 
 

--- a/tests/unit/tf/utils/test_batch.py
+++ b/tests/unit/tf/utils/test_batch.py
@@ -3,14 +3,22 @@ import pytest
 
 import merlin.models.tf as ml
 from merlin.io import Dataset
+from merlin.models.tf.models.base import get_task_names_from_outputs
 
 
+@pytest.mark.parametrize("output_type", ["prediction_tasks_v1", "model_outputs_v2"])
 @pytest.mark.parametrize("run_eagerly", [True, False])
-def test_model_encode(ecommerce_data: Dataset, run_eagerly):
+def test_model_encode(ecommerce_data: Dataset, output_type: str, run_eagerly):
+    if output_type == "prediction_tasks_v1":
+        output_block = ml.PredictionTasks(ecommerce_data.schema)
+    elif output_type == "model_outputs_v2":
+        output_block = ml.OutputBlock(ecommerce_data.schema)
+    output_task_names = get_task_names_from_outputs(output_block)
+
     model = ml.Model(
         ml.InputBlock(ecommerce_data.schema),
         ml.MLPBlock([2]),
-        ml.PredictionTasks(ecommerce_data.schema),
+        output_block,
     )
 
     model.compile(run_eagerly=run_eagerly, optimizer="adam")
@@ -19,7 +27,7 @@ def test_model_encode(ecommerce_data: Dataset, run_eagerly):
     ddf = data.compute(scheduler="synchronous")
 
     assert len(list(ddf.columns)) == 27
-    assert all([task in list(ddf.columns) for task in model.last.task_names])
+    assert all([task in list(ddf.columns) for task in output_task_names])
 
 
 def test_two_tower_embedding_extraction(ecommerce_data: Dataset):


### PR DESCRIPTION
### Goals :soccer:
- Fixes `model.batch_predict()` which was not working with `ModelOuput` (e.g. `BinaryOutput`, `RegressionOutput`) or with `ParallelBlock` of `ModelOuput`.

### Implementation Details :construction:
- The `model.batch_predict()` was only supporting the old output API for Models, based on `PredictionTask`.

### Testing Details :mag:
- Added to `test_model_encode` cases to test `ModelOutput` and `OutputBlock` with `model.batch_predict()`
