### PR TITLE
Update minimum version of TensorFlow from 2.8  to 2.9

### DIFF
--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         python-version: [3.8]
         os: [ubuntu-latest]
-        tensorflow-version: ["~=2.8.0", "~=2.9.0", "~=2.10.0", "~=2.11.0"]
+        tensorflow-version: ["~=2.9.0", "~=2.10.0", "~=2.11.0"]
 
     steps:
       - uses: actions/checkout@v3
@@ -76,7 +76,7 @@ jobs:
       matrix:
         python-version: [ 3.8 ]
         os: [ ubuntu-latest ]
-        tensorflow-version: ["~=2.8.0", "~=2.9.0", "~=2.10.0", "~=2.11.0"]
+        tensorflow-version: ["~=2.9.0", "~=2.10.0", "~=2.11.0"]
 
     steps:
       - uses: actions/checkout@v3

--- a/merlin/models/tf/core/encoder.py
+++ b/merlin/models/tf/core/encoder.py
@@ -19,7 +19,6 @@ from typing import Dict, Optional, Union
 
 import numpy as np
 import tensorflow as tf
-from packaging import version
 
 import merlin.io
 from merlin.models.io import save_merlin_metadata
@@ -213,16 +212,6 @@ class Encoder(tf.keras.Model):
             "This block is not meant to be trained by itself. ",
             "It can only be trained as part of a model.",
         )
-
-    def _set_save_spec(self, inputs, args=None, kwargs=None):
-        super()._set_save_spec(inputs, args, kwargs)
-
-        # We need to overwrite this in order to fix a Keras-bug in TF<2.9
-        if version.parse(tf.__version__) < version.parse("2.9.0"):
-            # Keras will interpret kwargs like `features` & `targets` as
-            # required args, which is wrong. This is a workaround.
-            _arg_spec = self._saved_model_arg_spec
-            self._saved_model_arg_spec = ([_arg_spec[0][0]], _arg_spec[1])
 
     def save(
         self,

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -282,16 +282,6 @@ class ModelBlock(Block, tf.keras.Model):
     def get_config(self):
         return {"block": tf.keras.utils.serialize_keras_object(self.block)}
 
-    def _set_save_spec(self, inputs, args=None, kwargs=None):
-        # We need to overwrite this in order to fix a Keras-bug in TF<2.9
-        super()._set_save_spec(inputs, args, kwargs)
-
-        if version.parse(tf.__version__) < version.parse("2.9.0"):
-            # Keras will interpret kwargs like `features` & `targets` as
-            # required args, which is wrong. This is a workaround.
-            _arg_spec = self._saved_model_arg_spec
-            self._saved_model_arg_spec = ([_arg_spec[0][0]], _arg_spec[1])
-
 
 class BaseModel(tf.keras.Model):
     def __init__(self, **kwargs):
@@ -1944,16 +1934,6 @@ class Model(BaseModel):
         config["batch_size"] = self._batch_size
 
         return config
-
-    def _set_save_spec(self, inputs, args=None, kwargs=None):
-        # We need to overwrite this in order to fix a Keras-bug in TF<2.9
-        super()._set_save_spec(inputs, args, kwargs)
-
-        if version.parse(tf.__version__) < version.parse("2.9.0"):
-            # Keras will interpret kwargs like `features` & `targets` as
-            # required args, which is wrong. This is a workaround.
-            _arg_spec = self._saved_model_arg_spec
-            self._saved_model_arg_spec = ([_arg_spec[0][0]], _arg_spec[1])
 
     @property
     def frozen_blocks(self):

--- a/merlin/models/tf/utils/testing_utils.py
+++ b/merlin/models/tf/utils/testing_utils.py
@@ -169,8 +169,11 @@ def numeric_test(actual, expected):
 
 
 # This function is copied from keras/testing_infra/test_utils.py
-# We need it here because this was not publicly exposed prior to 2.9.0
-# and our CI tests multiple versions of tensorflow/keras
+# We need it here because the EmbeddingTable signature requires us to pass some args
+# as positional instead of keyword arguments
+# If we change the signature of EmbeddingTable,
+# or if keras adds support for passing args as well as kwargs
+# we may be able to remove this in future and replace with the keras version
 @disable_cudnn_autotune
 def layer_test(
     layer_cls,

--- a/tests/unit/tf/examples/test_usecase_incremental_training_layer_freezing.py
+++ b/tests/unit/tf/examples/test_usecase_incremental_training_layer_freezing.py
@@ -1,7 +1,5 @@
 # Test is currently breaks in TF 2.10
 import pytest
-import tensorflow as tf
-from packaging import version
 from testbook import testbook
 
 from tests.conftest import REPO_ROOT
@@ -15,10 +13,6 @@ p = "examples/usecases/incremental-training-with-layer-freezing.ipynb"
     execute=False,
 )
 @pytest.mark.notebook
-@pytest.mark.skipif(
-    version.parse(tf.__version__) < version.parse("2.9.0"),
-    reason="tf.keras.optimizers.legacy is not available in TF <= 2.8",
-)
 def test_usecase_incremental_training_layer_freezing(tb):
     tb.inject(
         """


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)
 
Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR. 

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

- Updates minimum version of TensorFlow from 2.8  to 2.9

Removes some patching of `_set_save_spec` that was added for support for earlier TensorFlow versions.

_Motivation_. Newer versions of numpy have dropped support for the [deprecated builtin type aliaes](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) (e.g. `np.object`). 
This causes an expression like `tf.ragged.constant([[1, 2], [3]])` to raise `AttributeError: module 'numpy' has no attribute 'object'.`
