### PR TITLE
Pass mpi environment variable to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ allowlist_externals =
     bash
 deps =
     --no-deps -rrequirements/test.txt
+passenv =
+    OPAL_PREFIX
 setenv =
     TF_GPU_ALLOCATOR=cuda_malloc_async
 sitepackages=true
@@ -24,7 +26,7 @@ commands =
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git@{env:MERLIN_BRANCH:main}
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/nvtabular.git@{env:MERLIN_BRANCH:main}
     python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/systems.git@{env:MERLIN_BRANCH:main}
-    bash -c 'python -m pytest --cov-report term --cov merlin -m "{env:PYTEST_MARKERS}" -rxs tests || ([ $? = 5 ] && exit 0 || exit $?)'
+    bash -c 'python -m pytest --cov-report term --cov merlin -m "{env:PYTEST_MARKERS}" -rxs tests/ || ([ $? = 5 ] && exit 0 || exit $?)'
 
 [testenv:py38-multi-gpu]
 ; Runs in: Github Actions


### PR DESCRIPTION
This PR passes the necessary environment from the ci-runner to tox. The `OPAL_PREFIX` is available if Open MPI is available and horovod is installed with MPI enabled, but tox blocks all environments by default and running tests in tox will produce import errors like the one in https://github.com/NVIDIA-Merlin/models/pull/1134 for example.