### PR TITLE
Run all tests when CI utils cannot detect changes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@
 from __future__ import absolute_import
 
 import platform
+import warnings
 from pathlib import Path
 
 import distributed
@@ -88,7 +89,14 @@ except ModuleNotFoundError:
 
 
 def pytest_collection_modifyitems(items):
-    changed_backends = ci_utils.get_changed_backends()
+    try:
+        changed_backends = ci_utils.get_changed_backends()
+    except Exception as e:
+        warnings.warn(
+            f"Running all tests because CI utils failed to detect backend changes: {e}", UserWarning
+        )
+        changed_backends = ci_utils.BACKEND_ALIASES.values()
+
     full_name_to_alias = {v: k for k, v in ci_utils.BACKEND_ALIASES.items()}
 
     for item in items:


### PR DESCRIPTION
The detection of backend changes fails in some edge cases, e.g., when it runs from a release branch, or when it runs from a mounted directory inside a container. This PR proposes to run **all** tests by default if the detection fails in CI utils.