### PR TITLE
Use `tf.matmul` instead of `np.dot` in `test_retrieval_transformer` 

### DIFF
--- a/tests/unit/tf/transformers/test_block.py
+++ b/tests/unit/tf/transformers/test_block.py
@@ -79,9 +79,9 @@ def test_retrieval_transformer(sequence_testing_data: Dataset, run_eagerly):
     item_embeddings = model.candidate_embeddings().compute().to_numpy()
 
     assert list(item_embeddings.shape) == [101, d_model]
-    predicitons_2 = np.dot(query_embeddings, item_embeddings.T)
+    predictions_2 = tf.matmul(query_embeddings, tf.transpose(item_embeddings)).numpy()
 
-    np.testing.assert_allclose(predictions, predicitons_2, atol=1e-4)
+    np.testing.assert_allclose(predictions, predictions_2, atol=1e-4)
 
 
 def test_transformer_encoder():


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR.

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Fixes issue with `test_retrieval_transformer` failing in Blossom tests

### Implementation Details :construction:

<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

- The test `test_retrieval_transformer` is currently failing in Blossom with a tolerance error. This seems to be something to do with small differences in numerical results when running the computation on CPU vs GPU.

Using `tf.matmul` to run this operation on the same GPU device (when available) as the operation in the model runs.

### Testing Details :mag:

<!-- Describe what tests you've added for your changes. -->

Tested this by submitting a custom blossom job and running the test multiple times with pytest-repeat