### PR TITLE
Disable keras optimizer module change in SOK with `use_legacy_optimizer`

### DIFF
--- a/merlin/models/tf/distributed/backend.py
+++ b/merlin/models/tf/distributed/backend.py
@@ -30,4 +30,4 @@ if HAS_GPU:
 
 
 if sok_installed:
-    sok.init()
+    sok.init(use_legacy_optimizer=False)


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->


Fixes errors we were seeing from accesing `tf.keras.optimizers.legacy` due to the redefinition of the optimizers as a side-effect of the import of `sparse_operation_kit.experiment`

```
AttributeError: module 'keras.api._v2.keras.optimizers.legacy' has no attribute 'legacy'
```

## Implementation Details

A change to redefine the optimizers module in the `spare_operation_kit` was introduced in this change in HugeCTR last week https://github.com/NVIDIA-Merlin/HugeCTR/commit/2df20eb10c54f2f1c140371d4f3a792515bc5fa2

A follow-up change has been made in HugeCTR (release 23.04) which adds the optional parameter `use_legacy_optimizer` to the init function and moves the optimizers module mutation from global scope to within the body of this function: https://github.com/NVIDIA-Merlin/HugeCTR/commit/8ec7fa135bbb8074d6b9b84de64c2a8a45c9762c

We need to pass this parameter as `False` because the default is True which will activate the redefinition of the tf.keras.optimizers module. This optimizers module is required to be able to refer to optimizers as string values with a lookup by name with the `get` function.

## Before

```python
import tensorflow as tf
​
tf.keras.optimizers
# => <module 'keras.api._v2.keras.optimizers' from '/usr/local/lib/python3.8/dist-packages/keras/api/_v2/keras/optimizers/__init__.py'>
​
import sparse_operation_kit.experiment
​
tf.keras.optimizers
# => <module 'keras.api._v2.keras.optimizers.legacy' from '/usr/local/lib/python3.8/dist-packages/keras/api/_v2/keras/optimizers/legacy/__init__.py'>

tf.keras.optimizers.legacy
# => Raises AttributeError: module 'keras.api._v2.keras.optimizers.legacy' has no attribute 'legacy'
```

## After

```python
import tensorflow as tf
​
tf.keras.optimizers
# => <module 'keras.api._v2.keras.optimizers' from '/usr/local/lib/python3.8/dist-packages/keras/api/_v2/keras/optimizers/__init__.py'>
​
import sparse_operation_kit.experiment
​
tf.keras.optimizers
# => <module 'keras.api._v2.keras.optimizers' from '/usr/local/lib/python3.8/dist-packages/keras/api/_v2/keras/optimizers/__init__.py'>

tf.keras.optimizers.legacy
# => <module 'keras.api._v2.keras.optimizers.legacy' from '/usr/local/lib/python3.8/dist-packages/keras/api/_v2/keras/optimizers/legacy/__init__.py'>
```