### PR TITLE
Run tests marked with `notebook` marker in examples workflow

### DIFF
--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -34,7 +34,7 @@ jobs:
           if [[ "${{ github.ref }}" != 'refs/heads/main' ]]; then
               extra_pytest_markers="and changed"
           fi
-          cd ${{ github.workspace }}; PYTEST_MARKERS="unit and not (example or integration or notebook) $extra_pytest_markers" MERLIN_BRANCH=$branch COMPARE_BRANCH=${{ github.base_ref }} tox -e py38-gpu
+          cd ${{ github.workspace }}; PYTEST_MARKERS="unit and not (examples or integration or notebook) $extra_pytest_markers" MERLIN_BRANCH=$branch COMPARE_BRANCH=${{ github.base_ref }} tox -e py38-gpu
 
   tests-examples:
     runs-on: 1GPU
@@ -55,4 +55,4 @@ jobs:
           if [[ "${{ github.ref }}" != 'refs/heads/main' ]]; then
               extra_pytest_markers="and changed"
           fi
-          cd ${{ github.workspace }}; PYTEST_MARKERS="(example or notebook) $extra_pytest_markers" MERLIN_BRANCH=$branch COMPARE_BRANCH=${{ github.base_ref }} tox -e py38-gpu
+          cd ${{ github.workspace }}; PYTEST_MARKERS="(examples or notebook) $extra_pytest_markers" MERLIN_BRANCH=$branch COMPARE_BRANCH=${{ github.base_ref }} tox -e py38-gpu

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -34,7 +34,7 @@ jobs:
           if [[ "${{ github.ref }}" != 'refs/heads/main' ]]; then
               extra_pytest_markers="and changed"
           fi
-          cd ${{ github.workspace }}; PYTEST_MARKERS="unit and not (example or integration) $extra_pytest_markers" MERLIN_BRANCH=$branch COMPARE_BRANCH=${{ github.base_ref }} tox -e py38-gpu
+          cd ${{ github.workspace }}; PYTEST_MARKERS="unit and not (example or integration or notebook) $extra_pytest_markers" MERLIN_BRANCH=$branch COMPARE_BRANCH=${{ github.base_ref }} tox -e py38-gpu
 
   tests-examples:
     runs-on: 1GPU
@@ -55,4 +55,4 @@ jobs:
           if [[ "${{ github.ref }}" != 'refs/heads/main' ]]; then
               extra_pytest_markers="and changed"
           fi
-          cd ${{ github.workspace }}; PYTEST_MARKERS="example $extra_pytest_markers" MERLIN_BRANCH=$branch COMPARE_BRANCH=${{ github.base_ref }} tox -e py38-gpu
+          cd ${{ github.workspace }}; PYTEST_MARKERS="(example or notebook) $extra_pytest_markers" MERLIN_BRANCH=$branch COMPARE_BRANCH=${{ github.base_ref }} tox -e py38-gpu

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,12 @@ tests-changed:
 	coverage html --include 'merlin/models/*'
 
 tests-tf:
-	coverage run -m pytest --durations=100 --dist=loadfile --numprocesses=auto -rsx tests -m "tensorflow and not (integration or example)" || exit 1
+	coverage run -m pytest --durations=100 --dist=loadfile --numprocesses=auto -rsx tests -m "tensorflow and not (integration or example or notebook)" || exit 1
 	coverage report --include 'merlin/models/*'
 	coverage html --include 'merlin/models/*'
 
 tests-tf-examples:
-	coverage run -m pytest -rsx tests -m "tensorflow and example" || exit 1
+	coverage run -m pytest -rsx tests -m "tensorflow and (example or notebook)" || exit 1
 	coverage report --include 'merlin/models/*'
 	coverage html --include 'merlin/models/*'
 

--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,12 @@ tests-tf-integration:
 	coverage html --include 'merlin/models/*'
 
 tests-tf-changed:
-	coverage run -m pytest --durations=100 --dist=loadfile --numprocesses=auto -rsx tests -m "tensorflow and changed and not (integration or example) or always" || exit 1
+	coverage run -m pytest --durations=100 --dist=loadfile --numprocesses=auto -rsx tests -m "tensorflow and changed and not (integration or example or notebook) or always" || exit 1
 	coverage report --include 'merlin/models/*'
 	coverage html --include 'merlin/models/*'
 
 tests-tf-examples-changed:
