### PR TITLE
Run normal gpu workflows on 1GPU and skip on PR closed

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -8,7 +8,7 @@ on:
       - v*
   pull_request:
     branches: [ main ]
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,19 +16,16 @@ concurrency:
 
 jobs:
   gpu-ci:
-    runs-on: 2GPU
+    runs-on: 1GPU
 
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - name: Get Branch name
+      id: get-branch-name
+      uses: NVIDIA-Merlin/.github/actions/branch-name@main
     - name: Run tests
       run: |
-        ref_type=${{ github.ref_type }}
-        branch=main
-        if [[ $ref_type == "tag"* ]]
-        then
-          git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release*:refs/remotes/origin/release*
-          branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
-        fi
+        branch="${{ steps.get-branch-name.outputs.branch }}"
         cd ${{ github.workspace }}; tox -e py38-gpu -- $branch

--- a/.github/workflows/multi-gpu-ci.yml
+++ b/.github/workflows/multi-gpu-ci.yml
@@ -8,7 +8,7 @@ on:
       - v*
   pull_request:
     branches: [ main ]
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,13 +22,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - name: Get Branch name
+      id: get-branch-name
+      uses: NVIDIA-Merlin/.github/actions/branch-name@main
     - name: Run tests
       run: |
-        ref_type=${{ github.ref_type }}
-        branch=main
-        if [[ $ref_type == "tag"* ]]
-        then
-          git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +refs/heads/release*:refs/remotes/origin/release*
-          branch=$(git branch -r --contains ${{ github.ref_name }} --list '*release*' --format "%(refname:short)" | sed -e 's/^origin\///')
-        fi
+        branch="${{ steps.get-branch-name.outputs.branch }}"
         cd ${{ github.workspace }}; tox -e py38-multi-gpu -- $branch


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
- When a PR is merged to main, the GPU tests are triggered twice in GIthub Actions because it is both a "PR closed" event and a push to main event. Triggering on PR closed is removed to not run the same tests twice on a merge to main.
- The boilerplate code for getting the branch name has been [moved to .github repo as a reusable action](https://github.com/NVIDIA-Merlin/.github/tree/main/actions/branch-name#example-usage) so the action is simplified in this PR.
- We don't have to run the normal GPU tests on the 2GPU runner. We have a separate workflow for multi-gpu tests that require the 2GPU runner.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
