### PR TITLE
Adding ContrastiveOutput

### DIFF
--- a/merlin/models/torch/outputs/classification.py
+++ b/merlin/models/torch/outputs/classification.py
@@ -22,6 +22,7 @@ from torch import nn
 
 import merlin.dtypes as md
 from merlin.models.torch import schema
+from merlin.models.torch.batch import Batch
 from merlin.models.torch.inputs.embedding import EmbeddingTable
 from merlin.models.torch.outputs.base import ModelOutput
 from merlin.schema import ColumnSchema, Schema, Tags
@@ -288,6 +289,12 @@ class CategoricalTarget(nn.Module):
         """
         return self.linear.weight.t()
 
+    def should_apply_contrastive(self, batch: Optional[Batch]) -> bool:
+        if batch is not None and batch.targets and self.training:
+            return True
+
+        return False
+
 
 class EmbeddingTablePrediction(nn.Module):
     """Prediction of a categorical feature using weight-sharing [1] with an embedding table.
@@ -318,6 +325,7 @@ class EmbeddingTablePrediction(nn.Module):
             self.num_classes = table.num_embeddings
             self.col_schema = table.input_schema.first
             self.col_name = self.col_schema.name
+            self.target_name = self.col_name
         self.bias = nn.Parameter(
             torch.zeros(self.num_classes, dtype=torch.float32, device=self.embeddings().device)
         )
@@ -368,6 +376,7 @@ class EmbeddingTablePrediction(nn.Module):
         self.col_name = self.col_schema.name
         self.num_classes = self.col_schema.int_domain.max + 1
         self.output_schema = categorical_output_schema(self.col_schema, self.num_classes)
+        self.target_name = self.col_name
 
         return self
 
