### PR TITLE
Creates LogLossMetric and generalizes WandbLogger and ExamplesPerSecondCallback

### DIFF
--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -91,6 +91,7 @@ from merlin.models.tf.inputs.embedding import (
 )
 from merlin.models.tf.loader import KerasSequenceValidator, Loader, sample_batch
 from merlin.models.tf.losses import LossType
+from merlin.models.tf.metrics.evaluation import LogLossMetric
 from merlin.models.tf.metrics.topk import (
     AvgPrecisionAt,
     MRRAt,
@@ -301,4 +302,5 @@ __all__ = [
     "SequenceMaskRandom",
     "ReplaceMaskedEmbeddings",
     "Prediction",
+    "LogLossMetric",
 ]

--- a/merlin/models/tf/logging/callbacks.py
+++ b/merlin/models/tf/logging/callbacks.py
@@ -1,0 +1,215 @@
+import logging
+import time
+from typing import Any, Dict
+
+from tensorflow.keras.callbacks import Callback
+
+
+class WandbLogger:
+    def __init__(
+        self,
+        wandb_project: str = None,
+        wandb_entity: str = None,
+        config: Dict[str, Any] = {},
+        logging_path: str = None,
+        auto_init: bool = False,
+    ):
+        """Class to manage logging to Weights&Biases (W&B)
+        service, available at https://wandb.ai
+
+        Parameters
+        ----------
+        wandb_project : str, optional
+            Name of the W&B project to
+            log the runs. If not provided it is logged
+            to the user default W&B project", by default None
+        wandb_entity : str, optional
+            Name of the W&B entity (team name) to
+            log the runs. If not provided it is logged
+            to the user default W&B team", by default None
+        config : Dict[str, Any], optional
+            Dictionary with the run configuration / hyperparameters.
+            By default {}.
+        logging_path : str, optional
+            Path where the wandb will log information
+            locally. By default None, which logs to a local
+            ".wandb" folder
+        auto_init : bool, optional
+            If True, init() method will be called automatically
+            when the class is instantiated to configure wandb.
+            By default False
+        """
+        self.wandb_project = wandb_project
+        self.wandb_entity = wandb_entity
+        self._config = config
+        self.logging_path = logging_path
+        self._initialized = False
+
+        import wandb
+
+        self._wandb_lib = wandb
+
+        if auto_init:
+            self.init()
+
+    def init(self):
+        """Initializes W&B setting the project, team,
+        logging dir and hyperparamteres
+        """
+        self._wandb_lib.init(
+            project=self.wandb_project,
+            entity=self.wandb_entity,
+            config=self._config,
+            dir=self.logging_path,
+        )
+
+    def _check_wandb_init(self):
+        if self._wandb_lib.run is None:
+            raise ValueError(
+                "You need first to initialize W&B with "
+                "WandbLogger.init() or wandb.init() directly"
+            )
+
+    def config(self, config: Dict[str, Any] = {}):
+        """Updates wandb run configuration
+        (hyperparameters)
+
+        Parameters
+        ----------
+        config : Dict[str, Any], optional
+            Configuration dict, by default {}
+        """
+        self._check_wandb_init()
+        self._wandb_lib.config.update(config)
+
+    def log(self, metrics: Dict[str, Any]):
+        """Logs the metric values to wandb
+
+        Parameters
+        ----------
+        metrics : Dict[str, Any]
+            Metrics keys and values
+        """
+        self._check_wandb_init()
+        self._wandb_lib.log(metrics)
+
+    def get_callback(self, metrics_log_frequency: int = 10, **callback_kwargs):
+        """Returns a wandb.keras.WandbCallback() instance.
+        for usage with model.fit() and model.evaluate().
+
+        Parameters
+        ----------
+        metrics_log_frequency : int, optional
+            Number of steps on which the metrics are logged, by default 10.
+            Logging metrics every step might reduce training and evaluation
+            throughput.
+        """
+        callback = self._wandb_lib.keras.WandbCallback(
+            log_batch_frequency=metrics_log_frequency, **callback_kwargs
+        )
+        return callback
+
+    def teardown(self, exit_code: int = 0):
+        """Finish wandb logging gracefully
+
+        Parameters
+        ----------
+        exit_code : int, optional
+            Exit code for this run, by default 0
+        """
+        if self._wandb_lib.run is not None:
+            self._wandb_lib.finish(exit_code=exit_code)
+
+
+class ExamplesPerSecondCallback(Callback):
+    """ExamplesPerSecond callback.
+    This callback records the average_examples_per_sec and
+    current_examples_per_sec metrics during training.
+    """
+
+    def __init__(
+        self, batch_size: int, every_n_steps: int = 1, logger=None, log_to_console: bool = False
+    ):
+        """Logs the average_examples_per_sec and
+        current_examples_per_sec metrics during training.
+
+        Parameters
+        ----------
+        batch_size : int
+            Informs the batch size, as it is used for
+            computing the throughput statistics
+        every_n_steps : int, optional
+            Computes the metrics every N steps, by default 1
+        logger : bool, optional
+            Logs the average_examples_per_sec and
+            current_examples_per_sec metrics to a logger.
+            Typically it is the WandbLogger
+        log_to_console : bool, optional
+            Log with logging.debug(), so that the statistics
+            can be logged to console or file with logging library
+        """
+        self._batch_size = batch_size
+        self._every_n_steps = every_n_steps
+        self._logger = logger
+        self._log_to_console = log_to_console
+        super(ExamplesPerSecondCallback, self).__init__()
+
+    def on_train_begin(self, logs=None):
+        self._first_batch = True
+        self._epoch_steps = 0
+        self._train_batches_average_examples_per_sec = []
+
+    def on_train_end(self, logs=None):
+        average_examples_per_sec = self.get_avg_examples_per_sec()
+        self._train_batches_average_examples_per_sec.append(average_examples_per_sec)
+
+    def get_train_batches_mean_of_avg_examples_per_sec(self):
+        if len(self._train_batches_average_examples_per_sec) > 0:
+            return sum(self._train_batches_average_examples_per_sec) / float(
+                len(self._train_batches_average_examples_per_sec)
+            )
+        else:
+            return 0.0
+
+    def get_avg_examples_per_sec(self):
+        current_time = time.time()
+        average_examples_per_sec = self._batch_size * (
+            self._epoch_steps / (current_time - self._epoch_start_time)
+        )
+        return average_examples_per_sec
+
+    def on_train_batch_end(self, batch, logs=None):
+        # Discards the first batch, as it is used to compile the
+        # graph and affects the average
+        if self._first_batch:
+            self._epoch_steps = 0
+            self._first_batch = False
+            self._epoch_start_time = time.time()
+            self._last_recorded_time = time.time()
+            return
+
+        """Log the examples_per_sec metric every_n_steps."""
+        self._epoch_steps += 1
+        current_time = time.time()
+
+        if self._epoch_steps % self._every_n_steps == 0:
+            average_examples_per_sec = self.get_avg_examples_per_sec()
+            current_examples_per_sec = self._batch_size * (
+                self._every_n_steps / (current_time - self._last_recorded_time)
+            )
+
+            if self._log_to_console:
+                logging.debug(
+                    f"[Examples/sec - Epoch step: {self._epoch_steps}] "
+                    f"current: {current_examples_per_sec:.2f}, avg: {average_examples_per_sec:.2f}"
+                )
+
+            if self._logger:
+                self._logger.log(
+                    {
+                        "current_examples_per_sec": current_examples_per_sec,
+                        "average_examples_per_sec": average_examples_per_sec,
+                    }
+                )
+
+            self._last_recorded_time = current_time  # Update last_recorded_time

--- a/tests/common/tf/retrieval/retrieval_config.py
+++ b/tests/common/tf/retrieval/retrieval_config.py
@@ -16,10 +16,10 @@
 import fiddle as fdl
 
 from merlin.io import Dataset
+from merlin.models.tf.logging.callbacks import WandbLogger
 from tests.common.tf.retrieval.retrieval_utils import (
     RetrievalTrainEvalRunner,
     RetrievalTrainEvalRunnerV2,
-    WandbLogger,
     filter_schema,
     get_callbacks,
     get_dual_encoder_model,
@@ -59,7 +59,11 @@ def config_retrieval_train_eval_runner(
     wandb_project: str,
     retrieval_api_version: int,
 ):
-    wandb_logger_cfg = fdl.Config(WandbLogger, enabled=log_to_wandb, wandb_project=wandb_project)
+    wandb_logger_cfg = None
+    if log_to_wandb:
+        wandb_logger_cfg = fdl.Config(
+            WandbLogger, wandb_project=wandb_project, auto_init=log_to_wandb
+        )
 
     schema_cfg = fdl.Config(filter_schema, schema=train_ds.schema)
     optimizer = fdl.Config(get_optimizer)

--- a/tests/unit/tf/metrics/test_metrics.py
+++ b/tests/unit/tf/metrics/test_metrics.py
@@ -16,8 +16,30 @@
 
 import pytest
 import tensorflow as tf
+from tensorflow.keras.losses import binary_crossentropy
 
-from merlin.models.tf.metrics.evaluation import ItemCoverageAt, NoveltyAt, PopularityBiasAt
+from merlin.models.tf.metrics import metrics_registry
+from merlin.models.tf.metrics.evaluation import (
+    ItemCoverageAt,
+    LogLossMetric,
+    NoveltyAt,
+    PopularityBiasAt,
+)
+
+
+@pytest.mark.parametrize("metric", [LogLossMetric(), "logloss"])
+def test_logloss_metric(metric):
+    metric = metrics_registry.parse(metric)
+
+    y_pred = tf.convert_to_tensor([1.0, 0.5, 0.2, 2.3, 5.0], tf.float32)
+    y_true = tf.convert_to_tensor([0, 1, 0, 0, 1], tf.int32)
+
+    expected_result = binary_crossentropy(y_true, y_pred, from_logits=False)
+
+    metric.update_state(y_true, y_pred)
+    result = metric.result()
+
+    tf.debugging.assert_near(result, expected_result)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Goals :soccer:
This PR moves some utility classes from the [Quick-start for Ranking scripts](https://github.com/NVIDIA-Merlin/Merlin/tree/main/examples/quick_start) to Merlin Models, as they are generic and are useful in general for building training scripts with the library: `LogLossMetric`, `WandbLogger`, `ExamplesPerSecondCallback`

### Implementation Details :construction:
- `LogLossMetric`: Log loss (binary cross entropy( is a common loss and metric for binary classification. This class is useful when your are using class weights for binary classification, as in that case the loss for training will be influenced by the class weights. Having this metric allows you to have the unweighted log loss metric.
- `WandbLogger` - This class manages the logging to Weights&Biases, providing methods to initialize wandb, configure the run, log metrics and to return the `tf.keras.WandbCallback()` that can be used with Keras fit() and evaluate().
- `ExamplesPerSecondCallback` - Logs the training or evaluation throughput, i.e. steps/sec (to wandb or to console)


### Testing Details :mag:
- Adds a test for `LogLossMetric`: `test_logloss_metric`
- Changed retrieval integration tests to use the generalized `WandbLogger` and `ExamplesPerSecondCallback`
