### PR TITLE
Set upper bound on `transformers` dependency to `<4.30`

### DIFF
--- a/requirements/transformers.txt
+++ b/requirements/transformers.txt
@@ -1,1 +1,5 @@
-transformers>=4.23,<5
+# Version 4.30 of `transformers` started using functionality in TensorFlow 2.11
+# Until either that is changed in transformers or, we drop support
+# for TensorFlow versions prior to 2.11, then we need to keep this
+# upper bound on the version specifier
+transformers>=4.23,<4.30


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR.

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Fixes Error we're seeing in our tests with TensorFlow versions prior to 2.11

```
/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/transformers/modeling_tf_utils.py:84: in <module>
    from tensorflow.python.keras.engine import call_context
E   ImportError: cannot import name 'call_context' from 'tensorflow.python.keras.engine' (/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/tensorflow/python/keras/engine/__init__.py)
```

The newest version of the transformers package 4.30.0 started importing a module that only exists in TensorFlow 2.11 and above.

Setting this upper bound for now until we drop support for TensorFlow 2.10 and earlier, or this is updated in `transformers` to restore support for earlier versions of TensorFlow ([related issue here](https://github.com/huggingface/transformers/issues/24133))