### PR TITLE
Apply rename to initialize_from_schema to ContrastiveOutput

### DIFF
--- a/merlin/models/torch/outputs/contrastive.py
+++ b/merlin/models/torch/outputs/contrastive.py
@@ -74,7 +74,7 @@ class ContrastiveOutput(ModelOutput):
         )
 
         if schema:
-            self.setup_schema(schema)
+            self.initialize_from_schema(schema)
 
         self.init_hook_handle = self.register_forward_pre_hook(self.initialize)
         if not torch.jit.is_scripting():
@@ -121,7 +121,7 @@ class ContrastiveOutput(ModelOutput):
 
         return self
 
-    def setup_schema(self, target: Union[ColumnSchema, Schema]):
+    def initialize_from_schema(self, target: Union[ColumnSchema, Schema]):
         """Set up the schema for the output.
 
         Parameters

--- a/tests/unit/torch/outputs/test_constrastive.py
+++ b/tests/unit/torch/outputs/test_constrastive.py
@@ -13,7 +13,7 @@ from merlin.schema import Schema
 
 
 class TestContrastiveOutput:
-    def test_setup_schema(self, item_id_col_schema, user_id_col_schema):
+    def test_initialize_from_schema(self, item_id_col_schema, user_id_col_schema):
         contrastive = ContrastiveOutput()
 
         dot = ContrastiveOutput(schema=Schema([item_id_col_schema, user_id_col_schema]))
@@ -23,10 +23,10 @@ class TestContrastiveOutput:
         assert isinstance(target.to_call, CategoricalTarget)
 
         with pytest.raises(ValueError):
-            contrastive.setup_schema(1)
+            contrastive.initialize_from_schema(1)
 
         with pytest.raises(ValueError):
-            contrastive.setup_schema(Schema(["a", "b", "c"]))
+            contrastive.initialize_from_schema(Schema(["a", "b", "c"]))
 
     def test_outputs_without_downscore(self, item_id_col_schema):
         contrastive = ContrastiveOutput(item_id_col_schema, downscore_false_negatives=False)


### PR DESCRIPTION
### Goals :soccer:
https://github.com/NVIDIA-Merlin/models/pull/1186 renamed `setup_schema` to `initialize_from_schema`, this PR applies that rename to `ContrastiveOutput` which still used the old name.
