### PR TITLE
fix dependencies in docs build

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,9 @@
 attrs==21.4.0
 Jinja2<3.1
 linkify-it-py==1.0.3
-myst-nb
+myst-nb==0.17.2
+nbformat==5.9.2
+jsonschema==4.17.3
 natsort==8.1.0
 recommonmark==0.7.1
 sphinx_book_theme~=1.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -121,7 +121,7 @@ commands =
 changedir = {toxinidir}
 deps =
     -rrequirements/docs.txt
-    -rrequirements/test.txt
+    -rrequirements/dev.txt
     git+https://github.com/NVIDIA-Merlin/core.git
     git+https://github.com/NVIDIA-Merlin/dataloader.git
     git+https://github.com/NVIDIA-Merlin/NVTabular.git


### PR DESCRIPTION
`docs-build` in the CI is failing due to pip failing to resolve dependencies, e.g.,
```
Collecting nbformat~=5.0 (from myst-nb->-r requirements/docs.txt (line 4))
  Downloading nbformat-5.9.1-py3-none-any.whl.metadata (3.3 kB)
INFO: pip is still looking at multiple versions of pydata-sphinx-theme to determine which version is compatible with other requirements. This could take a while.
INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. See https://pip.pypa.io/warnings/backtracking for guidance. If you want to abort this run, press Ctrl + C.
INFO: pip is still looking at multiple versions of sqlalchemy to determine which version is compatible with other requirements. This could take a while.
INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. See https://pip.pypa.io/warnings/backtracking for guidance. If you want to abort this run, press Ctrl + C.
```

This PR fixes package versions in `requirements/docs.txt` to help the dependency resolver. It also replaces `test.txt` with `dev.txt` since the requirements in the latter are narrower and `dev.txt` doesn't install the unnecessary requirements that cause conflicts.