### PR TITLE
move merlin dependecy install in horovod-cpu tests

### DIFF
--- a/merlin/models/tf/distributed/backend.py
+++ b/merlin/models/tf/distributed/backend.py
@@ -22,7 +22,7 @@ if hvd_installed:
 
 if HAS_GPU:
     try:
-        from sparse_operation_kit import experiment as sok  # noqa: F401
+        import sparse_operation_kit as sok  # noqa: F401
 
         sok_installed = True
     except (ImportError, tf.errors.NotFoundError):

--- a/tox.ini
+++ b/tox.ini
@@ -57,14 +57,13 @@ setenv =
     HOROVOD_WITH_TENSORFLOW=1
     PATH={env:PATH}{:}{envdir}/env/bin
     LD_LIBRARY_PATH={env:LD_LIBRARY_PATH}{:}{envdir}/env/lib
-deps =
-    git+https://github.com/NVIDIA-Merlin/core.git@{env:MERLIN_BRANCH}
-    git+https://github.com/NVIDIA-Merlin/dataloader.git@{env:MERLIN_BRANCH}
-    git+https://github.com/NVIDIA-Merlin/NVTabular.git@{env:MERLIN_BRANCH}
 commands =
     conda update --yes --name base --channel defaults conda
     conda env create --prefix {envdir}/env --file requirements/horovod-cpu-environment.yml --force
-    {envdir}/env/bin/python -m pip install 'horovod==0.27.0' --no-cache-dir
+    {envdir}/env/bin/python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/core.git@{env:MERLIN_BRANCH:main}
+    {envdir}/env/bin/python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/dataloader.git@{env:MERLIN_BRANCH:main}
+    {envdir}/env/bin/python -m pip install --upgrade git+https://github.com/NVIDIA-Merlin/NVTabular.git@{env:MERLIN_BRANCH:main}
+    {envdir}/env/bin/python -m pip install 'horovod==0.28.1' --no-cache-dir
     {envdir}/env/bin/horovodrun --check-build
     {envdir}/env/bin/horovodrun -np 2 sh examples/usecases/multi-gpu/hvd_wrapper.sh pytest -m "unit and horovod {env:PYTEST_MARKERS}" -rxs {posargs:tests}
 


### PR DESCRIPTION
This PR fixes the environment issues discovered in https://github.com/NVIDIA-Merlin/models/pull/1232 and moves the installation of merlin dependencies to the correct place. Since we are testing horovod in a conda environment, the dependencies should be installed inside conda, not at the tox level.