### PR TITLE
Add dataloader pre-trained embeddings support to Merlin Models

### DIFF
--- a/merlin/datasets/entertainment/music_streaming/schema.json
+++ b/merlin/datasets/entertainment/music_streaming/schema.json
@@ -42,6 +42,16 @@
         "tag": [
           "categorical",
           "item"
+        ],
+        "extraMetadata": [
+          {
+            "_dims": [
+              [
+                0.0,
+                null
+              ]
+            ]
+          }
         ]
       }
     },

--- a/merlin/datasets/testing/schema.json
+++ b/merlin/datasets/testing/schema.json
@@ -6,7 +6,7 @@
       "intDomain": {
         "name": "user_id",
         "min": "1",
-        "max": "1797",
+        "max": "90",
         "isCategorical": true
       },
       "annotation": {
@@ -90,7 +90,6 @@
         "tag": [
           "continuous",
           "item"
-
         ]
       }
     },
@@ -100,7 +99,7 @@
       "intDomain": {
         "name": "item_id",
         "min": "1",
-        "max": "51996",
+        "max": "100",
         "isCategorical": true
       },
       "annotation": {
@@ -121,7 +120,7 @@
       "intDomain": {
         "name": "categories",
         "min": "1",
-        "max": "331",
+        "max": "70",
         "isCategorical": true
       },
       "annotation": {

--- a/merlin/datasets/testing/schema.json
+++ b/merlin/datasets/testing/schema.json
@@ -107,6 +107,16 @@
           "item_id",
           "categorical",
           "item"
+        ],
+        "extraMetadata": [
+          {
+            "_dims": [
+              [
+                0.0,
+                null
+              ]
+            ]
+          }
         ]
       }
     },

--- a/merlin/datasets/testing/sequence_testing/schema.json
+++ b/merlin/datasets/testing/sequence_testing/schema.json
@@ -14,6 +14,16 @@
           "categorical",
           "user_id",
           "user"
+        ],
+        "extraMetadata": [
+          {
+            "_dims": [
+              [
+                0.0,
+                null
+              ]
+            ]
+          }
         ]
       }
     },

