### PR TITLE
Install dependencies in transformers4rec test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -105,9 +105,9 @@ commands =
     git clone --depth 1 --branch {env:MERLIN_BRANCH:main} https://github.com/NVIDIA-Merlin/Transformers4Rec.git Transformers4Rec-{env:GIT_COMMIT}
     python -m pip install --upgrade -r "./Transformers4Rec-{env:GIT_COMMIT}/requirements/test.txt"
     python -m pip install --upgrade "./Transformers4Rec-{env:GIT_COMMIT}"
-    python -m pip install --no-deps git+https://github.com/NVIDIA-Merlin/core.git@{env:MERLIN_BRANCH:main}
-    python -m pip install --no-deps git+https://github.com/NVIDIA-Merlin/dataloader.git@{env:MERLIN_BRANCH:main}
-    python -m pip install --no-deps .
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{env:MERLIN_BRANCH:main}
+    python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git@{env:MERLIN_BRANCH:main}
+    python -m pip install .
     python -m pytest Transformers4Rec-{env:GIT_COMMIT}/tests/unit
 
 [testenv:docs]


### PR DESCRIPTION
This PR installs the dependencies necessary for `merlin.core`. `transformers4rec / tests (3.8, ubuntu-latest) (pull_request)` is fails with:
```
Transformers4Rec-60c3fd6d58d8aac5daea48974ba619c408af91fd/tests/conftest.py:23: in <module>
    from merlin.datasets.synthetic import generate_data
merlin/datasets/synthetic.py:26: in <module>
    import merlin.io
.tox/py38-transformers4rec-cpu/lib/python3.8/site-packages/merlin/io/__init__.py:18: in <module>
    from merlin.io import dataframe_iter, dataset, shuffle
.tox/py38-transformers4rec-cpu/lib/python3.8/site-packages/merlin/io/dataset.py:33: in <module>
    from npy_append_array import NpyAppendArray
E   ModuleNotFoundError: No module named 'npy_append_array'
```