### PR TITLE
Install 'colorlog' in dev/test environment

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -19,3 +19,4 @@ wandb
 optuna
 plotly
 GitPython
+colorlog


### PR DESCRIPTION
The test for the notebook [Retrieval with hyperparameter optimization](https://github.com/NVIDIA-Merlin/models/blob/main/examples/usecases/retrieval-with-hyperparameter-optimization.ipynb) is being skipped in the CI because the library `colorlog` is not installed in the CI test environment:
```
SKIPPED [1] tests/unit/tf/examples/test_usecase_retrieval_with_hpo.py:6: could not import 'optuna': No module named 'colorlog'
```
This PR adds `colorlog` to dev/test requirements.