### PR TITLE
Skip dependencies in SOK installation

### DIFF
--- a/examples/usecases/multi-gpu/install_sparse_operation_kit.sh
+++ b/examples/usecases/multi-gpu/install_sparse_operation_kit.sh
@@ -11,6 +11,6 @@ rm -rf hugectr/
 git clone https://github.com/NVIDIA-Merlin/HugeCTR.git hugectr
 
 cd hugectr/sparse_operation_kit/
-python setup.py install
+python setup.py develop --no-deps
 
 rm -rf ${HUGECTR_HOME}

--- a/merlin/models/tf/distributed/__init__.py
+++ b/merlin/models/tf/distributed/__init__.py
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#


### PR DESCRIPTION
`gpu-multi / tensorflow (pull_request) ` in the CI fails with:
```
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.8/dist-packages/horovod/openmpi_dist/bin/mpirun'
```
in https://github.com/NVIDIA-Merlin/models/pull/1110 for example, because [SOK requires horovod and reinstalls it](https://github.com/NVIDIA-Merlin/HugeCTR/blob/3b9b3cfafe4faed959e3d592825e9c1d0c7556a5/sparse_operation_kit/setup.py#L23), overwriting the [horovod installation in the ci-runner](https://github.com/NVIDIA-Merlin/Merlin/blob/5a73d74cda7d085f31088cd54a1e1933771d673a/ci/dockerfile.ci#L24). This PR fixes that by adding `--no-deps` so that SOK does not install dependencies. We run `setup.py` in development mode because `python install setup.py` does not support `--no-deps`.