### PR TITLE
Ensure TopKEncoder has correct outputs when model is saved

### DIFF
--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -443,11 +443,6 @@ class BaseModel(tf.keras.Model):
                 "`prediction_tasks` is deprecated and will be removed in a future version.",
             )
 
-        if num_v1_blocks > 0:
-            self.output_names = [task.task_name for task in self.prediction_tasks]
-        else:
-            self.output_names = [block.full_name for block in self.model_outputs]
-
         # This flag will make Keras change the metric-names which is not needed in v2
         from_serialized = kwargs.pop("from_serialized", num_v2_blocks > 0)
 

--- a/merlin/models/tf/models/base.py
+++ b/merlin/models/tf/models/base.py
@@ -69,6 +69,7 @@ from merlin.models.tf.models.utils import parse_prediction_blocks
 from merlin.models.tf.outputs.base import ModelOutput, ModelOutputType
 from merlin.models.tf.outputs.classification import CategoricalOutput
 from merlin.models.tf.outputs.contrastive import ContrastiveOutput
+from merlin.models.tf.outputs.topk import TopKOutput
 from merlin.models.tf.prediction_tasks.base import ParallelPredictionBlock, PredictionTask
 from merlin.models.tf.transforms.features import PrepareFeatures, expected_input_cols_from_schema
 from merlin.models.tf.transforms.sequence import SequenceTransform
@@ -322,6 +323,154 @@ class BaseModel(tf.keras.Model):
             trainable=False,
             synchronization=tf.VariableSynchronization.NONE,
             initial_value=lambda: True,
