### PR TITLE
Change default loss in BinaryOutput to BCELoss

### DIFF
--- a/merlin/models/torch/outputs/classification.py
+++ b/merlin/models/torch/outputs/classification.py
@@ -36,7 +36,7 @@ class BinaryOutput(ModelOutput):
         The metrics used for evaluation. Default includes Accuracy, AUROC, Precision, and Recall.
     """
 
-    DEFAULT_LOSS_CLS = nn.BCEWithLogitsLoss
+    DEFAULT_LOSS_CLS = nn.BCELoss
     DEFAULT_METRICS_CLS = (Accuracy, AUROC, Precision, Recall)
 
     def __init__(

--- a/merlin/models/torch/outputs/tabular.py
+++ b/merlin/models/torch/outputs/tabular.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+from collections import namedtuple
 from typing import Any, Callable, Optional, Union
 
 from merlin.models.torch.outputs.classification import BinaryOutput
@@ -65,6 +66,7 @@ class TabularOutputBlock(RouterBlock):
                     raise ValueError(f"Initializer {init} not found.")
 
             init(self)
+            self.named_tuple = namedtuple("Outputs", self.output_names)
 
     @classmethod
     def register_init(cls, name: str):

--- a/merlin/models/torch/outputs/tabular.py
+++ b/merlin/models/torch/outputs/tabular.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-from collections import namedtuple
 from typing import Any, Callable, Optional, Union
 
 from merlin.models.torch.outputs.classification import BinaryOutput
@@ -66,7 +65,6 @@ class TabularOutputBlock(RouterBlock):
                     raise ValueError(f"Initializer {init} not found.")
 
             init(self)
-            self.named_tuple = namedtuple("Outputs", self.output_names)
 
     @classmethod
     def register_init(cls, name: str):

--- a/tests/unit/torch/models/test_base.py
+++ b/tests/unit/torch/models/test_base.py
@@ -260,11 +260,12 @@ class TestComputeLoss:
         assert sorted(results.keys()) == ["loss"]
 
     def test_dict_inputs(self):
-        predictions = {"a": torch.randn(2, 1)}
+        outputs = mm.ParallelBlock({"a": mm.BinaryOutput(ColumnSchema("a"))})
+        predictions = outputs(torch.randn(2, 1))
         targets = {"a": torch.randint(2, (2, 1), dtype=torch.float32)}
-        model_outputs = (mm.BinaryOutput(ColumnSchema("a")),)
-        results = compute_loss(predictions, targets, model_outputs)
-        expected_loss = nn.BCEWithLogitsLoss()(predictions["a"], targets["a"])
+
+        results = compute_loss(predictions, targets, outputs.find(mm.ModelOutput))
+        expected_loss = nn.BCELoss()(predictions["a"], targets["a"])
         assert torch.allclose(results["loss"], expected_loss)
 
     def test_mixed_inputs(self):
@@ -272,7 +273,7 @@ class TestComputeLoss:
         targets = torch.randint(2, (2, 1), dtype=torch.float32)
         model_outputs = (mm.BinaryOutput(ColumnSchema("a")),)
         results = compute_loss(predictions, targets, model_outputs)
-        expected_loss = nn.BCEWithLogitsLoss()(predictions["a"], targets)
+        expected_loss = nn.BCELoss()(predictions["a"], targets)
         assert torch.allclose(results["loss"], expected_loss)
 
     def test_single_model_output(self):
@@ -280,7 +281,7 @@ class TestComputeLoss:
         targets = {"foo": torch.randint(2, (2, 1), dtype=torch.float32)}
         model_outputs = [mm.BinaryOutput(ColumnSchema("foo"))]
         results = compute_loss(predictions, targets, model_outputs)
-        expected_loss = nn.BCEWithLogitsLoss()(predictions["foo"], targets["foo"])
+        expected_loss = nn.BCELoss()(predictions["foo"], targets["foo"])
         assert torch.allclose(results["loss"], expected_loss)
 
     def test_tensor_input_no_targets(self):

--- a/tests/unit/torch/outputs/test_classification.py
+++ b/tests/unit/torch/outputs/test_classification.py
@@ -30,7 +30,7 @@ class TestBinaryOutput:
         binary_output = mm.BinaryOutput()
 
         assert isinstance(binary_output, mm.BinaryOutput)
-        assert isinstance(binary_output.loss, nn.BCEWithLogitsLoss)
+        assert isinstance(binary_output.loss, nn.BCELoss)
         assert binary_output.metrics == [
             Accuracy(task="binary"),
             AUROC(task="binary"),


### PR DESCRIPTION
### Goals :soccer:
This PR changes the default loss in `BinaryOutput` to `BCELoss`. Currently it's `BCEWithLogitsLoss` which means we apply sigmoid twice.