### PR TITLE
Adding evaluate- and test-step + introduce custom Trainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dmypy.json
 
 # Experiment files
 _test.py
+
+# Lightning
+**/lightning_logs/

--- a/merlin/models/torch/__init__.py
+++ b/merlin/models/torch/__init__.py
@@ -22,7 +22,7 @@ from merlin.models.torch.blocks.mlp import MLPBlock
 from merlin.models.torch.inputs.embedding import EmbeddingTable, EmbeddingTables
 from merlin.models.torch.inputs.select import SelectFeatures, SelectKeys
 from merlin.models.torch.inputs.tabular import TabularInputBlock
-from merlin.models.torch.models.base import Model
+from merlin.models.torch.models.base import Model, Trainer
 from merlin.models.torch.models.ranking import DLRMModel
 from merlin.models.torch.outputs.base import ModelOutput
 from merlin.models.torch.outputs.classification import BinaryOutput
@@ -55,6 +55,7 @@ __all__ = [
     "Concat",
     "Stack",
     "schema",
+    "Trainer",
     "DLRMBlock",
     "DLRMModel",
 ]

--- a/merlin/models/torch/models/base.py
+++ b/merlin/models/torch/models/base.py
@@ -50,15 +50,13 @@ class Model(LightningModule, Block):
 
     Example usage
     -------------
-    >>> model = Model(
+    >>> model = mm.Model(
     ...    TabularInputBlock(schema),
     ...    MLPBlock([32, 16]),
     ...    BinaryOutput(schema.select_by_tag(Tags.TARGET).first),
     ... )
-    ... trainer = Trainer(max_epochs=1)
-    ... with Loader(dataset, batch_size=16) as loader:
-    ...     model.initialize(loader)
-    ...     trainer.fit(model, loader)
+    ... trainer = mm.Trainer(max_epochs=1)
+    ... trainer.fit(model, dataset, batch_size=16)
     """
 
     def __init__(

--- a/merlin/models/torch/models/ranking.py
+++ b/merlin/models/torch/models/ranking.py
@@ -42,10 +42,10 @@ class DLRMModel(Model):
     ...    schema,
     ...    dim=64,
     ...    bottom_block=mm.MLPBlock([256, 64]),
-    ...    output_block=BinaryOutput(ColumnSchema("target")))
-    >>> trainer = pl.Trainer()
-    >>> model.initialize(dataloader)
-    >>> trainer.fit(model, dataloader)
+    ...    output_block=BinaryOutput(ColumnSchema("target"))
+    ... )
+    >>> trainer = mm.Trainer()
+    >>> trainer.fit(model, dataset, batch_size=1024)
 
     References
     ----------

--- a/merlin/models/torch/utils/traversal_utils.py
+++ b/merlin/models/torch/utils/traversal_utils.py
@@ -136,6 +136,38 @@ def leaf(module) -> nn.Module:
 
 
 def is_initialized(module) -> bool:
+    """
+    Checks whether a PyTorch module is initialized or not. A module is considered
+    initialized if it doesn't have any lazy-initialized parameters or buffers.
+
+    Parameters
+    ----------
+    module : torch.nn.Module
+        The PyTorch module to check for initialization.
+
+    Returns
+    -------
+    bool
+        True if the module is initialized (i.e., it doesn't have any lazy-initialized
+        parameters or buffers), False otherwise.
+
+    Notes
+    -----
+    A "lazy-initialized" parameter or buffer is one that doesn't have its values
+    set (i.e., its values are not computed) at the time of its creation. Instead,
+    their values are computed and set later, usually during the first forward pass.
+
+    This function uses the `apply` method of `torch.nn.Module` to apply the
+    `has_unitialized_params` function to every submodule in `module`. If any
+    submodule has at least one lazy-initialized parameter or buffer, the function
+    will return False, indicating that `module` is not fully initialized.
+
+    This function is useful for checking the initialization status of a model
+    before starting the training process, as certain operations (e.g., moving the
+    model to a GPU, saving the model to disk) can only be performed on fully
+    initialized models.
+    """
+
     has_lazy = []
 
     def has_unitialized_params(m):


### PR DESCRIPTION
### Goals :soccer:
This PR introduces a custom `Trainer` object that reduces boilerplate. With this, a model can be trained as follows:


```python
model = mm.Model(
   TabularInputBlock(schema),
   MLPBlock([32, 16]),
   BinaryOutput(schema.select_by_tag(Tags.TARGET).first),
)
trainer = mm.Trainer(max_epochs=1)
trainer.fit(model, dataset, batch_size=16)
```