+        )
+
+    def compile(
+        self,
+        optimizer="rmsprop",
+        loss: Optional[Union[str, Loss, Dict[str, Union[str, Loss]]]] = None,
+        metrics: Optional[
+            Union[
+                MetricType,
+                Sequence[MetricType],
+                Sequence[Sequence[MetricType]],
+                Dict[str, MetricType],
+                Dict[str, Sequence[MetricType]],
+            ]
+        ] = None,
+        loss_weights=None,
+        weighted_metrics: Optional[
+            Union[
+                MetricType,
+                Sequence[MetricType],
+                Sequence[Sequence[MetricType]],
+                Dict[str, MetricType],
+                Dict[str, Sequence[MetricType]],
+            ]
+        ] = None,
+        run_eagerly=None,
+        steps_per_execution=None,
+        jit_compile=None,
+        **kwargs,
+    ):
+        """Configures the model for training.
+        Example:
+        ```python
+        model.compile(optimizer=tf.keras.optimizers.Adam(learning_rate=1e-3),
+                      loss=tf.keras.losses.BinaryCrossentropy(),
+                      metrics=[tf.keras.metrics.BinaryAccuracy(),
+                               tf.keras.metrics.FalseNegatives()])
+        ```
+        Args:
+            optimizer: String (name of optimizer) or optimizer instance. See
+              `tf.keras.optimizers`.
+            loss: Optional[Union[str, Loss, Dict[str, Union[str, Loss]]]] = None
+              losses : Optional[Union[str, Loss, Dict[str, Union[str, Loss]]]], optional
+              {LOSS_PARAMETERS_DOCSTRINGS}
+              See `tf.keras.losses`. A loss
+              function is any callable with the signature `loss = fn(y_true,
+              y_pred)`, where `y_true` are the ground truth values, and
+              `y_pred` are the model's predictions.
+              `y_true` should have shape
+              `(batch_size, d0, .. dN)` (except in the case of
+              sparse loss functions such as
+              sparse categorical crossentropy which expects integer arrays of shape
+              `(batch_size, d0, .. dN-1)`).
+              `y_pred` should have shape `(batch_size, d0, .. dN)`.
+              The loss function should return a float tensor.
+              If a custom `Loss` instance is
+              used and reduction is set to `None`, return value has shape
+              `(batch_size, d0, .. dN-1)` i.e. per-sample or per-timestep loss
+              values; otherwise, it is a scalar. If the model has multiple outputs,
+              you can use a different loss on each output by passing a dictionary
+              or a list of losses. The loss value that will be minimized by the
+              model will then be the sum of all individual losses, unless
+              `loss_weights` is specified.
+            loss_weights: Optional list or dictionary specifying scalar coefficients
+              (Python floats) to weight the loss contributions of different model
+              outputs. The loss value that will be minimized by the model will then
+              be the *weighted sum* of all individual losses, weighted by the
+              `loss_weights` coefficients.
+                If a list, it is expected to have a 1:1 mapping to the model's
+                  outputs (Keras sorts tasks by name).
+                  If a dict, it is expected to map output names (strings)
+                  to scalar coefficients.
+            metrics: Optional[ Union[ MetricType, Sequence[MetricType],
+                  Sequence[Sequence[MetricType]],
+                  Dict[str, MetricType], Dict[str, Sequence[MetricType]], ] ], optional
+                  {METRICS_PARAMETERS_DOCSTRING}
+            weighted_metrics: Optional[ Union[ MetricType, Sequence[MetricType],
+                  Sequence[Sequence[MetricType]],
+                  Dict[str, MetricType], Dict[str, Sequence[MetricType]], ] ], optional
+                  List of metrics to be evaluated and weighted by
+                 `sample_weight` or `class_weight` during training and testing.
+                 {METRICS_PARAMETERS_DOCSTRING}
+            run_eagerly: Bool. Defaults to `False`. If `True`, this `Model`'s
+              logic will not be wrapped in a `tf.function`. Recommended to leave
+              this as `None` unless your `Model` cannot be run inside a
+              `tf.function`. `run_eagerly=True` is not supported when using
+              `tf.distribute.experimental.ParameterServerStrategy`.
+            steps_per_execution: Int. Defaults to 1. The number of batches to run
+              during each `tf.function` call. Running multiple batches inside a
+              single `tf.function` call can greatly improve performance on TPUs or
+              small models with a large Python overhead. At most, one full epoch
+              will be run each execution. If a number larger than the size of the
+              epoch is passed, the execution will be truncated to the size of the
+              epoch. Note that if `steps_per_execution` is set to `N`,
+              `Callback.on_batch_begin` and `Callback.on_batch_end` methods will
+              only be called every `N` batches (i.e. before/after each `tf.function`
+              execution).
+            jit_compile: If `True`, compile the model training step with XLA.
+              [XLA](https://www.tensorflow.org/xla) is an optimizing compiler for
+              machine learning.
+              `jit_compile` is not enabled for by default.
+              This option cannot be enabled with `run_eagerly=True`.
+              Note that `jit_compile=True` is
+              may not necessarily work for all models.
+              For more information on supported operations please refer to the
+              [XLA documentation](https://www.tensorflow.org/xla).
+              Also refer to
+              [known XLA issues](https://www.tensorflow.org/xla/known_issues) for
+              more details.
+            **kwargs: Arguments supported for backwards compatibility only.
+        """
+
+        num_v1_blocks = len(self.prediction_tasks)
+        num_v2_blocks = len(self.model_outputs)
+
+        if num_v1_blocks > 1 and num_v2_blocks > 1:
+            raise ValueError(
+                "You cannot use both `prediction_tasks` and `prediction_blocks` at the same time.",
+                "`prediction_tasks` is deprecated and will be removed in a future version.",
+            )
+
+        if num_v1_blocks > 0:
+            self.output_names = [task.task_name for task in self.prediction_tasks]
+        else:
+            if num_v2_blocks == 1 and isinstance(self.model_outputs[0], TopKOutput):
+                pass
+            else:
+                self.output_names = [block.full_name for block in self.model_outputs]
+
+        # This flag will make Keras change the metric-names which is not needed in v2
+        from_serialized = kwargs.pop("from_serialized", num_v2_blocks > 0)
+
+        if hvd_installed and hvd.size() > 1:
+            # Horovod: Specify `experimental_run_tf_function=False` to ensure TensorFlow
+            # uses hvd.DistributedOptimizer() to compute gradients.
+            kwargs.update({"experimental_run_tf_function": False})
+
+        super(BaseModel, self).compile(
+            optimizer=self._create_optimizer(optimizer),
+            loss=self._create_loss(loss),
+            metrics=self._create_metrics(metrics, weighted=False),
+            weighted_metrics=self._create_metrics(weighted_metrics, weighted=True),
+            run_eagerly=run_eagerly,
+            loss_weights=loss_weights,
+            steps_per_execution=steps_per_execution,
+            jit_compile=jit_compile,
+            from_serialized=from_serialized,
+            **kwargs,
         )
 
     def _create_optimizer(self, optimizer):