@@ -398,6 +407,12 @@ class EmbeddingTablePrediction(nn.Module):
             The corresponding embeddings.
         """
         return self.table({self.col_name: inputs})[self.col_name]
+
+    def should_apply_contrastive(self, batch: Optional[Batch]) -> bool:
+        if batch is not None and batch.targets and self.training:
+            return True
+
+        return False
 
 
 def categorical_output_schema(target: ColumnSchema, num_classes: int) -> Schema:

--- a/merlin/models/torch/outputs/contrastive.py
+++ b/merlin/models/torch/outputs/contrastive.py
@@ -1,0 +1,477 @@
+#
+# Copyright (c) 2023, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from typing import Dict, Final, Optional, Sequence, Tuple, Union
+
+import torch
+import torchmetrics as tm
+from torch import nn
+
+from merlin.models.torch import schema
+from merlin.models.torch.batch import Batch
+from merlin.models.torch.block import Block
+from merlin.models.torch.outputs import sampling  # noqa: F401
+from merlin.models.torch.outputs.base import ModelOutput
+from merlin.models.torch.outputs.classification import (
+    CategoricalOutput,
+    CategoricalTarget,
+    EmbeddingTablePrediction,
+    create_retrieval_metrics,
+)
+from merlin.models.utils.constants import MIN_FLOAT
+from merlin.schema import ColumnSchema, Schema
+
+
+class ContrastiveOutput(ModelOutput):
+    """
+    A prediction block for a contrastive output.
+
+    Parameters
+    ----------
+    schema: Union[ColumnSchema, Schema], optional
+        The schema defining the column properties. Default is None.
+    loss : nn.Module, optional
+        The loss function to use for the output model, defaults to
+        torch.nn.CrossEntropyLoss.
+    metrics : Optional[Sequence[Metric]], optional
+        The metrics to evaluate the model output.
+    logits_temperature: float, optional
+        Parameter used to reduce model overconfidence, so that logits / T.
+        by default 1.0
+    """
+
+    def __init__(
+        self,
+        schema: Optional[Union[ColumnSchema, Schema]] = None,
+        negative_sampling="in-batch",
+        loss: nn.Module = nn.CrossEntropyLoss(),
+        metrics: Optional[Sequence[tm.Metric]] = None,
+        downscore_false_negatives: bool = True,
+        false_negative_score: float = MIN_FLOAT,
+        logits_temperature: float = 1.0,
+    ):
+        if not metrics:
+            metrics = create_retrieval_metrics(
+                CategoricalOutput.DEFAULT_METRICS_CLS, CategoricalOutput.DEFAULT_K
+            )
+
+        super().__init__(
+            loss=loss,
+            metrics=metrics,
+            logits_temperature=logits_temperature,
+        )
+
+        if schema:
+            self.setup_schema(schema)
+
+        self.init_hook_handle = self.register_forward_pre_hook(self.initialize)
+        if not torch.jit.is_scripting():
+            if isinstance(negative_sampling, str):
+                negative_sampling = [negative_sampling]
+            self.negative_sampling = nn.ModuleList((Block.parse(s) for s in negative_sampling))
+            self.downscore_false_negatives = downscore_false_negatives
+            self.false_negative_score = false_negative_score
+
+    @classmethod
+    def with_weight_tying(
+        cls,
+        block: nn.Module,
+        selection: Optional[schema.Selection] = None,
+        negative_sampling="popularity",
+        loss: nn.Module = nn.CrossEntropyLoss(),
+        metrics: Optional[Sequence[tm.Metric]] = None,
+        logits_temperature: float = 1.0,
+        downscore_false_negatives: bool = True,
+        false_negative_score: float = MIN_FLOAT,
+    ) -> "CategoricalOutput":
+        self = cls(
+            loss=loss,
+            metrics=metrics,
+            logits_temperature=logits_temperature,
+            negative_sampling=negative_sampling,
+            downscore_false_negatives=downscore_false_negatives,
+            false_negative_score=false_negative_score,
+        )
+        self = self.tie_weights(block, selection)
+
+        return self
+
+    def tie_weights(
+        self, block: nn.Module, selection: Optional[schema.Selection] = None
+    ) -> "CategoricalOutput":
+        prediction = EmbeddingTablePrediction.with_weight_tying(block, selection)
+        self.num_classes = prediction.num_classes
+        if self:
+            self[0] = prediction
+        else:
+            self.prepend(prediction)
+        self.set_to_call(prediction)
+
+        return self
+
+    def setup_schema(self, target: Union[ColumnSchema, Schema]):
+        """Set up the schema for the output.
+
+        Parameters
+        ----------
+        target: Optional[ColumnSchema]
+            The schema defining the column properties.
+        """
+        if not isinstance(target, (ColumnSchema, Schema)):
+            raise ValueError(f"Target must be a ColumnSchema or Schema, got {target}.")
+
+        if isinstance(target, Schema) and len(target) > 1:
+            if len(target) > 2:
+                raise ValueError(f"Schema must have one or two column(s), got {target}.")
+
+            self.set_to_call(DotProduct(*target.column_names))
+        else:
+            if isinstance(target, Schema):
+                target = target.first
+            self.set_to_call(CategoricalTarget(target))
+
+        self.prepend(self.to_call)
+        if not self.metrics:
+            self.metrics = self.default_metrics()
+
+    def initialize(self, module, inputs):
+        if torch.jit.isinstance(inputs[0], Dict[str, torch.Tensor]):
+            for i in range(len(module)):
+                if isinstance(module[i], CategoricalTarget):
+                    module[i] = DotProduct(module[i].target_name)
+                    self.set_to_call(module[i])
+        elif isinstance(self.to_call, CategoricalTarget):
+            # Make sure CategoticalTarget is initialized
+            outputs = inputs[0]
+            for to_call in module.values:
+                outputs = to_call(outputs)
+
+        self.init_hook_handle.remove()  # Clear hook once block is initialized
+
+    def forward(
+        self, inputs: Union[torch.Tensor, Dict[str, torch.Tensor]], batch: Optional[Batch] = None
+    ) -> torch.Tensor:
+        outputs = inputs
+        for module in self.values:
+            should_apply_contrastive = False
+
+            can_contrast = (
+                not torch.jit.is_scripting()
+                and hasattr(module, "requires_batch")
+                and hasattr(module.to_wrap, "should_apply_contrastive")
+            )
+            if can_contrast:
+                should_apply_contrastive = module.to_wrap.should_apply_contrastive(batch)
+
+            if should_apply_contrastive:
+                if batch is None:
+                    raise ValueError("Contrastive output requires a batch")
+                _batch = batch if batch is not None else Batch({})
+
+                target_name = module.to_wrap.target_name
+
+                if torch.jit.isinstance(outputs, Dict[str, torch.Tensor]) and hasattr(
+                    module.to_wrap, "get_query_name"
+                ):
+                    query_name: str = module.to_wrap.get_query_name(outputs)
+                    outputs = self.contrastive_dot_product(
+                        outputs,
+                        _batch,
+                        target_name=target_name,
+                        query_name=query_name,
+                    )
+                elif torch.jit.isinstance(outputs, torch.Tensor):
+                    outputs = self.contrastive_lookup(
+                        outputs,
+                        _batch,
+                        target_name=target_name,
+                    )
+                else:
+                    raise RuntimeError("Couldn't apply contrastive output")
+            else:
+                outputs = module(outputs, batch=batch)
+
+        return outputs
+
+    @torch.jit.unused
+    def contrastive_dot_product(
+        self,
+        inputs: Dict[str, torch.Tensor],
+        batch: Batch,
+        target_name: str,
+        query_name: str,
+    ) -> torch.Tensor:
+        query = inputs[query_name]
+        positive = inputs[target_name]
+        if target_name in batch.features:
+            positive_id = batch.features[target_name]
+        else:
+            positive_id = torch.tensor(1)
+
+        negative, negative_id = self.sample_negatives(positive, positive_id=positive_id)
+
+        return self.contrastive_outputs(
+            query,
+            positive,
+            negative,
+            positive_id=positive_id,
+            negative_id=negative_id,
+        )
+
+    @torch.jit.unused
+    def contrastive_lookup(
+        self,
+        inputs: torch.Tensor,
+        batch: Batch,
+        target_name: str,
+    ) -> torch.Tensor:
+        query = inputs
+        if len(batch.targets) == 1:
+            positive_id = batch.target()
+        else:
+            positive_id = batch.targets[target_name]
+
+        if not hasattr(self.to_call, "embedding_lookup"):
+            raise ValueError("Couldn't infer positive embedding")
+        positive = self.embedding_lookup(positive_id)
+
+        negative, negative_id = self.sample_negatives(positive, positive_id=positive_id)
+
+        return self.contrastive_outputs(
+            query,
+            positive,
+            negative,
+            positive_id=positive_id,
+            negative_id=negative_id,
+        )
+
+    @torch.jit.unused
+    def sample_negatives(
+        self, positive: torch.Tensor, positive_id: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Samples negative examples for the given positive tensor.
+
+        Args:
+            positive (torch.Tensor): Tensor containing positive samples.
+            positive_id (torch.Tensor, optional): Tensor containing the IDs
+                of positive samples. Defaults to None.
+
+        Returns:
+            Tuple[torch.Tensor, Optional[torch.Tensor]]: A tuple containing the negative samples
+                tensor and the IDs of negative samples.
+        """
+        outputs, ids = [], []
+        for sampler in self.negative_sampling:
+            _positive_id: torch.Tensor = positive_id if positive_id is not None else torch.tensor(1)
+            negative, negative_id = sampler(positive, positive_id=_positive_id)
+            if negative.shape[0] == negative_id.shape[0]:
+                ids.append(negative_id)
+            outputs.append(negative)
+
+        if ids:
+            if len(outputs) != len(ids):
+                raise RuntimeError("The number of negative samples and ids must be the same")
+
+        negative_tensor = torch.cat(outputs, dim=1) if len(outputs) > 1 else outputs[0]
+        id_tensor = torch.tensor(1)
+        if ids:
+            id_tensor = torch.cat(ids, dim=0) if len(ids) > 1 else ids[0]
+
+        return negative_tensor, id_tensor
+
+    @torch.jit.unused
+    def contrastive_outputs(
+        self,
+        query: torch.Tensor,
+        positive: torch.Tensor,
+        negative: torch.Tensor,
+        positive_id: torch.Tensor,
+        negative_id: torch.Tensor,
+    ) -> torch.Tensor:
+        """Computes the contrastive outputs given
+            the query tensor, positive tensor, and negative tensor.
+
+        Args:
+            query (torch.Tensor): Tensor containing the query data.
+            positive (torch.Tensor): Tensor containing the positive data.
+            negative (torch.Tensor): Tensor containing the negative data.
+            positive_id (torch.Tensor, optional): Tensor containing the IDs of positive samples.
+                Defaults to None.
+            negative_id (torch.Tensor, optional): Tensor containing the IDs of negative samples.
+                Defaults to None.
+
+        Returns:
+            torch.Tensor: Tensor containing the contrastive outputs.
+
+            Note, the transformed-targets are stored in
+                the `target` attribute (which is a buffer).
+        """
+
+        # Dot-product for the positive-scores
+        positive_scores = torch.sum(query * positive, dim=-1, keepdim=True)
+        negative_scores = torch.matmul(query, negative.t())
+
+        if self.downscore_false_negatives:
+            if (
+                positive.shape[0] != positive_id.shape[0]
+                or negative.shape[0] != negative_id.shape[0]
+            ):
+                raise RuntimeError(
+                    "Both positive_id and negative_id must be provided "
+                    "when downscore_false_negatives is True"
+                )
+            negative_scores, _ = rescore_false_negatives(
+                positive_id, negative_id, negative_scores, self.false_negative_score
+            )
+
+        if len(negative_scores.shape) + 1 == len(positive_scores.shape):
+            negative_scores = negative_scores.unsqueeze(0)
+        output = torch.cat([positive_scores, negative_scores], dim=-1)
+
+        # Ensure the output is always float32 to avoid numerical instabilities
+        output = output.to(torch.float32)
+
+        batch_size = output.shape[0]
+        num_negatives = output.shape[1] - 1
+
+        self.target = torch.cat(
+            [
+                torch.ones(batch_size, 1, dtype=output.dtype),
+                torch.zeros(batch_size, num_negatives, dtype=output.dtype),
+            ],
+            dim=1,
+        )
+
+        return output
+
+    def embedding_lookup(self, ids: torch.Tensor) -> torch.Tensor:
+        return self.to_call.embedding_lookup(torch.squeeze(ids))
+
+    def set_to_call(self, to_call: nn.Module):
+        self.to_call = to_call
+        if not torch.jit.is_scripting() and hasattr(self, "negative_sampling"):
+            for sampler in self.negative_sampling:
+                if hasattr(sampler, "set_to_call"):
+                    sampler.set_to_call(to_call)
+
+
+@Block.registry.register("dot-product")
+class DotProduct(nn.Module):
+    """Dot-product between queries & candidates.
+
+    Parameters:
+    -----------
+    query_name : str, optional
+        Identify query tower for query/user embeddings, by default 'query'
+    candidate_name : str, optional
+        Identify item tower for item embeddings, by default 'candidate'
+    """
+
+    is_output_module: Final[bool] = True
+
+    def __init__(
+        self,
+        candidate_name: str = "candidate",
+        query_name: Optional[str] = None,
+    ):
+        super().__init__()
+        self.query_name: Optional[str] = query_name
+        self.candidate_name = candidate_name
+        self.target_name = self.candidate_name
+
+    def forward(self, inputs: Dict[str, torch.Tensor]) -> torch.Tensor:
+        if len(inputs) < 2:
+            raise RuntimeError(f"DotProduct requires at least two inputs, got: {inputs}")
+
+        candidate = inputs[self.candidate_name]
+
+        if len(inputs) == 2:
+            query_name = self.get_query_name(inputs)
+        elif self.query_name is not None:
+            query_name = self.query_name
+        else:
+            raise RuntimeError(
+                "DotProduct requires query_name to be set when more than ",
+                f"two inputs are provided, got: {inputs}",
+            )
+        query = inputs[query_name]
+
+        # Alternative is: torch.einsum('...i,...i->...', query, item)
+        return torch.sum(query * candidate, dim=-1, keepdim=True)
+
+    def get_query_name(self, inputs: Dict[str, torch.Tensor]) -> str:
+        if self.query_name is None:
+            for key in inputs:
+                if key != self.candidate_name:
+                    return key
+        else:
+            return self.query_name
+
+        raise RuntimeError(
+            "DotProduct requires query_name to be set when more than two inputs are provided"
+        )
+
+    def should_apply_contrastive(self, batch: Optional[Batch]) -> bool:
+        return self.training
+
+
+def rescore_false_negatives(
+    positive_item_ids: torch.Tensor,
+    neg_samples_item_ids: torch.Tensor,
+    negative_scores: torch.Tensor,
+    false_negatives_score: float,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Zeroes the logits of accidental negatives.
+
+    Parameters
+    ----------
+    positive_item_ids : torch.Tensor
+        A tensor containing the IDs of the positive items.
+    neg_samples_item_ids : torch.Tensor
+        A tensor containing the IDs of the negative samples.
+    negative_scores : torch.Tensor
+        A tensor containing the scores of the negative samples.
+    false_negatives_score : float
+        The score to assign to false negatives (accidental hits).
+
+    Returns
+    -------
+    torch.Tensor
+        A tensor containing the rescored negative scores.
+    torch.Tensor
+        A tensor containing a mask representing valid negatives.
+    """
+
+    # Removing dimensions of size 1 from the shape of the item ids, if applicable
+    positive_item_ids = torch.squeeze(positive_item_ids).to(neg_samples_item_ids.dtype)
+    neg_samples_item_ids = torch.squeeze(neg_samples_item_ids)
+
+    # Reshapes positive and negative ids so that false_negatives_mask matches the scores shape
+    false_negatives_mask = torch.eq(
+        positive_item_ids.unsqueeze(-1), neg_samples_item_ids.unsqueeze(0)
+    )
+
+    # Setting a very small value for false negatives (accidental hits) so that it has
+    # negligible effect on the loss functions
+    negative_scores = torch.where(
+        false_negatives_mask,
+        torch.ones_like(negative_scores) * false_negatives_score,
+        negative_scores,
+    )
+
+    valid_negatives_mask = ~false_negatives_mask
+
+    return torch.squeeze(negative_scores), valid_negatives_mask

--- a/merlin/models/torch/outputs/sampling/__init__.py
+++ b/merlin/models/torch/outputs/sampling/__init__.py
@@ -1,0 +1,7 @@
+from merlin.models.torch.outputs.sampling.in_batch import InBatchNegativeSampler
+from merlin.models.torch.outputs.sampling.popularity import PopularityBasedSampler
+
+__all__ = [
+    "InBatchNegativeSampler",
+    "PopularityBasedSampler",
+]

--- a/merlin/models/torch/outputs/sampling/in_batch.py
+++ b/merlin/models/torch/outputs/sampling/in_batch.py
@@ -1,0 +1,40 @@
+from typing import Tuple
+
+import torch
+from torch import nn
+
+from merlin.models.torch.block import registry
+
+
+@registry.register("in-batch")
+class InBatchNegativeSampler(nn.Module):
+    """PyTorch module that performs in-batch negative sampling."""
+
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("negative", torch.zeros(1, dtype=torch.float32))
+        self.register_buffer("negative_id", torch.zeros(1))
+
+    def forward(
+        self, positive: torch.Tensor, positive_id: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Doing in-batch negative-sampling.
+
+        positive & positive_id are registered as non-persistent buffers
+
+        Args:
+            positive (torch.Tensor): Tensor containing positive samples.
+            positive_id (torch.Tensor, optional): Tensor containing the IDs of
+                positive samples. Defaults to None.
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]: A tuple containing the positive
+                samples tensor and the positive samples IDs tensor.
+        """
+        if self.training:
+            if torch.jit.isinstance(positive, torch.Tensor):
+                self.negative = positive
+            if torch.jit.isinstance(positive_id, torch.Tensor):
+                self.negative_id = positive_id
+
+        return positive, positive_id

--- a/merlin/models/torch/outputs/sampling/popularity.py
+++ b/merlin/models/torch/outputs/sampling/popularity.py
@@ -6,45 +6,115 @@ from torch import nn
 from merlin.models.torch.block import registry
 
 
-class LogUniformSampler(object):
-    def __init__(self, range_max: int, n_sample: int):
-        """LogUniformSampler samples negative samples based on a log-uniform distribution.
+class LogUniformSampler(torch.nn.Module):
+    """
+    LogUniformSampler samples negative samples based on a log-uniform distribution.
+    `P(class) = (log(class + 2) - log(class + 1)) / log(max_id + 1)`
 
-        Credits to:
-        https://github.com/kimiyoung/transformer-xl/blob/master/pytorch/utils/log_uniform_sampler.py
+    This implementation is based on to:
+    https://github.com/kimiyoung/transformer-xl/blob/master/pytorch/utils/log_uniform_sampler.py
+    TensorFlow Reference:
+    https://github.com/tensorflow/tensorflow/blob/r1.10/tensorflow/python/ops/candidate_sampling_ops.py
 
-        TensorFlow Reference:
-        https://github.com/tensorflow/tensorflow/blob/r1.10/tensorflow/python/ops/candidate_sampling_ops.py
-            `P(class) = (log(class + 2) - log(class + 1)) / log(range_max + 1)`
-        expected count can be approximated by 1 - (1 - p)^n
-        and we use a numerically stable version -expm1(num_tries * log1p(-p))
-        Our implementation fixes num_tries at 2 * n_sample,
-        and the actual #samples will vary from run to run
+    LogUniformSampler assumes item ids are sorted decreasingly by their frequency.
+
+    if `unique_sampling==True`, then only unique sampled items will be returned.
+    The actual # samples will vary from run to run if `unique_sampling==True`,
+    as sampling without replacement (`torch.multinomial(..., replacement=False)`) is slow,
+    so we use `torch.multinomial(..., replacement=True).unique()` which doesn't guarantee
+    the same number of unique sampled items. You can try to increase
+    n_samples_multiplier_before_unique to increase the chances to have more
+    unique samples in that case.
+
+    Parameters
+    ----------
+    max_n_samples : int
+        The maximum desired number of negative samples. The number of samples might be
+        smaller than that if `unique_sampling==True`, as explained above.
+    max_id : int
+        The maximum value of the range for the log-uniform distribution.
+    min_id : Optional[int]
+        The minimum value of the range for the log-uniform sampling. By default 0.
+    unique_sampling : bool
+        Whether to return unique samples. By default True
+    n_samples_multiplier_before_unique : int
+        If unique_sampling=True, it is not guaranteed that the number of returned
+        samples will be equal to max_n_samples, as explained above.
+        You can increase n_samples_multiplier_before_unique to maximize
+        chances that a larger number of unique samples is returned.
+    """
+
+    def __init__(
+        self,
+        max_n_samples: int,
+        max_id: int,
+        min_id: Optional[int] = 0,
+        unique_sampling: bool = True,
+        n_samples_multiplier_before_unique: int = 2,
+    ):
+        super().__init__()
+
+        if max_id <= 0:
+            raise ValueError("max_id must be a positive integer.")
+        if max_n_samples <= 0:
+            raise ValueError("n_sample must be a positive integer.")
+
+        self.max_id = max_id
+        self.unique_sampling = unique_sampling
+        self.max_n_samples = max_n_samples
+        self.n_sample = max_n_samples
+        if self.unique_sampling:
+            self.n_sample = int(self.n_sample * n_samples_multiplier_before_unique)
+
+        with torch.no_grad():
+            dist = self.get_log_uniform_distr(max_id, min_id)
+            self.register_buffer("dist", dist)
+            unique_sampling_dist = self.get_unique_sampling_distr(dist, self.n_sample)
+            self.register_buffer("unique_sampling_dist", unique_sampling_dist)
+
+    def get_log_uniform_distr(self, max_id: int, min_id: int = 0) -> torch.Tensor:
+        """Approximates the items frequency distribution with log-uniform probability distribution
+        with P(class) = (log(class + 2) - log(class + 1)) / log(max_id + 1).
+        It assumes item ids are sorted decreasingly by their frequency.
 
         Parameters
         ----------
-        range_max : int
-            The maximum value of the range for the log-uniform distribution.
-        n_sample : int
-            The desired number of negative samples.
+        max_id : int
+            Maximum discrete value for sampling (e.g. cardinality of the item id)
+
+        Returns
+        -------
+        torch.Tensor
+            Returns the log uniform probability distribution
         """
+        log_indices = torch.arange(1.0, max_id - min_id + 2.0, 1.0).log_()
+        probs = (log_indices[1:] - log_indices[:-1]) / log_indices[-1]
+        if min_id > 0:
+            probs = torch.cat(
+                [torch.zeros([min_id], dtype=probs.dtype), probs], axis=0
+            )  # type: ignore
+        return probs
 
-        if range_max <= 0:
-            raise ValueError("range_max must be a positive integer.")
-        if n_sample <= 0:
-            raise ValueError("n_sample must be a positive integer.")
+    def get_unique_sampling_distr(self, dist, n_sample):
+        """Returns the probability that each item is sampled at least once
+        given the specified number of trials. This is meant to be used when
+        self.unique_sampling == True.
+        That probability can be approximated by by 1 - (1 - p)^n
+        and we use a numerically stable version: -expm1(num_tries * log1p(-p))
+        """
+        return (-(-dist.double().log1p_() * n_sample).expm1_()).float()
 
-        with torch.no_grad():
-            self.range_max = range_max
-            log_indices = torch.arange(1.0, range_max + 2.0, 1.0).log_()
-            self.dist = (log_indices[1:] - log_indices[:-1]) / log_indices[-1]
-
-            self.log_q = (-(-self.dist.double().log1p_() * 2 * n_sample).expm1_()).log_().float()
-
-        self.n_sample = n_sample
-
+    @torch.jit.unused
     def sample(self, labels: torch.Tensor):
-        """Sample negative samples and calculate their log probabilities.
+        """Sample negative samples and calculate their probabilities.
+
+        If `unique_sampling==True`, then only unique sampled items will be returned.
+        The actual # samples will vary from run to run if `unique_sampling==True`,
+        as sampling without replacement (`torch.multinomial(..., replacement=False)`) is slow,
+        so we use `torch.multinomial(..., replacement=True).unique()`
+        which doesn't guarantee the same number of unique sampled items.
+        You can try to increase n_samples_multiplier_before_unique
+        to increase the chances to have more unique samples in that case.
 
         Parameters
         ----------
@@ -53,63 +123,107 @@ class LogUniformSampler(object):
 
         Returns
         -------
-        true_log_probs : torch.Tensor, dtype=torch.float32, shape=(batch_size,)
-            The log probabilities of the input labels according
-            to the log-uniform distribution.
-        samp_log_probs : torch.Tensor, dtype=torch.float32, shape=(n_samples,)
-            The log probabilities of the sampled negative samples according
-            to the log-uniform distribution.
         neg_samples : torch.Tensor, dtype=torch.long, shape=(n_samples,)
             The unique negative samples drawn from the log-uniform distribution.
-
-        Raises
-        ------
-        TypeError
-            If `labels` is not a torch.Tensor.
-        ValueError
-            If `labels` has the wrong dtype, the wrong number of dimensions, is empty,
-            or contains values outside the range [0, range_max].
+        true_probs : torch.Tensor, dtype=torch.float32, shape=(batch_size,)
+            The probabilities of the input labels according
+            to the log-uniform distribution (depends on self.unique_sampling choice).
+        samp_log_probs : torch.Tensor, dtype=torch.float32, shape=(n_samples,)
+            The probabilities of the sampled negatives according
+            to the log-uniform distribution (depends on self.unique_sampling choice).
         """
 
         if not torch.is_tensor(labels):
-            raise TypeError("labels must be a torch.Tensor.")
+            raise TypeError("Labels must be a torch.Tensor.")
         if labels.dtype != torch.long:
-            raise ValueError("labels must be a tensor of dtype long.")
+            raise ValueError("Labels must be a tensor of dtype long.")
         if labels.dim() > 2 or (labels.dim() == 2 and min(labels.shape) > 1):
             raise ValueError(
-                "labels must be a 1-dimensional tensor or a 2-dimensional tensor"
+                "Labels must be a 1-dimensional tensor or a 2-dimensional tensor"
                 "with one of the dimensions equal to 1."
             )
         if labels.size(0) == 0:
-            raise ValueError("labels must not be an empty tensor.")
-        if (labels < 0).any() or (labels > self.range_max).any():
-            raise ValueError("All label values must be within the range [0, range_max].")
+            raise ValueError("Labels must not be an empty tensor.")
+        if (labels < 0).any() or (labels > self.max_id).any():
+            raise ValueError(
+                "All label values must be within the range [0, max_id], ",
+                f"got: [{labels.min().item()}, {labels.max().item()}].",
+            )
 
-        # neg_samples = torch.empty(0).long()
-        n_sample = self.n_sample
-        n_tries = 2 * n_sample
+        n_tries = self.n_sample
 
         with torch.no_grad():
-            neg_samples = torch.multinomial(self.dist, n_tries, replacement=True).unique()
+            neg_samples = torch.multinomial(
+                self.dist, n_tries, replacement=True  # type: ignore
+            ).unique()[: self.max_n_samples]
+
             device = labels.device
             neg_samples = neg_samples.to(device)
-            true_log_probs = self.log_q[labels].to(device)
-            samp_log_probs = self.log_q[neg_samples].to(device)
 
-            return true_log_probs, samp_log_probs, neg_samples
+            if self.unique_sampling:
+                dist = self.unique_sampling_dist
+            else:
+                dist = self.dist
+
+            true_probs = dist[labels]  # type: ignore
+            samples_probs = dist[neg_samples]  # type: ignore
+
+            return neg_samples, true_probs, samples_probs
 
 
 @registry.register("popularity")
 class PopularityBasedSampler(nn.Module):
-    def __init__(self, max_num_samples: int = 10, seed: Optional[int] = None):
+    """The PopularityBasedSampler generates negative samples for a positive
+    input sample based on popularity.
+
+    The class utilizes a LogUniformSampler to draw negative samples from a
+    log-uniform distribution. The sampler approximates the items' frequency
+    distribution with log-uniform probability distribution. The sampler assumes
+    item ids are sorted decreasingly by their frequency.
+
+    Parameters
+    ----------
+    max_num_samples : int, optional
+        The maximum number of negative samples desired. Default is 10.
+    unique_sampling : bool, optional
+        Whether to return unique samples. Default is True.
+    n_samples_multiplier_before_unique : int, optional
+        Factor to increase the chances to have more unique samples. Default is 2.
+
+    """
+
+    def __init__(
+        self,
+        max_num_samples: int = 10,
+        unique_sampling: bool = True,
+        n_samples_multiplier_before_unique: int = 2,
+    ):
         super().__init__()
         self.labels = torch.ones((1, 1), dtype=torch.int64)
         self.max_num_samples = max_num_samples
-        self.seed = seed
         self.negative = self.register_buffer("negative", None)
         self.negative_id = self.register_buffer("negative_id", None)
+        self.unique_sampling = unique_sampling
+        self.n_samples_multiplier_before_unique = n_samples_multiplier_before_unique
 
     def forward(self, positive, positive_id=None):
+        """Computes the forward pass of the PopularityBasedSampler.
+
+        Parameters
+        ----------
+        positive : torch.Tensor
+            The positive samples.
+        positive_id : torch.Tensor, optional
+            The ids of the positive samples. Default is None.
+
+        Returns
+        -------
+        negative : torch.Tensor
+            The negative samples.
+        negative_id : torch.Tensor
+            The ids of the negative samples.
+        """
+
         if torch.jit.is_scripting():
             raise RuntimeError("PopularityBasedSampler is not supported in TorchScript.")
 
@@ -117,12 +231,24 @@ class PopularityBasedSampler(nn.Module):
             raise RuntimeError("PopularityBasedSampler must be called after the model")
 
         del positive, positive_id
-        _, _, self.negative_id = self.sampler.sample(self.labels)
+        self.negative_id, _, _ = self.sampler.sample(self.labels)
 
         self.negative = self.to_call.embedding_lookup(torch.squeeze(self.negative_id))
 
         return self.negative, self.negative_id
 
-    def set_to_call(self, to_call):
+    def set_to_call(self, to_call: nn.Module):
+        """Set the model that will utilize this sampler.
+
+        Parameters
+        ----------
+        to_call : torch.nn.Module
+            The model that will utilize this sampler.
+        """
         self.to_call = to_call
-        self.sampler = LogUniformSampler(self.to_call.num_classes, self.max_num_samples)
+        self.sampler = LogUniformSampler(
+            max_n_samples=self.max_num_samples,
+            max_id=self.to_call.num_classes,
+            unique_sampling=self.unique_sampling,
+            n_samples_multiplier_before_unique=self.n_samples_multiplier_before_unique,
+        )

--- a/merlin/models/torch/outputs/sampling/popularity.py
+++ b/merlin/models/torch/outputs/sampling/popularity.py
@@ -1,0 +1,128 @@
+from typing import Optional
+
+import torch
+from torch import nn
+
+from merlin.models.torch.block import registry
+
+
+class LogUniformSampler(object):
+    def __init__(self, range_max: int, n_sample: int):
+        """LogUniformSampler samples negative samples based on a log-uniform distribution.
+
+        Credits to:
+        https://github.com/kimiyoung/transformer-xl/blob/master/pytorch/utils/log_uniform_sampler.py
+
+        TensorFlow Reference:
+        https://github.com/tensorflow/tensorflow/blob/r1.10/tensorflow/python/ops/candidate_sampling_ops.py
+            `P(class) = (log(class + 2) - log(class + 1)) / log(range_max + 1)`
+        expected count can be approximated by 1 - (1 - p)^n
+        and we use a numerically stable version -expm1(num_tries * log1p(-p))
+        Our implementation fixes num_tries at 2 * n_sample,
+        and the actual #samples will vary from run to run
+
+        Parameters
+        ----------
+        range_max : int
+            The maximum value of the range for the log-uniform distribution.
+        n_sample : int
+            The desired number of negative samples.
+        """
+
+        if range_max <= 0:
+            raise ValueError("range_max must be a positive integer.")
+        if n_sample <= 0:
+            raise ValueError("n_sample must be a positive integer.")
+
+        with torch.no_grad():
+            self.range_max = range_max
+            log_indices = torch.arange(1.0, range_max + 2.0, 1.0).log_()
+            self.dist = (log_indices[1:] - log_indices[:-1]) / log_indices[-1]
+
+            self.log_q = (-(-self.dist.double().log1p_() * 2 * n_sample).expm1_()).log_().float()
+
+        self.n_sample = n_sample
+
+    def sample(self, labels: torch.Tensor):
+        """Sample negative samples and calculate their log probabilities.
+
+        Parameters
+        ----------
+        labels : torch.Tensor, dtype=torch.long, shape=(batch_size,)
+            The input labels for which negative samples should be generated.
+
+        Returns
+        -------
+        true_log_probs : torch.Tensor, dtype=torch.float32, shape=(batch_size,)
+            The log probabilities of the input labels according
+            to the log-uniform distribution.
+        samp_log_probs : torch.Tensor, dtype=torch.float32, shape=(n_samples,)
+            The log probabilities of the sampled negative samples according
+            to the log-uniform distribution.
+        neg_samples : torch.Tensor, dtype=torch.long, shape=(n_samples,)
+            The unique negative samples drawn from the log-uniform distribution.
+
+        Raises
+        ------
+        TypeError
+            If `labels` is not a torch.Tensor.
+        ValueError
+            If `labels` has the wrong dtype, the wrong number of dimensions, is empty,
+            or contains values outside the range [0, range_max].
+        """
+
+        if not torch.is_tensor(labels):
+            raise TypeError("labels must be a torch.Tensor.")
+        if labels.dtype != torch.long:
+            raise ValueError("labels must be a tensor of dtype long.")
+        if labels.dim() > 2 or (labels.dim() == 2 and min(labels.shape) > 1):
+            raise ValueError(
+                "labels must be a 1-dimensional tensor or a 2-dimensional tensor"
+                "with one of the dimensions equal to 1."
+            )
+        if labels.size(0) == 0:
+            raise ValueError("labels must not be an empty tensor.")
+        if (labels < 0).any() or (labels > self.range_max).any():
+            raise ValueError("All label values must be within the range [0, range_max].")
+
+        # neg_samples = torch.empty(0).long()
+        n_sample = self.n_sample
+        n_tries = 2 * n_sample
+
+        with torch.no_grad():
+            neg_samples = torch.multinomial(self.dist, n_tries, replacement=True).unique()
+            device = labels.device
+            neg_samples = neg_samples.to(device)
+            true_log_probs = self.log_q[labels].to(device)
+            samp_log_probs = self.log_q[neg_samples].to(device)
+
+            return true_log_probs, samp_log_probs, neg_samples
+
+
+@registry.register("popularity")
+class PopularityBasedSampler(nn.Module):
+    def __init__(self, max_num_samples: int = 10, seed: Optional[int] = None):
+        super().__init__()
+        self.labels = torch.ones((1, 1), dtype=torch.int64)
+        self.max_num_samples = max_num_samples
+        self.seed = seed
+        self.negative = self.register_buffer("negative", None)
+        self.negative_id = self.register_buffer("negative_id", None)
+
+    def forward(self, positive, positive_id=None):
+        if torch.jit.is_scripting():
+            raise RuntimeError("PopularityBasedSampler is not supported in TorchScript.")
+
+        if not hasattr(self, "to_call"):
+            raise RuntimeError("PopularityBasedSampler must be called after the model")
+
+        del positive, positive_id
+        _, _, self.negative_id = self.sampler.sample(self.labels)
+
+        self.negative = self.to_call.embedding_lookup(torch.squeeze(self.negative_id))
+
+        return self.negative, self.negative_id
+
+    def set_to_call(self, to_call):
+        self.to_call = to_call
+        self.sampler = LogUniformSampler(self.to_call.num_classes, self.max_num_samples)

--- a/tests/unit/torch/outputs/sampling/test_in_batch.py
+++ b/tests/unit/torch/outputs/sampling/test_in_batch.py
@@ -1,0 +1,23 @@
+import torch
+
+from merlin.models.torch.outputs.sampling import InBatchNegativeSampler
+from merlin.models.torch.utils import module_utils
+
+
+class TestInBatchNegativeSampler:
+    def test_forward(self):
+        # Create a sample input tensor
+        positive = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        positive_id = torch.tensor([0, 1])
+
+        # Instantiate the InBatchNegativeSampler
+        sampler = InBatchNegativeSampler()
+
+        # Call the forward method
+        output_positive, output_positive_id = module_utils.module_test(
+            sampler, positive, positive_id=positive_id
+        )
+
+        # Check if the output_positive and output_positive_id tensors are correct
+        assert torch.equal(output_positive, positive)
+        assert torch.equal(output_positive_id, positive_id)

--- a/tests/unit/torch/outputs/sampling/test_popularity.py
+++ b/tests/unit/torch/outputs/sampling/test_popularity.py
@@ -90,7 +90,7 @@ class TestPopularityBasedSampler:
             num_classes = 1000
 
         sampler = PopularityBasedSampler()
-        sampler.to_call = MockToCall()
+        sampler.set_to_call(MockToCall())
 
         negative, negative_id = sampler(torch.tensor([1.0]), torch.tensor([1]))
 
@@ -102,7 +102,7 @@ class TestPopularityBasedSampler:
             num_classes = 1000
 
         sampler = PopularityBasedSampler()
-        sampler.to_call = MockToCall()
+        sampler.set_to_call(MockToCall())
 
         log_uniform_sampler = sampler.sampler
 

--- a/tests/unit/torch/outputs/sampling/test_popularity.py
+++ b/tests/unit/torch/outputs/sampling/test_popularity.py
@@ -1,0 +1,111 @@
+import pytest
+import torch
+
+from merlin.models.torch.outputs.sampling.popularity import (
+    LogUniformSampler,
+    PopularityBasedSampler,
+)
+
+
+class TestLogUniformSampler:
+    def test_init(self):
+        range_max = 1000
+        n_sample = 100
+        sampler = LogUniformSampler(range_max, n_sample)
+
+        assert sampler.range_max == range_max
+        assert sampler.n_sample == n_sample
+        assert sampler.dist.size(0) == range_max
+        assert sampler.log_q.size(0) == range_max
+
+    def test_sample(self):
+        range_max = 1000
+        n_sample = 100
+        sampler = LogUniformSampler(range_max, n_sample)
+
+        labels = torch.tensor([10, 50, 150])
+        true_log_probs, samp_log_probs, neg_samples = sampler.sample(labels)
+
+        assert true_log_probs.size() == labels.size()
+        assert samp_log_probs.size()[0] <= 2 * n_sample
+        assert neg_samples.size()[0] <= 2 * n_sample
+
+    @pytest.mark.parametrize("range_max, n_sample", [(1000, 100), (5000, 250), (10000, 500)])
+    def test_dist_sum(self, range_max, n_sample):
+        sampler = LogUniformSampler(range_max, n_sample)
+
+        assert torch.isclose(sampler.dist.sum(), torch.tensor(1.0), atol=1e-6)
+
+    def test_init_exceptions(self):
+        with pytest.raises(ValueError):
+            LogUniformSampler(-1000, 100)
+
+        with pytest.raises(ValueError):
+            LogUniformSampler(1000, -100)
+
+    def test_sample_exceptions(self):
+        range_max = 1000
+        n_sample = 100
+        sampler = LogUniformSampler(range_max, n_sample)
+
+        with pytest.raises(TypeError):
+            sampler.sample([10, 50, 150])
+
+        with pytest.raises(ValueError):
+            sampler.sample(torch.tensor([10, 50, 150], dtype=torch.float32))
+
+        with pytest.raises(ValueError):
+            sampler.sample(torch.tensor([]))
+
+        with pytest.raises(ValueError):
+            sampler.sample(torch.tensor([-1, 50, 150]))
+
+        with pytest.raises(ValueError):
+            sampler.sample(torch.tensor([10, 50, 150, 2000]))
+
+
+class TestPopularityBasedSampler:
+    def test_init_defaults(self):
+        sampler = PopularityBasedSampler()
+        assert sampler.labels.dtype == torch.int64
+        assert sampler.labels.shape == torch.Size([1, 1])
+        assert sampler.max_num_samples == 10
+        assert sampler.seed is None
+
+    def test_init_custom_values(self):
+        sampler = PopularityBasedSampler(max_num_samples=20, seed=42)
+        assert sampler.max_num_samples == 20
+        assert sampler.seed == 42
+
+    def test_forward_raises_runtime_error(self):
+        sampler = PopularityBasedSampler()
+        with pytest.raises(RuntimeError):
+            sampler(torch.tensor([1.0]), torch.tensor([1]))
+
+    def test_forward(self):
+        class MockToCall:
+            def embedding_lookup(self, ids):
+                return torch.tensor([42.0])
+
+            num_classes = 1000
+
+        sampler = PopularityBasedSampler()
+        sampler.to_call = MockToCall()
+
+        negative, negative_id = sampler(torch.tensor([1.0]), torch.tensor([1]))
+
+        assert isinstance(negative, torch.Tensor)
+        assert isinstance(negative_id, torch.Tensor)
+
+    def test_sampler_property(self):
+        class MockToCall:
+            num_classes = 1000
+
+        sampler = PopularityBasedSampler()
+        sampler.to_call = MockToCall()
+
+        log_uniform_sampler = sampler.sampler
+
+        assert isinstance(log_uniform_sampler, LogUniformSampler)
+        assert log_uniform_sampler.range_max == MockToCall.num_classes
+        assert log_uniform_sampler.n_sample == sampler.max_num_samples

--- a/tests/unit/torch/outputs/sampling/test_popularity.py
+++ b/tests/unit/torch/outputs/sampling/test_popularity.py
@@ -11,20 +11,20 @@ class TestLogUniformSampler:
     def test_init(self):
         range_max = 1000
         n_sample = 100
-        sampler = LogUniformSampler(range_max, n_sample)
+        sampler = LogUniformSampler(n_sample, range_max)
 
-        assert sampler.range_max == range_max
-        assert sampler.n_sample == n_sample
+        assert sampler.max_id == range_max
+        assert sampler.max_n_samples == n_sample
         assert sampler.dist.size(0) == range_max
-        assert sampler.log_q.size(0) == range_max
+        assert sampler.unique_sampling_dist.size(0) == range_max
 
     def test_sample(self):
         range_max = 1000
         n_sample = 100
-        sampler = LogUniformSampler(range_max, n_sample)
+        sampler = LogUniformSampler(n_sample, range_max)
 
         labels = torch.tensor([10, 50, 150])
-        true_log_probs, samp_log_probs, neg_samples = sampler.sample(labels)
+        neg_samples, true_log_probs, samp_log_probs = sampler.sample(labels)
 
         assert true_log_probs.size() == labels.size()
         assert samp_log_probs.size()[0] <= 2 * n_sample
@@ -32,35 +32,35 @@ class TestLogUniformSampler:
 
     @pytest.mark.parametrize("range_max, n_sample", [(1000, 100), (5000, 250), (10000, 500)])
     def test_dist_sum(self, range_max, n_sample):
-        sampler = LogUniformSampler(range_max, n_sample)
+        sampler = LogUniformSampler(n_sample, range_max)
 
         assert torch.isclose(sampler.dist.sum(), torch.tensor(1.0), atol=1e-6)
 
     def test_init_exceptions(self):
-        with pytest.raises(ValueError):
-            LogUniformSampler(-1000, 100)
+        with pytest.raises(ValueError, match="n_sample must be a positive integer."):
+            LogUniformSampler(-100, 1000)
 
-        with pytest.raises(ValueError):
-            LogUniformSampler(1000, -100)
+        with pytest.raises(ValueError, match="max_id must be a positive integer"):
+            LogUniformSampler(100, -1000)
 
     def test_sample_exceptions(self):
         range_max = 1000
         n_sample = 100
-        sampler = LogUniformSampler(range_max, n_sample)
+        sampler = LogUniformSampler(n_sample, range_max)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="Labels must be a torch.Tensor."):
             sampler.sample([10, 50, 150])
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Labels must be a tensor of dtype long."):
             sampler.sample(torch.tensor([10, 50, 150], dtype=torch.float32))
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Labels must be a tensor of dtype long."):
             sampler.sample(torch.tensor([]))
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="All label values must be within the range"):
             sampler.sample(torch.tensor([-1, 50, 150]))
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="All label values must be within the range"):
             sampler.sample(torch.tensor([10, 50, 150, 2000]))
 
 
