### PR TITLE
Fix import gpu without support

### DIFF
--- a/merlin/datasets/synthetic.py
+++ b/merlin/datasets/synthetic.py
@@ -24,7 +24,6 @@ from typing import Dict, Sequence, Tuple, Union
 import numpy as np
 
 import merlin.io
-from merlin.core.compat import cudf
 from merlin.models.utils import schema_utils
 from merlin.schema import Schema, Tags
 from merlin.schema.io.tensorflow_metadata import TensorflowMetadata

--- a/merlin/datasets/synthetic.py
+++ b/merlin/datasets/synthetic.py
@@ -24,6 +24,7 @@ from typing import Dict, Sequence, Tuple, Union
 import numpy as np
 
 import merlin.io
+from merlin.core.compat import cudf
 from merlin.models.utils import schema_utils
 from merlin.schema import Schema, Tags
 from merlin.schema.io.tensorflow_metadata import TensorflowMetadata

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -22,8 +22,8 @@ from keras.utils.tf_inspect import getfullargspec
 from packaging import version
 from tensorflow.python import to_dlpack
 
-from merlin.core.dispatch import DataFrameType
 from merlin.core.compat import cudf, cupy
+from merlin.core.dispatch import DataFrameType
 from merlin.io import Dataset
 from merlin.models.tf.core.base import Block, ModelContext
 from merlin.models.tf.typing import TabularData

--- a/merlin/models/tf/utils/tf_utils.py
+++ b/merlin/models/tf/utils/tf_utils.py
@@ -23,6 +23,7 @@ from packaging import version
 from tensorflow.python import to_dlpack
 
 from merlin.core.dispatch import DataFrameType
+from merlin.core.compat import cudf, cupy
 from merlin.io import Dataset
 from merlin.models.tf.core.base import Block, ModelContext
 from merlin.models.tf.typing import TabularData
@@ -298,13 +299,7 @@ def df_to_tensor(gdf, dtype=None):
 
 def tensor_to_df(tensor, index=None, gpu=None):
     if gpu is None:
-        try:
-            import cudf  # noqa: F401
-            import cupy
-
-            gpu = True
-        except ImportError:
-            gpu = False
+        gpu = cudf
 
     if gpu:
         # Note: It is not possible to convert Tensorflow tensors to the cudf dataframe

--- a/merlin/models/utils/nvt_utils.py
+++ b/merlin/models/utils/nvt_utils.py
@@ -1,5 +1,6 @@
 import logging
 
+from merlin.core.compat import cudf
 
 def require_nvt():
     try:
@@ -36,9 +37,7 @@ def require_nvt():
 
 
 def _check_nvt_gpu():
-    try:
-        import cudf  # noqa
-    except ImportError:
+    if not cudf:
         logging.warning(
             "A GPU was detected but rapids is not installed.",
             "NVTabular will not be able to use GPU.",

--- a/merlin/models/utils/nvt_utils.py
+++ b/merlin/models/utils/nvt_utils.py
@@ -2,6 +2,7 @@ import logging
 
 from merlin.core.compat import cudf
 
+
 def require_nvt():
     try:
         import nvtabular as nvt  # noqa

--- a/tests/unit/datasets/test_synthetic.py
+++ b/tests/unit/datasets/test_synthetic.py
@@ -20,6 +20,7 @@ from merlin.datasets.synthetic import generate_data, generate_user_item_interact
 from merlin.io import Dataset
 from merlin.models.utils.schema_utils import filter_dict_by_schema
 from merlin.schema import ColumnSchema, Schema, Tags
+from merlin.core.compat import cudf
 
 
 def test_synthetic_sequence_testing_data():
@@ -136,9 +137,8 @@ def test_generate_item_interactions_cpu(testing_data: Dataset):
         val == expected_dtypes[key] for key, val in dict(data.dtypes).items() if key != "categories"
     )
 
-
+@pytest.mark.skipif(not cudf, reason="cudf could not be imported")
 def test_generate_item_interactions_gpu(testing_data: Dataset):
-    cudf = pytest.importorskip("cudf")
     data = generate_user_item_interactions(testing_data.schema, num_interactions=500, device="cuda")
 
     assert isinstance(data, cudf.DataFrame)

--- a/tests/unit/datasets/test_synthetic.py
+++ b/tests/unit/datasets/test_synthetic.py
@@ -16,11 +16,11 @@
 import numpy as np
 import pytest
 