@@ -1615,151 +1764,6 @@ class Model(BaseModel):
                     child._feature_shapes = feature_shapes
                     child._feature_dtypes = feature_dtypes
         super()._maybe_build(inputs)
-
-    def compile(
-        self,
-        optimizer="rmsprop",
-        loss: Optional[Union[str, Loss, Dict[str, Union[str, Loss]]]] = None,
-        metrics: Optional[
-            Union[
-                MetricType,
-                Sequence[MetricType],
-                Sequence[Sequence[MetricType]],
-                Dict[str, MetricType],
-                Dict[str, Sequence[MetricType]],
-            ]
-        ] = None,
-        loss_weights=None,
-        weighted_metrics: Optional[
-            Union[
-                MetricType,
-                Sequence[MetricType],
-                Sequence[Sequence[MetricType]],
-                Dict[str, MetricType],
-                Dict[str, Sequence[MetricType]],
-            ]
-        ] = None,
-        run_eagerly=None,
-        steps_per_execution=None,
-        jit_compile=None,
-        **kwargs,
-    ):
-        """Configures the model for training.
-        Example:
-        ```python
-        model.compile(optimizer=tf.keras.optimizers.Adam(learning_rate=1e-3),
-                      loss=tf.keras.losses.BinaryCrossentropy(),
-                      metrics=[tf.keras.metrics.BinaryAccuracy(),
-                               tf.keras.metrics.FalseNegatives()])
-        ```
-        Args:
-            optimizer: String (name of optimizer) or optimizer instance. See
-              `tf.keras.optimizers`.
-            loss: Optional[Union[str, Loss, Dict[str, Union[str, Loss]]]] = None
-              losses : Optional[Union[str, Loss, Dict[str, Union[str, Loss]]]], optional
-              {LOSS_PARAMETERS_DOCSTRINGS}
-              See `tf.keras.losses`. A loss
-              function is any callable with the signature `loss = fn(y_true,
-              y_pred)`, where `y_true` are the ground truth values, and
-              `y_pred` are the model's predictions.
-              `y_true` should have shape
-              `(batch_size, d0, .. dN)` (except in the case of
-              sparse loss functions such as
-              sparse categorical crossentropy which expects integer arrays of shape
-              `(batch_size, d0, .. dN-1)`).
-              `y_pred` should have shape `(batch_size, d0, .. dN)`.
-              The loss function should return a float tensor.
-              If a custom `Loss` instance is
-              used and reduction is set to `None`, return value has shape
-              `(batch_size, d0, .. dN-1)` i.e. per-sample or per-timestep loss
-              values; otherwise, it is a scalar. If the model has multiple outputs,
-              you can use a different loss on each output by passing a dictionary
-              or a list of losses. The loss value that will be minimized by the
-              model will then be the sum of all individual losses, unless
-              `loss_weights` is specified.
-            loss_weights: Optional list or dictionary specifying scalar coefficients
-              (Python floats) to weight the loss contributions of different model
-              outputs. The loss value that will be minimized by the model will then
-              be the *weighted sum* of all individual losses, weighted by the
-              `loss_weights` coefficients.
-                If a list, it is expected to have a 1:1 mapping to the model's
-                  outputs (Keras sorts tasks by name).
-                  If a dict, it is expected to map output names (strings)
-                  to scalar coefficients.
-            metrics: Optional[ Union[ MetricType, Sequence[MetricType],
-                  Sequence[Sequence[MetricType]],
-                  Dict[str, MetricType], Dict[str, Sequence[MetricType]], ] ], optional
-                  {METRICS_PARAMETERS_DOCSTRING}
-            weighted_metrics: Optional[ Union[ MetricType, Sequence[MetricType],
-                  Sequence[Sequence[MetricType]],
-                  Dict[str, MetricType], Dict[str, Sequence[MetricType]], ] ], optional
-                  List of metrics to be evaluated and weighted by
-                 `sample_weight` or `class_weight` during training and testing.
-                 {METRICS_PARAMETERS_DOCSTRING}
-            run_eagerly: Bool. Defaults to `False`. If `True`, this `Model`'s
-              logic will not be wrapped in a `tf.function`. Recommended to leave
-              this as `None` unless your `Model` cannot be run inside a
-              `tf.function`. `run_eagerly=True` is not supported when using
-              `tf.distribute.experimental.ParameterServerStrategy`.
-            steps_per_execution: Int. Defaults to 1. The number of batches to run
-              during each `tf.function` call. Running multiple batches inside a
-              single `tf.function` call can greatly improve performance on TPUs or
-              small models with a large Python overhead. At most, one full epoch
-              will be run each execution. If a number larger than the size of the
-              epoch is passed, the execution will be truncated to the size of the
-              epoch. Note that if `steps_per_execution` is set to `N`,
-              `Callback.on_batch_begin` and `Callback.on_batch_end` methods will
-              only be called every `N` batches (i.e. before/after each `tf.function`
-              execution).
-            jit_compile: If `True`, compile the model training step with XLA.
-              [XLA](https://www.tensorflow.org/xla) is an optimizing compiler for
-              machine learning.
-              `jit_compile` is not enabled for by default.
-              This option cannot be enabled with `run_eagerly=True`.
-              Note that `jit_compile=True` is
-              may not necessarily work for all models.
-              For more information on supported operations please refer to the
-              [XLA documentation](https://www.tensorflow.org/xla).
-              Also refer to
-              [known XLA issues](https://www.tensorflow.org/xla/known_issues) for
-              more details.
-            **kwargs: Arguments supported for backwards compatibility only.
-        """
-
-        num_v1_blocks = len(self.prediction_tasks)
-        num_v2_blocks = len(self.model_outputs)
-
-        if num_v1_blocks > 1 and num_v2_blocks > 1:
-            raise ValueError(
-                "You cannot use both `prediction_tasks` and `prediction_blocks` at the same time.",
-                "`prediction_tasks` is deprecated and will be removed in a future version.",
-            )
-
-        if num_v1_blocks > 0:
-            self.output_names = [task.task_name for task in self.prediction_tasks]
-        else:
-            self.output_names = [block.full_name for block in self.model_outputs]
-
-        # This flag will make Keras change the metric-names which is not needed in v2
-        from_serialized = kwargs.pop("from_serialized", num_v2_blocks > 0)
-
-        if hvd_installed and hvd.size() > 1:
-            # Horovod: Specify `experimental_run_tf_function=False` to ensure TensorFlow
-            # uses hvd.DistributedOptimizer() to compute gradients.
-            kwargs.update({"experimental_run_tf_function": False})
-
-        super().compile(
-            optimizer=self._create_optimizer(optimizer),
-            loss=self._create_loss(loss),
-            metrics=self._create_metrics(metrics, weighted=False),
-            weighted_metrics=self._create_metrics(weighted_metrics, weighted=True),
-            run_eagerly=run_eagerly,
-            loss_weights=loss_weights,
-            steps_per_execution=steps_per_execution,
-            jit_compile=jit_compile,
-            from_serialized=from_serialized,
-            **kwargs,
-        )
 
     def build(self, input_shape=None):
         """Builds the model

--- a/tests/unit/tf/core/test_encoder.py
+++ b/tests/unit/tf/core/test_encoder.py
@@ -122,7 +122,7 @@ def test_topk_encoder(music_streaming_data: Dataset):
         loaded_topk_encoder = tf.keras.models.load_model(tmpdir)
     batch_output = loaded_topk_encoder(batch[0])
 
-    output_signature = loaded_topk_encoder.signatures["serving_default"].structured_output
+    output_signature = loaded_topk_encoder.signatures["serving_default"].structured_outputs
     assert len(output_signature) == 2
     assert output_signature["scores"] == tf.TensorSpec(
         shape=(None, TOP_K), dtype=tf.float32, name="scores"

--- a/tests/unit/tf/core/test_encoder.py
+++ b/tests/unit/tf/core/test_encoder.py
@@ -122,6 +122,15 @@ def test_topk_encoder(music_streaming_data: Dataset):
         loaded_topk_encoder = tf.keras.models.load_model(tmpdir)
     batch_output = loaded_topk_encoder(batch[0])
 
+    output_signature = loaded_topk_encoder.signatures["serving_default"].structured_output
+    assert len(output_signature) == 2
+    assert output_signature["scores"] == tf.TensorSpec(
+        shape=(None, TOP_K), dtype=tf.float32, name="scores"
+    )
+    assert output_signature["identifiers"] == tf.TensorSpec(
+        shape=(None, TOP_K), dtype=tf.int32, name="identifiers"
+    )
+
     assert list(batch_output.scores.shape) == [BATCH_SIZE, TOP_K]
     tf.debugging.assert_equal(
         topk_encoder.topk_layer._candidates,


### PR DESCRIPTION
<!--

Thank you for contributing to Merlin Models :)

Here are some guidelines to help the review process go smoothly.

1. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

2. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `status/work-in-progress`.

3. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `status/work-in-progress` label (if present) and replace
   it with `status/needs-review`. The additional changes then can be implemented on top of the
   same PR.

4. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

<!-- Remove if not applicable -->

Fixes #1220

### Goals :soccer:

<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

Ensure top-k encoder model outputs are correct when model is saved.

### Implementation Details :construction:

<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

Removing `output_names` in BaseModel.compile when we have a TopKOutput. This enables keras to figure out the output names correctly.

We currently set the output name based on the name of the model output. However, the BruteForce TopKLayer outputs a 2-tuple of scores and ids. Setting `model.output_names` to `["top_k_output"]` keras writes out the model with only one output with this name. The [relevant part in the keras code (2.12) is here](https://github.com/keras-team/keras/blob/f9336cc5114b4a9429a242deb264b707379646b7/keras/saving/legacy/saving_utils.py#L150-L156)

#### Before

```
The given SavedModel SignatureDef contains the following input(s):
  inputs['category-list__offsets'] tensor_info:
      dtype: DT_INT32
      shape: (-1)
      name: serving_default_category-list__offsets:0
  inputs['category-list__values'] tensor_info:
      dtype: DT_INT64
      shape: (-1)
      name: serving_default_category-list__values:0
  inputs['dayofweek-first'] tensor_info:
      dtype: DT_INT64
      shape: (-1)
      name: serving_default_dayofweek-first:0
  inputs['item_id-list__offsets'] tensor_info:
      dtype: DT_INT32
      shape: (-1)
      name: serving_default_item_id-list__offsets:0
  inputs['item_id-list__values'] tensor_info:
      dtype: DT_INT64
      shape: (-1)
      name: serving_default_item_id-list__values:0
The given SavedModel SignatureDef contains the following output(s):
  outputs['item_id-list/top_k_output'] tensor_info:
      dtype: DT_FLOAT
      shape: (-1, 100)
      name: StatefulPartitionedCall:0
Method name is: tensorflow/serving/predict
```

#### After

```
The given SavedModel SignatureDef contains the following input(s):
  inputs['category-list__offsets'] tensor_info:
      dtype: DT_INT32
      shape: (-1)
      name: serving_default_category-list__offsets:0
  inputs['category-list__values'] tensor_info:
      dtype: DT_INT64
      shape: (-1)
      name: serving_default_category-list__values:0
  inputs['dayofweek-first'] tensor_info:
      dtype: DT_INT64
      shape: (-1)
      name: serving_default_dayofweek-first:0
  inputs['item_id-list__offsets'] tensor_info:
      dtype: DT_INT32
      shape: (-1)
      name: serving_default_item_id-list__offsets:0
  inputs['item_id-list__values'] tensor_info:
      dtype: DT_INT64
      shape: (-1)
      name: serving_default_item_id-list__values:0
The given SavedModel SignatureDef contains the following output(s):
  outputs['identifiers'] tensor_info:
      dtype: DT_INT32
      shape: (-1, 100)
      name: StatefulPartitionedCall:0
  outputs['scores'] tensor_info:
      dtype: DT_FLOAT
      shape: (-1, 100)
      name: StatefulPartitionedCall:1
Method name is: tensorflow/serving/predict
```

### Testing Details :mag:

<!-- Describe what tests you've added for your changes. -->

Adds assertion for expected output signature in test of topk encoder