@@ -70,12 +70,10 @@ class TestPopularityBasedSampler:
         assert sampler.labels.dtype == torch.int64
         assert sampler.labels.shape == torch.Size([1, 1])
         assert sampler.max_num_samples == 10
-        assert sampler.seed is None
 
     def test_init_custom_values(self):
-        sampler = PopularityBasedSampler(max_num_samples=20, seed=42)
+        sampler = PopularityBasedSampler(max_num_samples=20)
         assert sampler.max_num_samples == 20
-        assert sampler.seed == 42
 
     def test_forward_raises_runtime_error(self):
         sampler = PopularityBasedSampler()
@@ -107,5 +105,5 @@ class TestPopularityBasedSampler:
         log_uniform_sampler = sampler.sampler
 
         assert isinstance(log_uniform_sampler, LogUniformSampler)
-        assert log_uniform_sampler.range_max == MockToCall.num_classes
-        assert log_uniform_sampler.n_sample == sampler.max_num_samples
+        assert log_uniform_sampler.max_id == MockToCall.num_classes
+        assert log_uniform_sampler.max_n_samples == sampler.max_num_samples

--- a/tests/unit/torch/outputs/test_constrastive.py
+++ b/tests/unit/torch/outputs/test_constrastive.py
@@ -1,0 +1,185 @@
+import pytest
+import torch
+
+import merlin.models.torch as mm
+from merlin.models.torch.outputs.contrastive import ContrastiveOutput, rescore_false_negatives
+from merlin.models.torch.utils.module_utils import module_test
+from merlin.schema import Schema
+
+
+class TestContrastiveOutput:
+    def test_outputs_without_downscore(self, item_id_col_schema):
+        contrastive = ContrastiveOutput(item_id_col_schema, downscore_false_negatives=False)
+
+        query = torch.tensor([[0.1, 0.2], [0.3, 0.4]])
+        positive = torch.tensor([[0.5, 0.6], [0.7, 0.8]])
+        negative = torch.tensor([[0.9, 1.0], [1.1, 1.2], [1.3, 1.4]])
+
+        out = contrastive.contrastive_outputs(query, positive, negative)
+
+        expected_out = torch.tensor(
+            [[0.1700, 0.2900, 0.3500, 0.4100], [0.5300, 0.6700, 0.8100, 0.9500]]
+        )
+        expected_target = torch.tensor([[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]])
+
+        assert torch.allclose(out, expected_out, atol=1e-4)
+        assert torch.equal(contrastive.target, expected_target)
+
+    def test_outputs_with_rescore_false_negatives(self, item_id_col_schema):
+        contrastive = ContrastiveOutput(item_id_col_schema, false_negative_score=-100.0)
+
+        query = torch.tensor([[0.1, 0.2]])
+        positive = torch.tensor([[0.5, 0.6]])
+        negative = torch.tensor([[0.5, 0.6], [0.9, 1.0]])
+        positive_id = torch.tensor([[0]])
+        negative_id = torch.tensor([[0, 1]])
+
+        out = contrastive.contrastive_outputs(query, positive, negative, positive_id, negative_id)
+
+        # Explanation:
+        # 1. positive_scores = dot(query, positive) = dot([0.1, 0.2], [0.5, 0.6]) = 0.17
+        # 2. negative_scores = matmul(query, negative.T)
+        #   = matmul([[0.1, 0.2]], [[0.5, 0.9], [0.6, 1.0]]) = [[0.17, 0.29]]
+        # 3. Since the first negative sample is a false negative (its id is in positive_id),
+        #   we downscore it to -100.0
+        # 4. The final output is a concatenation of the positive_scores and the
+        #   rescored negative_scores: [[0.17, -100.0, 0.29]]
+
+        expected_out = torch.tensor([[0.17, -100.0, 0.29]])
+        expected_target = torch.tensor([[1.0, 0.0, 0.0]])
+
+        assert torch.allclose(out, expected_out, atol=1e-4)
+        assert torch.equal(contrastive.target, expected_target)
+
+    def test_outputs_raises_runtime_error(self, item_id_col_schema):
+        contrastive = ContrastiveOutput(item_id_col_schema)
+
+        query = torch.tensor([[0.1, 0.2], [0.3, 0.4]])
+        positive = torch.tensor([[0.5, 0.6], [0.7, 0.8]])
+        negative = torch.tensor([[0.9, 1.0], [1.1, 1.2], [1.3, 1.4]])
+        positive_id = torch.tensor([0, 1])
+        negative_id = torch.tensor([1, 2, 3])
+
+        with pytest.raises(RuntimeError):
+            contrastive.contrastive_outputs(query, positive, negative, positive_id)
+
+        with pytest.raises(RuntimeError):
+            contrastive.contrastive_outputs(query, positive, negative, negative_id=negative_id)
+
+    def test_call_categorical_target(self, item_id_col_schema):
+        model = mm.Block(
+            mm.EmbeddingTable(10, Schema([item_id_col_schema])),
+            mm.Concat(),
+            ContrastiveOutput(item_id_col_schema),
+        )
+
+        item_id = torch.tensor([1, 2, 3])
+        features = {"item_id": item_id}
+        batch = mm.Batch(features)
+
+        outputs = module_test(model, features, batch=batch)
+        contrastive_outputs = model(features, batch=batch.replace(targets=item_id + 1))
+
+        self.assert_contrastive_outputs(contrastive_outputs, model[-1].target, outputs)
+
+    def test_call_dot_product(self, user_id_col_schema, item_id_col_schema):
+        schema = Schema([user_id_col_schema, item_id_col_schema])
+        model = mm.Block(
+            mm.EmbeddingTables(10, schema),
+            ContrastiveOutput(item_id_col_schema),
+        )
+
+        user_id = torch.tensor([1, 2, 3])
+        item_id = torch.tensor([1, 2, 3])
+
+        data = {"user_id": user_id, "item_id": item_id}
+        contrastive_outputs = model(data, batch=mm.Batch(data))
+
+        model.eval()
+        outputs = module_test(model, data, batch=mm.Batch(data))
+
+        self.assert_contrastive_outputs(contrastive_outputs, model[-1].target, outputs)
+
+    def test_call_dot_product_table(self, user_id_col_schema, item_id_col_schema):
+        schema = Schema([user_id_col_schema, item_id_col_schema])
+        embeddings = mm.EmbeddingTables(10, schema)
+        model = mm.Block(
+            embeddings,
+            mm.MLPBlock([10]),
+            ContrastiveOutput.with_weight_tying(embeddings, item_id_col_schema),
+        )
+
+        user_id = torch.tensor([1, 2, 3])
+        item_id = torch.tensor([1, 2, 3])
+
+        data = {"user_id": user_id, "item_id": item_id}
+        contrastive_outputs = model(data, batch=mm.Batch(data, targets=item_id + 1))
+
+        model.eval()
+        outputs = module_test(model, data, batch=mm.Batch(data))
+
+        self.assert_contrastive_outputs(contrastive_outputs, model[-1].target, outputs)
+
+    def assert_contrastive_outputs(self, contrastive_outputs, targets, outputs):
+        assert contrastive_outputs.shape == (3, 4)
+        assert targets.shape == (3, 4)
+        assert not torch.equal(outputs, contrastive_outputs)
+        assert targets[:, 0].all().item()
+        assert torch.equal(targets[:, 1:], torch.zeros_like(targets[:, 1:]))
+
+
+class Test_rescore_false_negatives:
+    def test_no_false_negatives(self):
+        positive_item_ids = torch.tensor([1, 3, 5])
+        neg_samples_item_ids = torch.tensor([2, 4, 6])
+        negative_scores = torch.tensor([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]])
+        false_negatives_score = -100.0
+
+        rescored_neg_scores, valid_negatives_mask = rescore_false_negatives(
+            positive_item_ids, neg_samples_item_ids, negative_scores, false_negatives_score
+        )
+
+        assert torch.equal(rescored_neg_scores, negative_scores)
+        assert torch.equal(
+            valid_negatives_mask, torch.ones_like(valid_negatives_mask, dtype=torch.bool)
+        )
+
+    def test_with_false_negatives(self):
+        positive_item_ids = torch.tensor([1, 3, 5])
+        neg_samples_item_ids = torch.tensor([1, 4, 5])
+        negative_scores = torch.tensor([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]])
+        false_negatives_score = -100.0
+
+        rescored_neg_scores, valid_negatives_mask = rescore_false_negatives(
+            positive_item_ids, neg_samples_item_ids, negative_scores, false_negatives_score
+        )
+
+        expected_rescored_neg_scores = torch.tensor(
+            [[-100.0, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, -100.0]]
+        )
+        expected_valid_negatives_mask = torch.tensor(
+            [[False, True, True], [True, True, True], [True, True, False]], dtype=torch.bool
+        )
+
+        assert torch.equal(rescored_neg_scores, expected_rescored_neg_scores)
+        assert torch.equal(valid_negatives_mask, expected_valid_negatives_mask)
+
+    def test_all_false_negatives(self):
+        positive_item_ids = torch.tensor([1, 3, 5])
+        neg_samples_item_ids = torch.tensor([1, 3, 5])
+        negative_scores = torch.tensor([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]])
+        false_negatives_score = -100.0
+
+        rescored_neg_scores, valid_negatives_mask = rescore_false_negatives(
+            positive_item_ids, neg_samples_item_ids, negative_scores, false_negatives_score
+        )
+
+        expected_rescored_neg_scores = torch.tensor(
+            [[-100.0, 0.2, 0.3], [0.4, -100.0, 0.6], [0.7, 0.8, -100.0]]
+        )
+        expected_valid_negatives_mask = torch.tensor(
+            [[False, True, True], [True, False, True], [True, True, False]], dtype=torch.bool
+        )
+
+        assert torch.equal(rescored_neg_scores, expected_rescored_neg_scores)
+        assert torch.equal(valid_negatives_mask, expected_valid_negatives_mask)


### PR DESCRIPTION
### Goals :soccer:
This PR builds on the `CategoricalOutput` and adds `ContrastiveOutput`. This can be used with dot-product, categorical-prediction or weight-tying.

### Implementation Details :construction:
The contrastive part of `CategoricalOutput` doesn't work with torch-script, this is fine since it's during training only. 