### PR TITLE
Increase tolerance in transformer tests

### DIFF
--- a/merlin/models/tf/utils/testing_utils.py
+++ b/merlin/models/tf/utils/testing_utils.py
@@ -113,10 +113,10 @@ def model_test(
         if isinstance(model_preds, dict):
             for task_name in model_preds:
                 tf.debugging.assert_near(
-                    model_preds[task_name], loaded_model_preds[task_name], atol=1e-5
+                    model_preds[task_name], loaded_model_preds[task_name], atol=1e-4
                 )
         else:
-            tf.debugging.assert_near(model_preds, loaded_model_preds, atol=1e-5)
+            tf.debugging.assert_near(model_preds, loaded_model_preds, atol=1e-4)
 
         loaded_model.compile(run_eagerly=run_eagerly, optimizer=optimizer, **kwargs)
         loaded_model.fit(iter(batch))

--- a/tests/unit/tf/transformers/test_block.py
+++ b/tests/unit/tf/transformers/test_block.py
@@ -81,7 +81,7 @@ def test_retrieval_transformer(sequence_testing_data: Dataset, run_eagerly):
     assert list(item_embeddings.shape) == [101, d_model]
     predicitons_2 = np.dot(query_embeddings, item_embeddings.T)
 
-    np.testing.assert_allclose(predictions, predicitons_2, atol=1e-6)
+    np.testing.assert_allclose(predictions, predicitons_2, atol=1e-4)
 
 
 def test_transformer_encoder():


### PR DESCRIPTION
This PR increases the absolute tolerance to 1e-4  in hopes of reducing flakiness. The changes were based on the release-23.05 branch. 
