### PR TITLE
fixes for legacy optimizers

### DIFF
--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -19,6 +19,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Sequence, Type, Union
 
+import keras
 import tensorflow as tf
 from tensorflow.keras import backend
 from tensorflow.python import to_dlpack
@@ -1189,7 +1190,7 @@ def serialize_table_config(table_config: TableConfig) -> Dict[str, Any]:
     if "initializer" in table:
         table["initializer"] = tf.keras.initializers.serialize(table["initializer"])
     if "optimizer" in table:
-        table["optimizer"] = tf.keras.optimizers.serialize(table["optimizer"])
+        table["optimizer"] = keras.api._v2.keras.optimizers.serialize(table["optimizer"])
 
     return table
 

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -24,6 +24,7 @@ from collections.abc import Sequence as SequenceCollection
 from functools import partial
 from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Sequence, Union, runtime_checkable
 
+import keras
 import six
 import tensorflow as tf
 from keras.engine.compile_utils import MetricsContainer
@@ -469,7 +470,7 @@ class BaseModel(tf.keras.Model):
         if version.parse(tf.__version__) < version.parse("2.11.0"):
             optimizer = tf.keras.optimizers.get(optimizer)
         else:
-            optimizer = tf.keras.optimizers.get(optimizer, use_legacy_optimizer=True)
+            optimizer = keras.optimizers.get(optimizer, use_legacy_optimizer=True)
 
         if hvd_installed and hvd.size() > 1:
             if optimizer.__module__.startswith("horovod"):

--- a/tests/unit/tf/blocks/test_optimizer.py
+++ b/tests/unit/tf/blocks/test_optimizer.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import keras
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -31,7 +32,7 @@ from merlin.schema import Schema, Tags
 if version.parse(tf.__version__) < version.parse("2.11.0"):
     keras_optimizers = tf.keras.optimizers
 else:
-    keras_optimizers = tf.keras.optimizers.legacy
+    keras_optimizers = keras.api._v2.keras.optimizers.legacy
 
 
 def generate_two_layers():
@@ -560,8 +561,8 @@ def test_lazy_adam_slots_unique_eager():
 
 def test_lazy_adam_serialization():
     optimizer = ml.LazyAdam()
-    config = tf.keras.optimizers.serialize(optimizer)
-    new_optimizer = tf.keras.optimizers.deserialize(config)
+    config = keras.api._v2.keras.optimizers.serialize(optimizer)
+    new_optimizer = keras.api._v2.keras.optimizers.deserialize(config)
     assert new_optimizer.get_config() == optimizer.get_config()
 
 


### PR DESCRIPTION
This PR fixes issues around test failures alluding to the following error:
```
           module 'keras.api._v2.keras.optimizers.legacy' has no attribute 'legacy'
           AttributeError: module 'keras.api._v2.keras.optimizers.legacy' has no attribute 'legacy'
```
We see these errors in the test_optimizers and test_embeddings files. We also see the error creep up in the Merlin integration test. 