### PR TITLE
Add importorskip for pytorch_lightning to torch tests

### DIFF
--- a/tests/unit/torch/__init__.py
+++ b/tests/unit/torch/__init__.py
@@ -16,3 +16,4 @@
 import pytest
 
 pytest.importorskip("torch")
+pytest.importorskip("pytorch_lightning")


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR.

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Fixes Error in gpu-multi ([example ](https://github.com/NVIDIA-Merlin/systems/actions/runs/5284978752/jobs/9562999400?pr=345) where pytest fails to collect tests if pytorch_lighting is not available.

Add importorskip for pytorch_lightning to torch tests module enabling tests to collect in an environment with torch installed but not pytorch_lighting.