### PR TITLE
Fix reloading of the transformer-based models

### DIFF
--- a/merlin/models/tf/__init__.py
+++ b/merlin/models/tf/__init__.py
@@ -133,6 +133,7 @@ from merlin.models.tf.prediction_tasks.retrieval import ItemRetrievalTask
 from merlin.models.utils.dependencies import is_transformers_available
 
 if is_transformers_available():
+    import transformers
     from merlin.models.tf.transformers.block import (
         AlbertBlock,
         BertBlock,


### PR DESCRIPTION
Fixes #1132 

### Goals :soccer:

- Import transformers assets when the Hugging Face library is installed. 

### Implementation Details :construction:

- Add `import transformers` in the __init__ file of Merlin Models

### Testing Details :mag:
- The issue is happening when we try to reload a model in a different python process to the one that saved the model. 
