### PR TITLE
Fix sok import error in ut

### DIFF
--- a/merlin/models/tf/distributed/backend.py
+++ b/merlin/models/tf/distributed/backend.py
@@ -22,7 +22,7 @@ if hvd_installed:
 
 if HAS_GPU:
     try:
-        from sparse_operation_kit import experiment as sok  # noqa: F401
+        from sparse_operation_kit import sparse_operation_kit as sok  # noqa: F401
 
         sok_installed = True
     except (ImportError, tf.errors.NotFoundError):

--- a/merlin/models/tf/distributed/backend.py
+++ b/merlin/models/tf/distributed/backend.py
@@ -22,7 +22,7 @@ if hvd_installed:
 
 if HAS_GPU:
     try:
-        from sparse_operation_kit import sparse_operation_kit as sok  # noqa: F401
+        import sparse_operation_kit as sok  # noqa: F401
 
         sok_installed = True
     except (ImportError, tf.errors.NotFoundError):


### PR DESCRIPTION
SOK has refactored the code path and remove experiment. There are ut failure in tests/unit/tf/horovod/test_embedding.py due to below error:
ImportError: 'horovod' and 'sparse_operation_kit' are required to use SOKEmbedding.