### PR TITLE
Move horovod and sok init functions to user code

### DIFF
--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -34,7 +34,7 @@ jobs:
           if [[ "${{ github.ref }}" != 'refs/heads/main' ]]; then
               extra_pytest_markers="and changed"
           fi
-          cd ${{ github.workspace }}; PYTEST_MARKERS="unit and not (example or integration) $extra_pytest_markers" MERLIN_BRANCH=$branch COMPARE_BRANCH=${{ github.base_ref }} tox -e py38-gpu
+          cd ${{ github.workspace }}; PYTEST_MARKERS="and unit and not (example or integration) $extra_pytest_markers" MERLIN_BRANCH=$branch COMPARE_BRANCH=${{ github.base_ref }} tox -e py38-gpu
 
   tests-example-integration:
     runs-on: 1GPU
@@ -55,4 +55,4 @@ jobs:
           if [[ "${{ github.ref }}" != 'refs/heads/main' ]]; then
               extra_pytest_markers="and changed"
           fi
-          cd ${{ github.workspace }}; PYTEST_MARKERS="(example or integration) $extra_pytest_markers" MERLIN_BRANCH=$branch COMPARE_BRANCH=${{ github.base_ref }} tox -e py38-gpu
+          cd ${{ github.workspace }}; PYTEST_MARKERS="and (example or integration) $extra_pytest_markers" MERLIN_BRANCH=$branch COMPARE_BRANCH=${{ github.base_ref }} tox -e py38-gpu

--- a/merlin/models/tf/distributed/backend.py
+++ b/merlin/models/tf/distributed/backend.py
@@ -17,9 +17,6 @@ except ImportError:
     pass
 
 
-if hvd_installed:
-    hvd.init()
-
 if HAS_GPU:
     try:
         from sparse_operation_kit import experiment as sok  # noqa: F401
@@ -27,7 +24,3 @@ if HAS_GPU:
         sok_installed = True
     except (ImportError, tf.errors.NotFoundError):
         pass
-
-
-if sok_installed:
-    sok.init(use_legacy_optimizer=False)

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,3 +15,5 @@ markers =
     horovod: mark as requiring horovod
     changed: mark as requiring changed files
     always: mark as always running
+    multigpu: Tests only run in multiple-GPU environments
+    singlegpu: Optional marker to run tests in single-GPU environments. Usually used when running in both single- and multi-GPU.

--- a/tests/unit/tf/horovod/test_embedding.py
+++ b/tests/unit/tf/horovod/test_embedding.py
@@ -9,6 +9,7 @@ from merlin.models.tf.distributed.embedding import SOKEmbedding
 from merlin.schema import ColumnSchema, Tags
 
 
+@pytest.mark.multigpu
 @pytest.mark.skipif(not HAS_GPU, reason="No GPU available")
 @pytest.mark.skipif(importlib.util.find_spec("sparse_operation_kit") is None, reason="needs sok")
 class TestSOKEmbedding:
@@ -20,6 +21,10 @@ class TestSOKEmbedding:
     )
 
     def test_sok_embedding_basic(self):
+        from sparse_operation_kit import experiment as sok
+
+        sok.init(use_legacy_optimizer=False)
+
         embedding = SOKEmbedding(16, self.sample_column_schema, vocab_sizes=[10])
         inputs = [tf.ragged.constant([[0, 1, 0], [1, 0]])]
         combiners = ["sum"]
@@ -27,6 +32,10 @@ class TestSOKEmbedding:
         assert outputs[0].shape == (2, 16)
 
     def test_sok_embedding_pretrained(self):
+        from sparse_operation_kit import experiment as sok
+
+        sok.init(use_legacy_optimizer=False)
+
         weights = {}
         indices = np.array([0, 1, 2])
         values = np.arange(3 * 16).reshape(3, 16)
@@ -41,6 +50,10 @@ class TestSOKEmbedding:
         assert outputs[0].shape == (2, 16)
 
     def test_sok_embedding_config(self):
