### PR TITLE
Add Transformers Torch Extras to install requirements

### DIFF
--- a/requirements/transformers.txt
+++ b/requirements/transformers.txt
@@ -1,1 +1,3 @@
-transformers>=4.23,<5
+transformers[torch]>=4.23,<5
+pyarrow>=1.0
+torchmetrics>=0.10.0


### PR DESCRIPTION
This PR updates the transformers dependencies to align with https://github.com/NVIDIA-Merlin/Transformers4Rec/pull/699.