### PR TITLE
Remove use of deprecated start_index from Categorify

### DIFF
--- a/examples/usecases/ecommerce-session-based-next-item-prediction-for-fashion.ipynb
+++ b/examples/usecases/ecommerce-session-based-next-item-prediction-for-fashion.ipynb
@@ -468,7 +468,7 @@
    "source": [
     "%%time\n",
     "item_features_names = ['f_' + str(col) for col in [47, 68]]\n",
-    "cat_features = [['item_id', 'purchase_id']] + item_features_names >> nvt.ops.Categorify(start_index=1)\n",
+    "cat_features = [['item_id', 'purchase_id']] + item_features_names >> nvt.ops.Categorify()\n",
     "\n",
     "features = ['session_id', 'timestamp'] + cat_features"
    ]

--- a/examples/usecases/transformers-next-item-prediction.ipynb
+++ b/examples/usecases/transformers-next-item-prediction.ipynb
@@ -352,7 +352,7 @@
     "\n",
     "categorical_features = (['city_id', 'booker_country', 'hotel_country'] +\n",
     "                         weekday_checkin + weekday_checkout\n",
-    "                       ) >> ops.Categorify(start_index=1)  \n",
+    "                       ) >> ops.Categorify()\n",
     "\n",
     "groupby_features = categorical_features + ['utrip_id', 'checkin'] >> ops.Groupby(\n",
     "    groupby_cols=['utrip_id'],\n",

--- a/merlin/datasets/ecommerce/booking/dataset.py
+++ b/merlin/datasets/ecommerce/booking/dataset.py
@@ -183,7 +183,7 @@ def default_booking_transformation(**kwargs):
     Returns:
         Workflow: NVTabular workflow
     """
-    cat = lambda: nvt.ops.Categorify(start_index=1)  # noqa: E731
+    cat = lambda: nvt.ops.Categorify()  # noqa: E731
 
     df_season = get_lib().DataFrame(
         {"month": range(1, 13), "season": ([0] * 3) + ([1] * 3) + ([2] * 3) + ([3] * 3)}


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR.

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->


### Goals :soccer:

Fix use of Categorify to support new version of NVTabular

### Implementation Details :construction:

<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

- `start_index` was removed from `Categorify` in https://github.com/NVIDIA-Merlin/NVTabular/pull/1692