+        from sparse_operation_kit import experiment as sok
+
+        sok.init(use_legacy_optimizer=False)
+
         embedding = SOKEmbedding(16, self.sample_column_schema, vocab_sizes=[10], name="item_id")
         config = embedding.get_config()
         _ = SOKEmbedding.from_config(config)

--- a/tests/unit/tf/horovod/test_horovod.py
+++ b/tests/unit/tf/horovod/test_horovod.py
@@ -123,6 +123,7 @@ def test_horovod_multigpu_dlrm(
         assert saved_model not in os.listdir(tmpdir)
 
 
+@pytest.mark.multigpu
 def test_horovod_multigpu_two_tower(
     music_streaming_data, tmpdir, batch_size=11, learning_rate=0.03
 ):

--- a/tests/unit/tf/horovod/test_horovod.py
+++ b/tests/unit/tf/horovod/test_horovod.py
@@ -8,7 +8,7 @@ from tensorflow.keras.utils import set_random_seed
 import merlin.models.tf as mm
 from merlin.datasets.advertising.criteo.dataset import default_criteo_transform
 from merlin.io.dataset import Dataset
-from merlin.models.tf.distributed.backend import hvd, hvd_installed
+from merlin.models.tf.distributed.backend import hvd_installed
 from merlin.models.utils.example_utils import workflow_fit_transform
 from merlin.schema.tags import Tags
 
@@ -17,6 +17,7 @@ from merlin.schema.tags import Tags
 set_random_seed(42)
 
 
+@pytest.mark.multigpu
 @pytest.mark.parametrize("custom_distributed_optimizer", [True, False])
 def test_horovod_multigpu_dlrm(
     criteo_data,
@@ -35,6 +36,10 @@ def test_horovod_multigpu_dlrm(
     Even with multiple GPUs, if you simply run pytest without horovodrun, it
     will use only one GPU.
     """
+    import horovod.tensorflow.keras as hvd
+
+    hvd.init()
+
     criteo_data.to_ddf().to_parquet(os.path.join(tmpdir, "train"))
     criteo_data.to_ddf().to_parquet(os.path.join(tmpdir, "valid"))
     workflow = default_criteo_transform()
@@ -131,6 +136,10 @@ def test_horovod_multigpu_two_tower(
     Even with multiple GPUs, if you simply run pytest without horovodrun, it
     will use only one GPU.
     """
+    import horovod.tensorflow.keras as hvd
+
+    hvd.init()
+
     # As a workaround for nvtabular producing different numbers of batches in
     # workers, we repartition the dataset in multiples of hvd.size().
     # https://github.com/NVIDIA-Merlin/models/issues/765

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git@{env:MERLIN_BRANCH:main}
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/nvtabular.git@{env:MERLIN_BRANCH:main}
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/systems.git@{env:MERLIN_BRANCH:main}
-    bash -c 'python -m pytest --cov-report term --cov merlin -m "{env:PYTEST_MARKERS}" -rxs tests || ([ $? = 5 ] && exit 0 || exit $?)'
+    bash -c 'python -m pytest --cov-report term --cov merlin -m "(singlegpu or not multigpu) {env:PYTEST_MARKERS}" -rxs tests || ([ $? = 5 ] && exit 0 || exit $?)'
 
 [testenv:py38-multi-gpu]
 ; Runs in: Github Actions


### PR DESCRIPTION
### Goals :soccer:

- Remove `hvd.init()` and `sok.init()` and have the users run them.
- Introduce `singlegpu` and `multigpu` markers.

### Implementation Details :construction:

In some cases when horovod is not built correctly or not configured correctly with MPI, `hvd.init()` or `sok.init()` will throw an MPI_LIB errors on the C-level, which we cannot catch from Python. This happened in https://github.com/NVIDIA-Merlin/models/pull/1134 for example.

Following @oliverholworthy's proposal, this PR leaves `hvd.init()` and/or `sok.init()` up to the user.

We still need to initialize them to run unit tests but incorrect installation in the ci-runner will still block the CI, so this PR also introduces `singlegpu` and `multigpu` pytest markers to skip the horovod tests in the single-gpu case, similarly to https://github.com/NVIDIA-Merlin/Merlin/pull/999.