### PR TITLE
fix gpu parallel nb example

### DIFF
--- a/examples/usecases/multi-gpu-data-parallel-training.ipynb
+++ b/examples/usecases/multi-gpu-data-parallel-training.ipynb
@@ -31,6 +31,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "15b423f1",
    "metadata": {
@@ -62,6 +63,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "cfb261fa",
    "metadata": {},
@@ -70,6 +72,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1c458709",
    "metadata": {},
@@ -101,6 +104,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "0f8f45d0",
    "metadata": {},
@@ -109,6 +113,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e5bb985f",
    "metadata": {},
@@ -193,6 +198,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3e7d97d2",
    "metadata": {},
@@ -201,6 +207,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "c344a8fc",
    "metadata": {},
@@ -228,6 +235,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7b12aa11",
    "metadata": {},
@@ -246,6 +254,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f86db86f",
    "metadata": {},
@@ -261,6 +270,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a656271a",
    "metadata": {},
@@ -320,8 +330,8 @@
     "args = parser.parse_args()\n",
     "\n",
     "# define train and valid dataset objects\n",
-    "train = Dataset(os.path.join(args.path, \"train\", \"part_\" + str(MPI_RANK) + \".parquet\"))\n",
-    "valid = Dataset(os.path.join(args.path, \"valid\", \"part_\" + str(MPI_RANK) + \".parquet\"))\n",
+    "train = Dataset(os.path.join(args.path, \"train\", \"*.parquet\"))\n",
+    "valid = Dataset(os.path.join(args.path, \"valid\", \"*.parquet\"))\n",
     "\n",
     "# define schema object\n",
     "target_column = train.schema.select_by_tag(Tags.TARGET).column_names[0]\n",
@@ -362,6 +372,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "11b7e63a",
    "metadata": {},
@@ -417,6 +428,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b5ed3903",
    "metadata": {},
@@ -425,6 +437,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3cea5782-c88f-4a34-990f-9074bb387d63",
    "metadata": {},
@@ -433,6 +446,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "de4d3d88-979e-4587-a74a-bcf61db36b84",
    "metadata": {},


### PR DESCRIPTION
This PR fixes an error in this notebook. When you are creating datasets for training/validation using the dataloader you do not break up the dataset per working yourself. All you need to do is pass the rank and size (ENV VARS that come from MPI ) to the dataloader it will take care of pulling out only the relevant partitions for that worker. Do not use logic to try and split the dataset via file enumeration parsing logic. Pass all files to the dataloader and pass the global_size and global_rank parameters and the dataloader will handle the rest. This resolves #1114