+from merlin.core.compat import cudf
 from merlin.datasets.synthetic import generate_data, generate_user_item_interactions
 from merlin.io import Dataset
 from merlin.models.utils.schema_utils import filter_dict_by_schema
 from merlin.schema import ColumnSchema, Schema, Tags
-from merlin.core.compat import cudf
 
 
 def test_synthetic_sequence_testing_data():
@@ -136,6 +136,7 @@ def test_generate_item_interactions_cpu(testing_data: Dataset):
     assert all(
         val == expected_dtypes[key] for key, val in dict(data.dtypes).items() if key != "categories"
     )
+
 
 @pytest.mark.skipif(not cudf, reason="cudf could not be imported")
 def test_generate_item_interactions_gpu(testing_data: Dataset):

--- a/tests/unit/tf/blocks/retrieval/test_matrix_factorization.py
+++ b/tests/unit/tf/blocks/retrieval/test_matrix_factorization.py
@@ -20,6 +20,7 @@ import tensorflow as tf
 import merlin.models.tf as ml
 from merlin.io import Dataset
 from merlin.schema import Tags
+from merlin.core.compat import cudf
 
 
 def test_matrix_factorization_block(music_streaming_data: Dataset):
@@ -71,14 +72,11 @@ def test_matrix_factorization_embedding_export(music_streaming_data: Dataset, tm
     assert os.path.exists(item_embedding_parquet)
 
     # Test GPU export if available
-    try:
-        import cudf  # noqa: F401
-
+    if cudf:
         user_embedding_parquet = str(tmp_path / "users.parquet")
         mf.export_embedding_table(Tags.USER_ID, user_embedding_parquet, gpu=True)
         assert os.path.exists(user_embedding_parquet)
         df = mf.embedding_table_df(Tags.USER_ID, gpu=True)
         assert isinstance(df, cudf.DataFrame)
         assert len(df) == 10001
-    except ImportError:
-        pass
+

--- a/tests/unit/tf/blocks/retrieval/test_matrix_factorization.py
+++ b/tests/unit/tf/blocks/retrieval/test_matrix_factorization.py
@@ -18,9 +18,9 @@ import os
 import tensorflow as tf
 
 import merlin.models.tf as ml
+from merlin.core.compat import cudf
 from merlin.io import Dataset
 from merlin.schema import Tags
-from merlin.core.compat import cudf
 
 
 def test_matrix_factorization_block(music_streaming_data: Dataset):
@@ -79,4 +79,3 @@ def test_matrix_factorization_embedding_export(music_streaming_data: Dataset, tm
         df = mf.embedding_table_df(Tags.USER_ID, gpu=True)
         assert isinstance(df, cudf.DataFrame)
         assert len(df) == 10001
-

--- a/tests/unit/tf/blocks/retrieval/test_two_tower.py
+++ b/tests/unit/tf/blocks/retrieval/test_two_tower.py
@@ -20,6 +20,7 @@ import pytest
 import tensorflow as tf
 
 import merlin.models.tf as ml
+from merlin.core.compat import cudf
 from merlin.datasets.synthetic import generate_data
 from merlin.io import Dataset
 from merlin.models.tf.core.aggregation import ElementWiseMultiply
@@ -59,17 +60,13 @@ def test_matrix_factorization_embedding_export(music_streaming_data: Dataset, tm
     assert os.path.exists(item_embedding_parquet)
 
     # Test GPU export if available
-    try:
-        import cudf  # noqa: F401
-
+    if cudf:
         user_embedding_parquet = str(tmp_path / "users.parquet")
         mf.export_embedding_table(Tags.USER_ID, user_embedding_parquet, gpu=True)
         assert os.path.exists(user_embedding_parquet)
         df = mf.embedding_table_df(Tags.USER_ID, gpu=True)
         assert isinstance(df, cudf.DataFrame)
         assert len(df) == 10001
-    except ImportError:
-        pass
 
 
 def test_elementwisemultiply():

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -725,7 +725,6 @@ def test_embedding_features_exporting_and_loading_pretrained_initializer(testing
 
     # Test GPU export if available
     if cudf:
-
         items_embeddings_dataset = emb_module.embedding_table_dataset(Tags.ITEM_ID, gpu=True)
         assert np.allclose(
             item_id_embeddings.numpy(),

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -21,6 +21,7 @@ import tensorflow as tf
 from tensorflow.keras.initializers import RandomUniform
 
 import merlin.models.tf as mm
+from merlin.core.compat import cudf
 from merlin.io import Dataset
 from merlin.models.tf.utils import testing_utils
 from merlin.models.tf.utils.testing_utils import assert_output_shape, model_test
@@ -723,8 +724,7 @@ def test_embedding_features_exporting_and_loading_pretrained_initializer(testing
     assert np.allclose(item_id_embeddings.numpy(), emb_init(item_id_embeddings.shape).numpy())
 
     # Test GPU export if available
-    try:
-        import cudf  # noqa: F401
+    if cudf:
 
         items_embeddings_dataset = emb_module.embedding_table_dataset(Tags.ITEM_ID, gpu=True)
         assert np.allclose(
@@ -734,9 +734,6 @@ def test_embedding_features_exporting_and_loading_pretrained_initializer(testing
 
         emb_init = mm.TensorInitializer.from_dataset(items_embeddings_dataset)
         assert np.allclose(item_id_embeddings.numpy(), emb_init(item_id_embeddings.shape).numpy())
-
-    except ImportError:
-        pass
 
 
 def test_shared_embeddings(music_streaming_data: Dataset):

--- a/tests/unit/xgb/test_xgboost.py
+++ b/tests/unit/xgb/test_xgboost.py
@@ -22,11 +22,13 @@ import pytest
 import sklearn.datasets
 import xgboost
 
-from merlin.core.dispatch import HAS_GPU
+from merlin.core.compat import HAS_GPU
 from merlin.datasets.synthetic import generate_data
 from merlin.io import Dataset
 from merlin.models.xgb import XGBoost, dataset_to_xy
 
+if not HAS_GPU:
+    pytest.skip(reason="No GPU available", allow_module_level=True)
 
 def test_without_dask_client(music_streaming_data: Dataset):
     with pytest.raises(ValueError) as exc_info:

--- a/tests/unit/xgb/test_xgboost.py
+++ b/tests/unit/xgb/test_xgboost.py
@@ -30,6 +30,7 @@ from merlin.models.xgb import XGBoost, dataset_to_xy
 if not HAS_GPU:
     pytest.skip(reason="No GPU available", allow_module_level=True)
 
+
 def test_without_dask_client(music_streaming_data: Dataset):
     with pytest.raises(ValueError) as exc_info:
         model = XGBoost(music_streaming_data.schema, objective="reg:logistic")

--- a/tests/unit/xgb/test_xgboost.py
+++ b/tests/unit/xgb/test_xgboost.py
@@ -35,7 +35,6 @@ def test_without_dask_client(music_streaming_data: Dataset):
     assert "No global client found" in str(exc_info.value)
 
 
-# @pytest.mark.skipif(not HAS_GPU, reason="No GPU available")
 @pytest.mark.usefixtures("dask_client")
 class TestXGBoost:
     def test_unsupported_objective(self, music_streaming_data: Dataset):

--- a/tests/unit/xgb/test_xgboost.py
+++ b/tests/unit/xgb/test_xgboost.py
@@ -27,9 +27,6 @@ from merlin.datasets.synthetic import generate_data
 from merlin.io import Dataset
 from merlin.models.xgb import XGBoost, dataset_to_xy
 
-if not HAS_GPU:
-    pytest.skip(reason="No GPU available", allow_module_level=True)
-
 
 def test_without_dask_client(music_streaming_data: Dataset):
     with pytest.raises(ValueError) as exc_info:
@@ -38,6 +35,7 @@ def test_without_dask_client(music_streaming_data: Dataset):
     assert "No global client found" in str(exc_info.value)
 
 
+# @pytest.mark.skipif(not HAS_GPU, reason="No GPU available")
 @pytest.mark.usefixtures("dask_client")
 class TestXGBoost:
     def test_unsupported_objective(self, music_streaming_data: Dataset):


### PR DESCRIPTION
This PR allows for usage in an environment setup for GPUs but that does not have GPUs. So it will rely on the CPU logic instead. Regardless of whether the GPU packages are installed and detected, if there are no GPUs available it will leverage CPU instead. Previously we would hit cuda init errors when this was attempted. This helps us run our GPU container without the --gpus flag. 
