### PR TITLE
Making it possible to set optimizer and scheduler instances via PyTorch model properties for training

### DIFF
--- a/merlin/models/torch/models/base.py
+++ b/merlin/models/torch/models/base.py
@@ -75,8 +75,9 @@ class Model(LightningModule, Block):
         self.initialization = initialization
 
     @property
+    @torch.jit.ignore
     def optimizer(self):
-        return self._optimizer
+        return self._optimizer if hasattr(self, "_optimizer") else None
 
     def configure_optimizers(
         self,

--- a/merlin/models/torch/models/base.py
+++ b/merlin/models/torch/models/base.py
@@ -66,6 +66,7 @@ class Model(LightningModule, Block):
     """
 
     def __init__(self, *blocks: nn.Module, initialization="auto"):
+        super().__init__()
 
         # Copied from BlockContainer.__init__
         self.values = nn.ModuleList()

--- a/merlin/models/torch/models/base.py
+++ b/merlin/models/torch/models/base.py
@@ -19,6 +19,7 @@ import os
 from typing import Dict, Iterator, List, Optional, Sequence, Type, Union
 
 import torch
+from packaging import version
 from pytorch_lightning import LightningDataModule, LightningModule
 from torch import nn, optim
 
@@ -31,7 +32,11 @@ from merlin.models.torch.utils import module_utils
 from merlin.models.utils.registry import camelcase_to_snakecase
 
 OptimizerType = Union[optim.Optimizer, Type[optim.Optimizer], str]
-LRSchedulerType = Union[optim.lr_scheduler.LRScheduler, Type[optim.lr_scheduler.LRScheduler]]
+
+if version.parse(torch.__version__).major < 2:
+    LRSchedulerType = Union[optim.lr_scheduler._LRScheduler, Type[optim.lr_scheduler._LRScheduler]]
+else:
+    LRSchedulerType = Union[optim.lr_scheduler.LRScheduler, Type[optim.lr_scheduler.LRScheduler]]
 
 
 class Model(LightningModule, Block):

--- a/tests/unit/torch/models/test_base.py
+++ b/tests/unit/torch/models/test_base.py
@@ -52,6 +52,16 @@ class TestModel:
         model = mm.Model(mm.Block(), mm.Block(), optimizer=optimizer)
         assert model.optimizer is torch.optim.SGD
 
+    def test_init_optimizer_and_scheduler_instances_via_property(self):
+        model = mm.Model(mm.MLPBlock([32, 16]))
+        model.optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
+        model.scheduler = torch.optim.lr_scheduler.StepLR(
+            model.optimizer, step_size=100, gamma=0.99
+        )
+        opt, sched = model.configure_optimizers()
+        assert opt == [model.optimizer]
+        assert sched == [model.scheduler]
+
     def test_pre_and_pre(self):
         inputs = torch.tensor([[1, 2], [3, 4]])
         model = mm.Model(mm.Block(), mm.Block())

--- a/tests/unit/torch/models/test_base.py
+++ b/tests/unit/torch/models/test_base.py
@@ -44,23 +44,17 @@ class TestModel:
         model = mm.Model(mm.Block(), nn.Linear(10, 10))
         assert isinstance(model, mm.Model)
         assert len(model) == 2
-        assert model.optimizer is torch.optim.Adam
-        assert isinstance(model.configure_optimizers(), torch.optim.Adam)
+        assert isinstance(model.configure_optimizers()[0], torch.optim.Adam)
 
-    def test_init_optimizer(self):
-        optimizer = torch.optim.SGD
-        model = mm.Model(mm.Block(), mm.Block(), optimizer=optimizer)
-        assert model.optimizer is torch.optim.SGD
+    def test_init_optimizer_and_scheduler(self):
+        model = mm.Model(mm.MLPBlock([4, 4]))
+        model.initialize(mm.Batch(torch.rand(2, 2)))
 
-    def test_init_optimizer_and_scheduler_instances_via_property(self):
-        model = mm.Model(mm.MLPBlock([32, 16]))
-        model.optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
-        model.scheduler = torch.optim.lr_scheduler.StepLR(
-            model.optimizer, step_size=100, gamma=0.99
-        )
-        opt, sched = model.configure_optimizers()
-        assert opt == [model.optimizer]
-        assert sched == [model.scheduler]
+        optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
+        scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=100, gamma=0.99)
+        opt, sched = model.configure_optimizers(optimizer, scheduler)
+        assert opt == [optimizer]
+        assert sched == [scheduler]
 
     def test_pre_and_pre(self):
         inputs = torch.tensor([[1, 2], [3, 4]])


### PR DESCRIPTION
### Goals :soccer:

- Make it possible to user learning rate schedulers for training MM PyTorch models

### Implementation Details :construction:
- Currently it is possible to provide an Optimizer class in the PyTorch model constructor, which is instantiated within the standard PyT Lightning method `configure_optimizers()` with the `model.parameters()`.
- The learning rate scheduler constructor needs the optimizer instance, as well as other required arguments, so it cannot be provided as constructor argument if the optimizer instance is created within `configure_optimizers()` method.
- This PR makes it possible to provide Optimizer and Scheduler instances via properties, so that the user has more flexibility to instantiate those objects, including cases where different optimizers are used for different parameters.

### Testing Details :mag:

- Added the `test_init_optimizer_and_scheduler_instances_via_property`