-	coverage run -m pytest -rsx tests -m "tensorflow and changed and example" || exit 1
+	coverage run -m pytest -rsx tests -m "tensorflow and changed and (example or notebook)" || exit 1
 	coverage report --include 'merlin/models/*'
 	coverage html --include 'merlin/models/*'
 

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,12 @@ tests-changed:
 	coverage html --include 'merlin/models/*'
 
 tests-tf:
-	coverage run -m pytest --durations=100 --dist=loadfile --numprocesses=auto -rsx tests -m "tensorflow and not (integration or example or notebook)" || exit 1
+	coverage run -m pytest --durations=100 --dist=loadfile --numprocesses=auto -rsx tests -m "tensorflow and not (integration or examples or notebook)" || exit 1
 	coverage report --include 'merlin/models/*'
 	coverage html --include 'merlin/models/*'
 
 tests-tf-examples:
-	coverage run -m pytest -rsx tests -m "tensorflow and (example or notebook)" || exit 1
+	coverage run -m pytest -rsx tests -m "tensorflow and (examples or notebook)" || exit 1
 	coverage report --include 'merlin/models/*'
 	coverage html --include 'merlin/models/*'
 
@@ -37,12 +37,12 @@ tests-tf-integration:
 	coverage html --include 'merlin/models/*'
 
 tests-tf-changed:
-	coverage run -m pytest --durations=100 --dist=loadfile --numprocesses=auto -rsx tests -m "tensorflow and changed and not (integration or example or notebook) or always" || exit 1
+	coverage run -m pytest --durations=100 --dist=loadfile --numprocesses=auto -rsx tests -m "tensorflow and changed and not (integration or examples or notebook) or always" || exit 1
 	coverage report --include 'merlin/models/*'
 	coverage html --include 'merlin/models/*'
 
 tests-tf-examples-changed:
-	coverage run -m pytest -rsx tests -m "tensorflow and changed and (example or notebook)" || exit 1
+	coverage run -m pytest -rsx tests -m "tensorflow and changed and (examples or notebook)" || exit 1
 	coverage report --include 'merlin/models/*'
 	coverage html --include 'merlin/models/*'
 

--- a/examples/01-Getting-started.ipynb
+++ b/examples/01-Getting-started.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Copyright 2022 NVIDIA Corporation. All Rights Reserved.\n",
+    "# Copyright 2023 NVIDIA Corporation. All Rights Reserved.\n",
     "#\n",
     "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
     "# you may not use this file except in compliance with the License.\n",

--- a/merlin/models/utils/ci_utils.py
+++ b/merlin/models/utils/ci_utils.py
@@ -25,7 +25,7 @@ BACKEND_ALIASES = {
     "lightfm": "lightfm",
     "xgb": "xgboost",
 }
-OTHER_MARKERS = {"unit", "integration", "example", "datasets", "horovod", "transformers"}
+OTHER_MARKERS = {"unit", "integration", "examples", "datasets", "horovod", "transformers"}
 SHARED_MODULES = {
     "/datasets/",
     "/models/config/",

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 markers =
     version: mark as testing the version number
     notebook: mark as testing notebooks
-    example: mark as testing examples
+    examples: mark as testing examples
     datasets: mark as testing datasets
     integration: mark as an integration test
     unit: mark as a unit test


### PR DESCRIPTION
### Goals :soccer:

- Replace `example` pytest markers with `examples` (with an s).
- Run tests marked with `pytest.mark.notebook` in `examples` workflow.

### Implementation Details :construction:

- `ci_utils` was searching for tests with `/example/` (without an s) in their paths but none was being marked with the marker because tests were in `/examples/` (with an s). https://github.com/NVIDIA-Merlin/models/blob/92833fa0cfca002a7cf4e009b7c09bae53a336f2/tests/conftest.py#L101-L103 https://github.com/NVIDIA-Merlin/models/blob/92833fa0cfca002a7cf4e009b7c09bae53a336f2/merlin/models/utils/ci_utils.py#L28 This PR replaces all `example` markers with `examples` so the right paths can be extracted.
- Since all notebook tests belong to examples, this PR includes `notebook` tests in the `examples` workflows so that even if the pytest marks from path extraction in the above fails notebook tests run in examples workflows.