--- a/merlin/datasets/testing/sequence_testing/schema.json
+++ b/merlin/datasets/testing/sequence_testing/schema.json
@@ -6,7 +6,7 @@
       "intDomain": {
         "name": "test_user_id",
         "min": "1",
-        "max": "1797",
+        "max": "90",
         "isCategorical": true
       },
       "annotation": {
@@ -122,7 +122,7 @@
       "intDomain": {
         "name": "item_id_seq",
         "min": "1",
-        "max": "51996",
+        "max": "100",
         "isCategorical": true
       },
       "annotation": {

--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -86,6 +86,7 @@ from merlin.models.tf.inputs.embedding import (
     Embeddings,
     EmbeddingTable,
     FeatureConfig,
+    PretrainedEmbeddings,
     SequenceEmbeddingFeatures,
     TableConfig,
 )
@@ -215,6 +216,7 @@ __all__ = [
     "EmbeddingTable",
     "AverageEmbeddingsByWeightFeature",
     "Embeddings",
+    "PretrainedEmbeddings",
     "FeatureConfig",
     "TableConfig",
     "ParallelPredictionBlock",

--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -58,6 +58,7 @@ from merlin.models.tf.core.aggregation import (
     ConcatFeatures,
     ElementwiseSum,
     ElementwiseSumItemMulti,
+    SequenceAggregator,
     StackFeatures,
 )
 from merlin.models.tf.core.base import (
@@ -238,6 +239,7 @@ __all__ = [
     "Filter",
     "ParallelBlock",
     "StackFeatures",
+    "SequenceAggregator",
     "DotProductInteraction",
     "FMPairwiseInteraction",
     "FMBlock",

--- a/merlin/models/tf/blocks/mlp.py
+++ b/merlin/models/tf/blocks/mlp.py
@@ -96,7 +96,12 @@ def MLPBlock(
 
     for idx, dim in enumerate(dimensions):
         dropout_layer = None
-        activation_idx = activation if isinstance(activation, str) else activation[idx]
+        activation = activation or "linear"
+        if isinstance(activation, str):
+            activation_idx = activation
+        else:
+            activation_idx = activation[idx]
+
         if no_activation_last_layer and idx == len(dimensions) - 1:
             activation_idx = "linear"
         else:

--- a/merlin/models/tf/inputs/embedding.py
+++ b/merlin/models/tf/inputs/embedding.py
@@ -664,7 +664,7 @@ def PretrainedEmbeddings(
     aggregation: Optional[TabularAggregationType], optional
         Transformation block to apply for aggregating the inputs, by default None
     block_name: str, optional
-        Name of the block, by default "embeddings"
+        Name of the block, by default "pretrained_embeddings"
     Returns
     -------
     ParallelBlock
@@ -1339,7 +1339,7 @@ def process_str_sequence_combiner(
         combiner = tf.keras.layers.Lambda(lambda x: tf.reduce_max(x, axis=1))
     else:
         raise ValueError(
-            "Only 'mean' and 'sum' str combiners is implemented for dense"
+            "Only 'mean', 'sum', and 'max' str combiners is implemented for dense"
             " list/multi-hot embedded features. You can also"
             " provide a tf.keras.layers.Layer instance as a sequence combiner."
         )

--- a/merlin/models/tf/loader.py
+++ b/merlin/models/tf/loader.py
@@ -266,6 +266,7 @@ class Loader(merlin.dataloader.tensorflow.Loader):
         sparse_max=None,
         sparse_as_dense=False,
         schema=None,
+        **loader_kwargs,
     ):
         dataset = _validate_dataset(
             paths_or_dataset, batch_size, buffer_size, engine, device, reader_kwargs
@@ -320,6 +321,7 @@ class Loader(merlin.dataloader.tensorflow.Loader):
             global_size=global_size,
             global_rank=global_rank,
             drop_last=drop_last,
+            **loader_kwargs,
         )
 
         # Override these parameters after initializing the parent dataloader
@@ -406,7 +408,7 @@ def sample_batch(
     inputs, targets = batch[0], batch[1]
 
     if prepare_features:
-        pf = PrepareFeatures(loader.schema)
+        pf = PrepareFeatures(loader.output_schema)
         if targets is not None:
             inputs, targets = pf(inputs, targets=targets)
         else:

--- a/merlin/models/tf/outputs/sampling/popularity.py
+++ b/merlin/models/tf/outputs/sampling/popularity.py
@@ -147,7 +147,7 @@ class PopularityBasedSamplerV2(CandidateSampler):
         tf.Tensor
             Probabilities of each item to be sampled
         """
-        log_indices = tf.math.log(tf.range(1.0, self.max_id - self.min_id + 2.0, 1.0))
+        log_indices = tf.math.log(tf.range(1.0, self.max_id - self.min_id + 3.0, 1.0))
         sampling_probs = (log_indices[1:] - log_indices[:-1]) / log_indices[-1]
 
         if self.unique:

--- a/merlin/models/tf/transforms/features.py
+++ b/merlin/models/tf/transforms/features.py
@@ -192,13 +192,14 @@ class PrepareListFeatures(TabularBlock):
                             val = list_col_to_ragged(
                                 inputs[f"{name}__values"], inputs[f"{name}__offsets"]
                             )
+
                             del inputs[f"{name}__values"]
                             del inputs[f"{name}__offsets"]
                         else:
                             raise ValueError(f"Feature '{name}' was not found in the inputs")
 
                     if len(val.shape) == 2 and Tags.EMBEDDING not in self.schema[name].tags:
-                        # Only expands 2D sequential features  if
+                        # Only expands 2D sequential features if
                         # they are not pre-trained embeeddings
                         val = tf.expand_dims(val, axis=-1)
 
@@ -243,7 +244,10 @@ class PrepareListFeatures(TabularBlock):
                                 )
                             seq_length = int(col_schema_shape.dims[1].max)
 
-                        output_shapes[name] = tf.TensorShape([batch_size, seq_length, 1])
+                        last_dim = 1
+                        if Tags.EMBEDDING in self.schema[name].tags:
+                            last_dim = col_schema_shape[-1].max
+                        output_shapes[name] = tf.TensorShape([batch_size, seq_length, last_dim])
 
                     else:
                         if (
@@ -358,6 +362,7 @@ class PrepareFeatures(TabularBlock):
             else:
                 out_targets = targets
             return (outputs, out_targets)
+
         return outputs
 
     def compute_output_shape(self, input_shapes):

--- a/merlin/models/tf/transforms/regularization.py
+++ b/merlin/models/tf/transforms/regularization.py
@@ -34,7 +34,7 @@ class L2Norm(TabularBlock):
         if isinstance(inputs, dict):
             inputs = {key: self._l2_norm(inp, axis=axis) for key, inp in inputs.items()}
         else:
-            inputs = self._l2_norm(inputs)
+            inputs = self._l2_norm(inputs, axis=axis)
 
         return inputs
 

--- a/merlin/models/tf/transforms/sequence.py
+++ b/merlin/models/tf/transforms/sequence.py
@@ -161,9 +161,9 @@ class SequenceTransform(TabularBlock):
         }
 
         seq_shapes = list(seq_inputs_shapes.values())
-        if not all(x == seq_shapes[0] for x in seq_shapes):
+        if not all(x[:2] == seq_shapes[0][:2] for x in seq_shapes):
             raise ValueError(
-                "The sequential inputs must have the same shape, but the shapes "
+                "The sequential inputs must have the first two dims equal, but they "
                 f"are different: {seq_inputs_shapes}"
             )
 

--- a/tests/unit/tf/blocks/test_mlp.py
+++ b/tests/unit/tf/blocks/test_mlp.py
@@ -107,7 +107,7 @@ def test_mlp_model_with_sequential_features_and_combiner(
     assert len(metrics) > 0
 
     predictions = model.predict(loader, steps=1)
-    assert predictions.shape == (8, 51997)
+    assert predictions.shape == (8, 101)
 
 
 @pytest.mark.parametrize("no_activation_last_layer", [False, True])

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -472,7 +472,7 @@ def test_embeddings_with_regularization(testing_data: Dataset):
         schema, dim=dim, embeddings_regularizer=tf.keras.regularizers.L2(0.2)
     )
 
-    inputs = mm.sample_batch(testing_data, batch_size=100, include_targets=False)
+    inputs = mm.sample_batch(testing_data, batch_size=20, include_targets=False)
     _ = embeddings_wo_reg(inputs)
     _ = embeddings_batch_reg(inputs)
     _ = embeddings_table_reg(inputs)

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -632,8 +632,8 @@ def test_embedding_features_yoochoose_custom_initializers(testing_data: Dataset)
 def test_embedding_features_yoochoose_pretrained_initializer(testing_data: Dataset):
     schema = testing_data.schema.select_by_tag(Tags.CATEGORICAL)
 
-    pretrained_emb_item_ids = np.random.random((51997, 64))
-    pretrained_emb_categories = np.random.random((332, 64))
+    pretrained_emb_item_ids = np.random.random((101, 64))
+    pretrained_emb_categories = np.random.random((71, 64))
 
     emb_module = mm.EmbeddingFeatures.from_schema(
         schema,

--- a/tests/unit/tf/inputs/test_embedding.py
+++ b/tests/unit/tf/inputs/test_embedding.py
@@ -497,7 +497,7 @@ def test_embedding_features_yoochoose_infer_embedding_sizes(testing_data: Datase
     assert (
         emb_module.embedding_tables["user_id"].embeddings.shape[1]
         == embeddings["user_id"].shape[1]
-        == 20
+        == 10
     )
     assert (
         emb_module.embedding_tables["user_country"].embeddings.shape[1]
@@ -507,12 +507,12 @@ def test_embedding_features_yoochoose_infer_embedding_sizes(testing_data: Datase
     assert (
         emb_module.embedding_tables["item_id"].embeddings.shape[1]
         == embeddings["item_id"].shape[1]
-        == 46
+        == 10
     )
     assert (
         emb_module.embedding_tables["categories"].embeddings.shape[1]
         == embeddings["categories"].shape[1]
-        == 13
+        == 9
     )
 
 
@@ -533,7 +533,7 @@ def test_embedding_features_yoochoose_infer_embedding_sizes_multiple_8(testing_d
     assert (
         emb_module.embedding_tables["user_id"].embeddings.shape[1]
         == embeddings["user_id"].shape[1]
-        == 24
+        == 16
     )
     assert (
         emb_module.embedding_tables["user_country"].embeddings.shape[1]
@@ -543,7 +543,7 @@ def test_embedding_features_yoochoose_infer_embedding_sizes_multiple_8(testing_d
     assert (
         emb_module.embedding_tables["item_id"].embeddings.shape[1]
         == embeddings["item_id"].shape[1]
-        == 48
+        == 16
     )
     assert (
         emb_module.embedding_tables["categories"].embeddings.shape[1]
@@ -579,12 +579,12 @@ def test_embedding_features_yoochoose_partially_infer_embedding_sizes(testing_da
     assert (
         emb_module.embedding_tables["item_id"].embeddings.shape[1]
         == embeddings["item_id"].shape[1]
-        == 46
+        == 10
     )
     assert (
         emb_module.embedding_tables["categories"].embeddings.shape[1]
         == embeddings["categories"].shape[1]
-        == 13
+        == 9
     )
 
 

--- a/tests/unit/tf/models/test_retrieval.py
+++ b/tests/unit/tf/models/test_retrieval.py
@@ -868,7 +868,7 @@ def test_youtube_dnn_retrieval_v2(sequence_testing_data: Dataset, run_eagerly, t
     target_augmentation = target_augmentation(schema=seq_schema, target=target)
 
     model = mm.YoutubeDNNRetrievalModelV2(
-        schema=sequence_testing_data.schema, top_block=mm.MLPBlock([32]), num_sampled=1000
+        schema=sequence_testing_data.schema, top_block=mm.MLPBlock([8]), num_sampled=10
     )
 
     dataloader = mm.Loader(sequence_testing_data, batch_size=50)
@@ -952,7 +952,7 @@ def test_youtube_dnn_v2_export_embeddings(sequence_testing_data: Dataset):
     predict_next = mm.SequencePredictLast(schema=seq_schema, target=target)
 
     model = mm.YoutubeDNNRetrievalModelV2(
-        schema=sequence_testing_data.schema, top_block=mm.MLPBlock([32]), num_sampled=1000
+        schema=sequence_testing_data.schema, top_block=mm.MLPBlock([8]), num_sampled=10
     )
 
     dataloader = mm.Loader(sequence_testing_data, batch_size=50)
@@ -961,7 +961,7 @@ def test_youtube_dnn_v2_export_embeddings(sequence_testing_data: Dataset):
     )
 
     candidates = model.candidate_embeddings().compute()
-    assert list(candidates.columns) == [str(i) for i in range(32)]
+    assert list(candidates.columns) == [str(i) for i in range(8)]
     assert len(candidates.index) == 101
 
     # Export the query embeddings is raising an error from dask, related to

--- a/tests/unit/tf/models/test_retrieval.py
+++ b/tests/unit/tf/models/test_retrieval.py
@@ -962,7 +962,7 @@ def test_youtube_dnn_v2_export_embeddings(sequence_testing_data: Dataset):
 
     candidates = model.candidate_embeddings().compute()
     assert list(candidates.columns) == [str(i) for i in range(32)]
-    assert len(candidates.index) == 51997
+    assert len(candidates.index) == 101
 
     # Export the query embeddings is raising an error from dask, related to
     # the support of multi-hot input features.
@@ -987,7 +987,7 @@ def test_youtube_dnn_topk_evaluation(sequence_testing_data: Dataset, run_eagerly
     predict_next = mm.SequencePredictLast(schema=seq_schema, target=target)
 
     model = mm.YoutubeDNNRetrievalModelV2(
-        schema=sequence_testing_data.schema, top_block=mm.MLPBlock([32]), num_sampled=1000
+        schema=sequence_testing_data.schema, top_block=mm.MLPBlock([8]), num_sampled=10
     )
 
     dataloader = mm.Loader(sequence_testing_data, batch_size=50)

--- a/tests/unit/tf/outputs/test_classification.py
+++ b/tests/unit/tf/outputs/test_classification.py
@@ -116,7 +116,7 @@ def test_last_item_prediction(sequence_testing_data: Dataset, run_eagerly):
     for target in predictions:
         model = mm.Model(
             mm.InputBlockV2(schema, categorical=embeddings),
-            mm.MLPBlock([32]),
+            mm.MLPBlock([8]),
             mm.CategoricalOutput(target),
         )
         testing_utils.model_test(model, dataloader, run_eagerly=run_eagerly)

--- a/tests/unit/tf/outputs/test_contrastive.py
+++ b/tests/unit/tf/outputs/test_contrastive.py
@@ -144,14 +144,14 @@ def test_setting_negative_sampling_strategy(sequence_testing_data: Dataset):
     assert output[1].shape == (batch[1].shape[0], 51)
 
     model_out.set_negative_samplers(
-        [PopularityBasedSamplerV2(max_id=51996, max_num_samples=20)],
+        [PopularityBasedSamplerV2(max_id=100, max_num_samples=20)],
     )
 
     output = model(batch[0], batch[1], training=True)
     assert output.outputs.shape == (batch[1].shape[0], 21)
 
     model_out.set_negative_samplers(
-        ["in-batch", PopularityBasedSamplerV2(max_id=51996, max_num_samples=20)],
+        ["in-batch", PopularityBasedSamplerV2(max_id=100, max_num_samples=20)],
     )
     output = model(batch[0], batch[1], training=True)
     assert output.outputs.shape == (batch[1].shape[0], 71)

--- a/tests/unit/tf/transformers/test_block.py
+++ b/tests/unit/tf/transformers/test_block.py
@@ -169,6 +169,7 @@ def test_transformer_as_classification_model(sequence_testing_data: Dataset, run
             schema,
             categorical=mm.Embeddings(schema, sequence_combiner=None),
         ),
+        mm.MLPBlock([EMBED_DIM]),
         BertBlock(
             d_model=EMBED_DIM,
             n_head=8,
@@ -536,7 +537,7 @@ def test_transformer_encoder_with_contrastive_output(sequence_testing_data: Data
         to_call=target_schema,
         negative_samplers=mm.PopularityBasedSamplerV2(
             max_num_samples=10,
-            max_id=1000,
+            max_id=100,
             min_id=1,
         ),
         logq_sampling_correction=True,

--- a/tests/unit/tf/transforms/test_features.py
+++ b/tests/unit/tf/transforms/test_features.py
@@ -881,7 +881,7 @@ def test_broadcast_to_sequence_input_block(sequence_testing_data: Dataset):
     assert set([tuple(list(v.shape)[:-1]) for v in input_batch.values()]) == set(
         [tuple([100, None])]
     )
-    assert list(input_batch["item_id_seq"].shape) == [100, None, 32]
+    assert list(input_batch["item_id_seq"].shape) == [100, None, 8]
     assert list(input_batch["categories"].shape) == [100, None, 16]
     assert list(input_batch["item_age_days_norm"].shape) == [100, None, 1]
     assert list(input_batch["user_age"].shape) == [100, None, 1]

--- a/tests/unit/tf/transforms/test_features.py
+++ b/tests/unit/tf/transforms/test_features.py
@@ -1221,6 +1221,10 @@ def get_loader_with_contextual_seq_pretrained_embeddings():
         ]
     )
 
+    from merlin.models.utils.schema_utils import schema_to_tensorflow_metadata_json
+
+    schema_to_tensorflow_metadata_json(schema, "sequential_with_pretrained_embeddings.json")
+
     input_df = pd.DataFrame(
         [
             {

--- a/tests/unit/tf/transforms/test_features.py
+++ b/tests/unit/tf/transforms/test_features.py
@@ -1413,6 +1413,7 @@ def test_model_with_pretrained_embeddings(run_eagerly: bool):
 @testing_utils.mark_run_eagerly_modes
 def test_model_with_pretrained_embeddings_seq_aggregation(run_eagerly: bool):
     loader = get_loader_with_contextual_seq_pretrained_embeddings()
+
     schema = loader.output_schema
 
     input_block = mm.InputBlockV2(
@@ -1425,12 +1426,12 @@ def test_model_with_pretrained_embeddings_seq_aggregation(run_eagerly: bool):
             schema.select_by_tag(Tags.EMBEDDING),
             sequence_combiner="mean",
             normalizer="l2-norm",
+            output_dims={"pretrained_item_id_embeddings": 6},
         ),
     )
 
     model = mm.Model(
         input_block,
-        mm.MLPBlock([4]),
         mm.BinaryOutput("purchase"),
     )
 


### PR DESCRIPTION
Fixes #1070, Fixes #1071, Fixes #1068, Fixes #1072, Fixes #1073

### Goals :soccer:
- Add support to pre-trained embeddings provided by the `EmbeddingOperator` transform from Merlin dataloader:  https://github.com/NVIDIA-Merlin/Merlin/issues/211

### Tasks
- [x] #1071
- [x] #1068
- [x] #1073
- [x] #1070
- [x] #1072

### Implementation Details :construction:
- Creates the `PretrainedEmbeddings` block that takes pre-trained embedding features and optionally projects them to a dim with a linear layer, applies a sequence aggregator and normalizes (e.g. with l2-norm). All of these options are configurable
- The `InputBlockV2` was changed to accept an optional `pretrained_embeddings` argument, which by default selects features tagged with the EMBEDDING tag,
- `PrepareListFeatures` was changed to define the shape of the last dim the pre-trained embeddings provided by the Loader, as that dim is None in graph mode.

### Testing Details :mag:
- Created many tests demonstrating how pre-trained embeddings can be used with models like DLRM, DCN, sequential Transformer models with BroadcastFeatures and with causal and masked language modeling SequenceMasking classes
- I took this opportunity also to try and **speed up many tests** by reducing drastically the cardinality of categorical features in some dataset schemas used for synthetic data generation. Many tests had to be updated to match the new cardinalities.
